### PR TITLE
Scope gallery access header to intended endpoints and API origin

### DIFF
--- a/openeire/src/services/api.ts
+++ b/openeire/src/services/api.ts
@@ -10,39 +10,6 @@ export const api = axios.create({
   },
 });
 
-// --- UNIFIED INTERCEPTOR ---
-// This handles BOTH User Authentication and Gallery Access
-api.interceptors.request.use(
-  (config) => {
-    // 1. Handle User Auth (Login)
-    const token =
-      localStorage.getItem("accessToken") ||
-      sessionStorage.getItem("accessToken");
-    if (token) {
-      config.headers.Authorization = `Bearer ${token}`;
-    }
-
-    // 2. Handle Gallery Guest Pass (The new feature)
-    const gallerySession = localStorage.getItem('gallery_access');
-    if (gallerySession) {
-      try {
-        const { code } = JSON.parse(gallerySession);
-        if (code) {
-          // This header tells the backend: "I have the password for the vault"
-          config.headers['X-Gallery-Access-Token'] = code;
-        }
-      } catch (e) {
-        console.error("Error parsing gallery access token", e);
-      }
-    }
-
-    return config;
-  },
-  (error) => {
-    return Promise.reject(error);
-  }
-);
-
 const getRequestPath = (url?: string): string => {
   if (!url) return "";
   if (url.startsWith("http://") || url.startsWith("https://")) {
@@ -56,13 +23,85 @@ const getRequestPath = (url?: string): string => {
   return normalizeApiPath(url);
 };
 
-const shouldSkipForbiddenRouteRedirect = (requestPath: string): boolean =>
+export const isGalleryAccessScopedPath = (requestPath: string): boolean =>
   requestPath.startsWith("photos/") ||
   requestPath.startsWith("videos/") ||
   requestPath.startsWith("gallery/");
 
+const isAbsoluteUrl = (url: string): boolean =>
+  url.startsWith("http://") || url.startsWith("https://");
+
+export const isSameApiOriginRequest = (
+  url?: string,
+  baseUrl?: string,
+): boolean => {
+  if (!url || !isAbsoluteUrl(url)) {
+    return true;
+  }
+
+  if (!baseUrl) {
+    return false;
+  }
+
+  try {
+    const requestOrigin = new URL(url).origin;
+    const apiOrigin = new URL(baseUrl).origin;
+    return requestOrigin === apiOrigin;
+  } catch {
+    return false;
+  }
+};
+
+export const shouldAttachGalleryAccessToken = (
+  url?: string,
+  baseUrl?: string,
+): boolean =>
+  isGalleryAccessScopedPath(getRequestPath(url)) &&
+  isSameApiOriginRequest(url, baseUrl);
+
+const shouldSkipForbiddenRouteRedirect = (requestPath: string): boolean =>
+  isGalleryAccessScopedPath(requestPath);
+
 const shouldHandleGlobalErrorRoute = (method?: string): boolean =>
   (method ?? "get").toLowerCase() === "get";
+
+// --- UNIFIED INTERCEPTOR ---
+// This handles BOTH User Authentication and Gallery Access
+api.interceptors.request.use(
+  (config) => {
+    // 1. Handle User Auth (Login)
+    const token =
+      localStorage.getItem("accessToken") ||
+      sessionStorage.getItem("accessToken");
+    if (token) {
+      config.headers.Authorization = `Bearer ${token}`;
+    }
+
+    // 2. Handle Gallery Guest Pass (Only for scoped digital-gallery endpoints)
+    const gallerySession = localStorage.getItem("gallery_access");
+    const apiBaseUrl =
+      typeof config.baseURL === "string" ? config.baseURL : api.defaults.baseURL;
+    if (
+      gallerySession &&
+      shouldAttachGalleryAccessToken(config.url, apiBaseUrl)
+    ) {
+      try {
+        const { code } = JSON.parse(gallerySession);
+        if (code) {
+          // This header tells the backend: "I have the password for the vault"
+          config.headers["X-Gallery-Access-Token"] = code;
+        }
+      } catch (e) {
+        console.error("Error parsing gallery access token", e);
+      }
+    }
+
+    return config;
+  },
+  (error) => {
+    return Promise.reject(error);
+  },
+);
 
 api.interceptors.response.use(
   (response) => response,

--- a/openeire/tests/galleryAccessScope.test.ts
+++ b/openeire/tests/galleryAccessScope.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import {
+  isGalleryAccessScopedPath,
+  shouldAttachGalleryAccessToken,
+} from "../src/services/api";
+
+describe("isGalleryAccessScopedPath", () => {
+  it("returns true for protected gallery content endpoints", () => {
+    expect(isGalleryAccessScopedPath("gallery/")).toBe(true);
+    expect(isGalleryAccessScopedPath("photos/123/")).toBe(true);
+    expect(isGalleryAccessScopedPath("videos/456/")).toBe(true);
+  });
+
+  it("returns false for non-gallery endpoints", () => {
+    expect(isGalleryAccessScopedPath("auth/profile/")).toBe(false);
+    expect(isGalleryAccessScopedPath("checkout/order-history/")).toBe(false);
+    expect(isGalleryAccessScopedPath("gallery-request/")).toBe(false);
+    expect(isGalleryAccessScopedPath("gallery-verify/")).toBe(false);
+  });
+
+  it("attaches token only for same-origin scoped requests", () => {
+    const baseUrl = "http://127.0.0.1:8000/api/";
+
+    expect(shouldAttachGalleryAccessToken("gallery/", baseUrl)).toBe(true);
+    expect(shouldAttachGalleryAccessToken("photos/123/", baseUrl)).toBe(true);
+    expect(shouldAttachGalleryAccessToken("videos/456/", baseUrl)).toBe(true);
+
+    expect(
+      shouldAttachGalleryAccessToken(
+        "http://127.0.0.1:8000/api/videos/456/",
+        baseUrl,
+      ),
+    ).toBe(true);
+
+    expect(
+      shouldAttachGalleryAccessToken("https://example.com/api/videos/456/", baseUrl),
+    ).toBe(false);
+    expect(shouldAttachGalleryAccessToken("auth/profile/", baseUrl)).toBe(false);
+  });
+});


### PR DESCRIPTION
Closes #72 

## Summary

This PR scopes `X-Gallery-Access-Token` injection to only gallery-protected endpoints and same-origin API requests. It removes global header leakage and aligns request behavior with least-privilege access control.

## Why

When `gallery_access` existed in local storage, the gallery token header was attached to all API requests, including unrelated endpoints (auth/profile/checkout). This broadened token exposure and was out of scope for endpoints that do not require gallery access.

## Screenshots / Demo

- [x] Not needed
- [ ] Added (attach screenshots / short Loom link)

## Changes

- Backend:
  - None
- Frontend:
  - Added request-path scoping helper for gallery endpoints (`gallery/`, `photos/`, `videos/`)
  - Added same-origin guard for absolute URLs before attaching gallery token
  - Updated request interceptor to apply both checks before setting `X-Gallery-Access-Token`
  - Reused the same gallery path predicate for 403 route-skip logic to keep behavior consistent
  - Added regression tests covering scoped and non-scoped endpoints + same-origin/external absolute URL behavior
- Infra/Config:
  - None

## Testing

- [ ] Django tests pass locally
- [x] React build passes locally
- [ ] Manual smoke test done

Additional checks run:
- [x] `npm run lint` passed
- [x] `npx tsc --noEmit` passed
- [x] `npm run test` passed (4 files, 14 tests)

### Manual smoke test checklist (quick)

- [ ] No console errors
- [ ] Forms submit correctly (success + validation errors)
- [ ] API errors handled (loading/error states)
- [ ] Mobile layout checked
- [x] Auth/permissions verified (if relevant)

## Risk & Rollback

Risk level: Medium

Rollback plan:

- [x] Revert PR
- [ ] Feature flag off
- [ ] Hotfix path described:

## Notes for Reviewer (Codex/Copilot)

Focus review on:

- [x] Security (auth, permissions, file uploads, CSRF/CORS)
- [x] Performance (N+1 queries, heavy renders, unnecessary requests)
- [x] Maintainability (naming, structure, duplicated logic)
