### PR TITLE
Defer video card loading to reduce eager network usage

### DIFF
--- a/openeire/src/components/ProductCard.tsx
+++ b/openeire/src/components/ProductCard.tsx
@@ -24,6 +24,8 @@ const ProductCard: React.FC<ProductCardProps> = ({
   const [showQuickView, setShowQuickView] = useState(false);
   const [isHovered, setIsHovered] = useState(false);
   const [isVideoPlaying, setIsVideoPlaying] = useState(false);
+  const [shouldLoadVideo, setShouldLoadVideo] = useState(false);
+  const cardRef = useRef<HTMLDivElement>(null);
   const videoRef = useRef<HTMLVideoElement>(null);
 
   const isVideo = product.product_type === "video";
@@ -47,14 +49,40 @@ const ProductCard: React.FC<ProductCardProps> = ({
     : "https://via.placeholder.com/400x300?text=No+Preview";
 
   const rawVideoFile = product.file;
-  const videoUrl = rawVideoFile
+  const fullVideoUrl = rawVideoFile
     ? rawVideoFile.startsWith("http")
       ? rawVideoFile
       : `${BACKEND_BASE_URL}${rawVideoFile}`
     : null;
+  const videoUrl = shouldLoadVideo ? fullVideoUrl : null;
 
   useEffect(() => {
-    if (!isVideo || !videoRef.current || !videoUrl) return;
+    if (!isVideo || shouldLoadVideo || !cardRef.current) return;
+
+    if (typeof IntersectionObserver === "undefined") {
+      setShouldLoadVideo(true);
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (entry.isIntersecting) {
+          setShouldLoadVideo(true);
+          observer.disconnect();
+        }
+      },
+      { rootMargin: "150px" },
+    );
+
+    observer.observe(cardRef.current);
+    return () => observer.disconnect();
+  }, [isVideo, shouldLoadVideo]);
+
+  useEffect(() => {
+    if (!isVideo || !videoRef.current || !videoUrl) {
+      setIsVideoPlaying(false);
+      return;
+    }
 
     if (isHovered) {
       const playPromise = videoRef.current.play();
@@ -78,6 +106,13 @@ const ProductCard: React.FC<ProductCardProps> = ({
     e.stopPropagation();
     setShowQuickView(true);
     if (onModalOpen) onModalOpen();
+  };
+
+  const handleMouseEnter = () => {
+    setIsHovered(true);
+    if (isVideo) {
+      setShouldLoadVideo(true);
+    }
   };
 
   const getBadge = () => {
@@ -104,8 +139,9 @@ const ProductCard: React.FC<ProductCardProps> = ({
   return (
     <>
       <div
+        ref={cardRef}
         className="group relative bg-black rounded-2xl overflow-hidden shadow-sm hover:shadow-2xl transition-all duration-500 transform hover:-translate-y-1 border border-white/10"
-        onMouseEnter={() => setIsHovered(true)}
+        onMouseEnter={handleMouseEnter}
         onMouseLeave={() => setIsHovered(false)}
       >
         <Link
@@ -121,14 +157,14 @@ const ProductCard: React.FC<ProductCardProps> = ({
             }`}
           />
 
-          {isVideo && videoUrl && (
+          {isVideo && shouldLoadVideo && videoUrl && (
             <video
               ref={videoRef}
               src={videoUrl}
               muted
               loop
               playsInline
-              preload="auto"
+              preload="metadata"
               className="absolute inset-0 z-0 w-full h-full object-cover"
             />
           )}


### PR DESCRIPTION
Closes #71 

## Summary

This PR reduces gallery video card network overhead by removing eager video preloading behavior. Video sources now initialize only when users show intent (hover) or when cards approach the viewport, while keeping image thumbnails as the default preview.

## Why

Video cards previously used `preload="auto"` across list items, which caused aggressive background downloads and performance degradation on galleries with many video products.

## Screenshots / Demo

- [x] Not needed
- [ ] Added (attach screenshots / short Loom link)

## Changes

- Backend:
  - None
- Frontend:
  - Updated `ProductCard` video loading strategy to lazy-init source
  - Added intersection-based near-viewport trigger for video load
  - Added hover-intent trigger for immediate preview readiness
  - Changed `<video preload="auto">` to `preload="metadata"`
  - Preserved thumbnail-first UX until video is actually playing
- Infra/Config:
  - None

## Testing

- [ ] Django tests pass locally
- [x] React build passes locally
- [ ] Manual smoke test done

Additional checks run:
- [x] `npm run lint` passed
- [x] `npx tsc --noEmit` passed
- [x] `npm run test` passed (3 files, 11 tests)

### Manual smoke test checklist (quick)

- [ ] No console errors
- [ ] Forms submit correctly (success + validation errors)
- [ ] API errors handled (loading/error states)
- [ ] Mobile layout checked
- [ ] Auth/permissions verified (if relevant)

## Risk & Rollback

Risk level: Medium

Rollback plan:

- [x] Revert PR
- [ ] Feature flag off
- [ ] Hotfix path described:

## Notes for Reviewer (Codex/Copilot)

Focus review on:

- [ ] Security (auth, permissions, file uploads, CSRF/CORS)
- [x] Performance (N+1 queries, heavy renders, unnecessary requests)
- [x] Maintainability (naming, structure, duplicated logic)
