### PR TITLE
Add checkout shipping transit estimates by country and tier, #53

### DIFF
--- a/openeire/src/components/CheckoutForm.tsx
+++ b/openeire/src/components/CheckoutForm.tsx
@@ -8,6 +8,26 @@ import { UserProfile, getCountries, Country } from "../services/api";
 import { useCart } from "../context/CartContext";
 import { FaTruck, FaCreditCard, FaBoxOpen } from "react-icons/fa";
 
+const SHIPPING_METHODS = ["budget", "standard", "express"] as const;
+type ShippingMethod = (typeof SHIPPING_METHODS)[number];
+type SupportedTransitCountry = "IE" | "US";
+
+const TRANSIT_ESTIMATES: Record<
+  SupportedTransitCountry,
+  Record<ShippingMethod, string>
+> = {
+  IE: {
+    budget: "Estimated: Slower than Standard postal service",
+    standard: "Estimated: 5-7 working days",
+    express: "Estimated: 1-6 working days",
+  },
+  US: {
+    budget: "Estimated: Slower than Standard postal service",
+    standard: "Estimated: 4-6 working days",
+    express: "Estimated: 1-6 working days",
+  },
+};
+
 interface CheckoutFormProps {
   initialData?: UserProfile | null;
   onShippingChange: (details: any) => void;
@@ -138,6 +158,17 @@ const CheckoutForm: React.FC<CheckoutFormProps> = ({
     "w-full bg-black border border-white/20 rounded-lg p-4 text-white placeholder-gray-600 focus:border-brand-500 focus:ring-1 focus:ring-brand-500 outline-none transition-all";
   const labelClass =
     "block text-xs font-bold text-gray-500 uppercase tracking-widest mb-2";
+  const selectedTransitCountry =
+    shippingDetails.country === "IE" || shippingDetails.country === "US"
+      ? shippingDetails.country
+      : null;
+
+  const getTransitEstimate = (method: ShippingMethod) => {
+    if (!selectedTransitCountry) {
+      return "Select country for estimate";
+    }
+    return TRANSIT_ESTIMATES[selectedTransitCountry][method];
+  };
 
   return (
     <form onSubmit={handleSubmit} className="space-y-8">
@@ -265,7 +296,7 @@ const CheckoutForm: React.FC<CheckoutFormProps> = ({
           </div>
 
           <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-            {["budget", "standard", "express"].map((method) => (
+            {SHIPPING_METHODS.map((method) => (
               <label
                 key={method}
                 className={`flex flex-col items-center justify-center p-4 border rounded-xl cursor-pointer transition-all ${
@@ -285,9 +316,23 @@ const CheckoutForm: React.FC<CheckoutFormProps> = ({
                 <span className="capitalize text-white font-bold mb-1">
                   {method}
                 </span>
+                <span className="text-xs text-gray-400 text-center">
+                  {getTransitEstimate(method)}
+                </span>
               </label>
             ))}
           </div>
+
+          <p className="mt-4 text-xs text-gray-400">
+            Note: Transit times do not include the 2-4 day custom production
+            window.
+          </p>
+          {selectedTransitCountry === "US" && shippingMethod === "standard" && (
+            <p className="mt-2 text-xs text-gray-500">
+              Some specialty items printed only in Europe can take 10-15
+              working days to reach the US.
+            </p>
+          )}
         </div>
       )}
 


### PR DESCRIPTION
## Summary

This PR adds static, policy-aligned shipping transit estimates to checkout for physical print orders.  
Estimates are shown per shipping tier (Budget, Standard, Express) and update based on selected country (`IE` vs `US`) without calling external APIs.

## Why

Implements issue #53 so customers can see expected delivery windows directly in checkout instead of leaving to the Shipping Policy page.

## Screenshots / Demo

- [x] Not needed
- [ ] Added (attach screenshots / short Loom link)

## Changes

- Backend:
  - None (frontend-only implementation)
- Frontend:
  - Added typed shipping-tier constants and country+tier transit estimate mapping in `CheckoutForm.tsx`
  - Rendered estimate text beneath each shipping option card
  - Added disclaimer: `Note: Transit times do not include the 2-4 day custom production window.`
  - Added US-standard-only caveat for specialty items printed in Europe: `10-15 working days`
- Infra/Config:
  - None

## Testing

- [ ] Django tests pass locally
- [x] React build passes locally
- [ ] Manual smoke test done

### Manual smoke test checklist (quick)

- [ ] No console errors
- [ ] Forms submit correctly (success + validation errors)
- [ ] API errors handled (loading/error states)
- [ ] Mobile layout checked
- [ ] Auth/permissions verified (if relevant)

## Risk & Rollback

Risk level: Low

Rollback plan:

- [x] Revert PR
- [ ] Feature flag off
- [x] Hotfix path described: Revert commit `acf0e1a` to immediately remove estimates/disclaimer UI.

## Notes for Reviewer (Codex/Copilot)

Focus review on:

- [ ] Security (auth, permissions, file uploads, CSRF/CORS)
- [ ] Performance (N+1 queries, heavy renders, unnecessary requests)
- [x] Maintainability (naming, structure, duplicated logic)