### PR TITLE
Attach session access token in API request interceptor

### DIFF
--- a/openeire/src/services/api.ts
+++ b/openeire/src/services/api.ts
@@ -14,7 +14,9 @@ export const api = axios.create({
 api.interceptors.request.use(
   (config) => {
     // 1. Handle User Auth (Login)
-    const token = localStorage.getItem('accessToken');
+    const token =
+      localStorage.getItem("accessToken") ||
+      sessionStorage.getItem("accessToken");
     if (token) {
       config.headers.Authorization = `Bearer ${token}`;
     }


### PR DESCRIPTION
Closes #67 

## Summary

This PR fixes an auth regression where users logged in with “Remember me” unchecked could appear authenticated in UI but send unauthenticated API requests. The API request interceptor now reads access tokens from both `localStorage` and `sessionStorage`.

## Why

Session-based logins store tokens in `sessionStorage`, but the interceptor previously only read `localStorage`, causing missing `Authorization` headers on protected requests.

## Screenshots / Demo

- [x] Not needed
- [ ] Added (attach screenshots / short Loom link)

## Changes

- Backend:
  - None
- Frontend:
  - Updated token lookup in `src/services/api.ts` request interceptor to:
    - `localStorage.getItem("accessToken") || sessionStorage.getItem("accessToken")`
- Infra/Config:
  - None

## Testing

- [ ] Django tests pass locally
- [x] React build passes locally
- [x] Manual smoke test done

### Manual smoke test checklist (quick)

- [x] No console errors
- [x] Forms submit correctly (success + validation errors)
- [x] API errors handled (loading/error states)
- [ ] Mobile layout checked
- [x] Auth/permissions verified (if relevant)

## Risk & Rollback

Risk level: Low

Rollback plan:

- [x] Revert PR
- [ ] Feature flag off
- [x] Hotfix path described:
  - Revert `src/services/api.ts` token lookup change if unexpected auth behavior appears

## Notes for Reviewer (Codex/Copilot)

Focus review on:

- [x] Security (auth, permissions, file uploads, CSRF/CORS)
- [ ] Performance (N+1 queries, heavy renders, unnecessary requests)
- [x] Maintainability (naming, structure, duplicated logic)
