### PR TITLE
Fix quick add button to open LicenseRequestModal, #56

### DIFF
--- a/openeire/src/components/ProductCard.tsx
+++ b/openeire/src/components/ProductCard.tsx
@@ -87,7 +87,6 @@ const ProductCard: React.FC<ProductCardProps> = ({
   }, [isHovered, isVideo, videoUrl, product.title]);
 
   const handleQuickAdd = (e: React.MouseEvent) => {
-    if (!isPhysical) return;
     e.preventDefault();
     e.stopPropagation();
 


### PR DESCRIPTION
Closes #56 

## Summary

Fixes the Quick Add button for digital products so it opens `LicenseRequestModal` instead of navigating to the product detail page.

## Why

Bug: QuickAddModal button for digital purchases redirected to `ProductDetailPage` instead of opening `LicenseRequestModal`.

## Screenshots / Demo

- [x] Not needed
- [ ] Added (attach screenshots / short Loom link)

## Changes

- Backend:
  -
- Frontend:
  - Prevent navigation on Quick Add click for digital items and open `LicenseRequestModal`.
- Infra/Config:
  -

## Testing

- [ ] Django tests pass locally
- [ ] React build passes locally
- [x] Manual smoke test done

### Manual smoke test checklist (quick)

- [ ] No console errors
- [ ] Forms submit correctly (success + validation errors)
- [ ] API errors handled (loading/error states)
- [ ] Mobile layout checked
- [ ] Auth/permissions verified (if relevant)

## Risk & Rollback

Risk level: Low

Rollback plan:

- [x] Revert PR
- [ ] Feature flag off
- [ ] Hotfix path described:

## Notes for Reviewer (Codex/Copilot)

Focus review on:

- [ ] Security (auth, permissions, file uploads, CSRF/CORS)
- [ ] Performance (N+1 queries, heavy renders, unnecessary requests)
- [ ] Maintainability (naming, structure, duplicated logic)
