### PR TITLE
Add per-post SEO tags for blog detail pages

### DIFF
--- a/openeire/package-lock.json
+++ b/openeire/package-lock.json
@@ -17,6 +17,7 @@
         "dompurify": "^3.3.3",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
+        "react-helmet": "^6.1.0",
         "react-hot-toast": "^2.6.0",
         "react-icons": "^5.5.0",
         "react-masonry-css": "^1.0.16",
@@ -4293,6 +4294,36 @@
       },
       "peerDependencies": {
         "react": "^19.1.1"
+      }
+    },
+    "node_modules/react-fast-compare": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
+      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
+      "license": "MIT"
+    },
+    "node_modules/react-helmet": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/react-helmet/-/react-helmet-6.1.0.tgz",
+      "integrity": "sha512-4uMzEY9nlDlgxr61NL3XbKRy1hEkXmKNXhjbAIOVw5vcFrsdYbH2FEwcNyWvWinl103nXgzYNlns9ca+8kFiWw==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4.1.1",
+        "prop-types": "^15.7.2",
+        "react-fast-compare": "^3.1.1",
+        "react-side-effect": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.3.0"
+      }
+    },
+    "node_modules/react-helmet/node_modules/react-side-effect": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/react-side-effect/-/react-side-effect-2.1.2.tgz",
+      "integrity": "sha512-PVjOcvVOyIILrYoyGEpDN3vmYNLdy1CajSFNt4TDsVQC5KpTijDvWVoR+/7Rz2xT978D8/ZtFceXxzsPwZEDvw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.3.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react-hot-toast": {

--- a/openeire/package.json
+++ b/openeire/package.json
@@ -20,6 +20,7 @@
     "dompurify": "^3.3.3",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
+    "react-helmet": "^6.1.0",
     "react-hot-toast": "^2.6.0",
     "react-icons": "^5.5.0",
     "react-masonry-css": "^1.0.16",

--- a/openeire/src/components/SEOHead.tsx
+++ b/openeire/src/components/SEOHead.tsx
@@ -1,4 +1,11 @@
-import React, { useEffect } from "react";
+import React from "react";
+import { Helmet } from "react-helmet";
+import {
+  SITE_TITLE,
+  buildAbsoluteSiteUrl,
+  getCurrentCanonicalUrl,
+  getCurrentPageUrl,
+} from "../config/site";
 
 interface SEOHeadProps {
   title: string;
@@ -6,56 +13,11 @@ interface SEOHeadProps {
   image?: string;
   url?: string;
   canonicalPath?: string;
+  canonicalUrl?: string;
   noindex?: boolean;
   type?: "website" | "article";
+  appendSiteTitle?: boolean;
 }
-
-const getSiteOrigin = (): string => {
-  const configured = import.meta.env.VITE_SITE_URL?.trim().replace(/\/+$/, "");
-  if (configured) {
-    try {
-      const normalized = new URL(configured);
-      if (normalized.protocol === "http:" || normalized.protocol === "https:") {
-        normalized.pathname = "";
-        normalized.search = "";
-        normalized.hash = "";
-        return normalized.toString().replace(/\/+$/, "");
-      }
-    } catch {
-      // Fall back to the current origin when VITE_SITE_URL is misconfigured.
-    }
-  }
-
-  if (typeof window === "undefined") return "";
-  return window.location.origin;
-};
-
-const buildAbsoluteUrl = (value: string): string => {
-  if (/^https?:\/\//i.test(value)) return value;
-  const origin = getSiteOrigin();
-  if (!origin) return value;
-  return new URL(value, `${origin}/`).toString();
-};
-
-const getCurrentUrl = (): string => {
-  if (typeof window === "undefined") return "";
-  const origin = getSiteOrigin();
-  const current = new URL(window.location.href);
-  return origin
-    ? new URL(`${current.pathname}${current.search}${current.hash}`, `${origin}/`).toString()
-    : current.toString();
-};
-
-const getCurrentCanonicalUrl = (): string => {
-  if (typeof window === "undefined") return "";
-  const origin = getSiteOrigin();
-  const current = new URL(window.location.href);
-  current.search = "";
-  current.hash = "";
-  return origin
-    ? new URL(current.pathname, `${origin}/`).toString()
-    : current.toString();
-};
 
 const SEOHead: React.FC<SEOHeadProps> = ({
   title,
@@ -63,71 +25,41 @@ const SEOHead: React.FC<SEOHeadProps> = ({
   image,
   url,
   canonicalPath,
+  canonicalUrl,
   noindex = false,
   type = "website",
+  appendSiteTitle = true,
 }) => {
-  const siteTitle = "OpenÉire Studios";
-  const fullTitle = `${title} | ${siteTitle}`;
-  const pageUrl = url ? buildAbsoluteUrl(url) : getCurrentUrl();
-  const canonicalUrl = canonicalPath
-    ? buildAbsoluteUrl(canonicalPath)
-    : getCurrentCanonicalUrl();
+  const resolvedTitle = appendSiteTitle ? `${title} | ${SITE_TITLE}` : title;
+  const pageUrl = url ? buildAbsoluteSiteUrl(url) : getCurrentPageUrl();
+  const resolvedCanonicalUrl = canonicalUrl
+    ? buildAbsoluteSiteUrl(canonicalUrl)
+    : canonicalPath
+      ? buildAbsoluteSiteUrl(canonicalPath)
+      : getCurrentCanonicalUrl();
 
-  useEffect(() => {
-    document.title = fullTitle;
+  return (
+    <Helmet>
+      <title>{resolvedTitle}</title>
+      <meta name="description" content={description} />
+      <meta name="robots" content={noindex ? "noindex, follow" : "index, follow"} />
 
-    const updateMeta = (
-      name: string,
-      content: string,
-      attribute: "name" | "property" = "name",
-    ) => {
-      let element = document.querySelector(`meta[${attribute}="${name}"]`);
+      <meta property="og:type" content={type} />
+      <meta property="og:site_name" content={SITE_TITLE} />
+      <meta property="og:url" content={pageUrl} />
+      <meta property="og:title" content={resolvedTitle} />
+      <meta property="og:description" content={description} />
+      {image ? <meta property="og:image" content={image} /> : null}
 
-      if (!element) {
-        element = document.createElement("meta");
-        element.setAttribute(attribute, name);
-        document.head.appendChild(element);
-      }
+      <meta name="twitter:card" content={image ? "summary_large_image" : "summary"} />
+      <meta name="twitter:url" content={pageUrl} />
+      <meta name="twitter:title" content={resolvedTitle} />
+      <meta name="twitter:description" content={description} />
+      {image ? <meta name="twitter:image" content={image} /> : null}
 
-      element.setAttribute("content", content);
-    };
-
-    const updateLink = (rel: string, href: string) => {
-      let element = document.querySelector(`link[rel="${rel}"]`);
-
-      if (!element) {
-        element = document.createElement("link");
-        element.setAttribute("rel", rel);
-        document.head.appendChild(element);
-      }
-
-      element.setAttribute("href", href);
-    };
-
-    updateMeta("description", description);
-    updateMeta("robots", noindex ? "noindex, follow" : "index, follow");
-
-    updateMeta("og:type", type, "property");
-    updateMeta("og:site_name", siteTitle, "property");
-    updateMeta("og:url", pageUrl, "property");
-    updateMeta("og:title", fullTitle, "property");
-    updateMeta("og:description", description, "property");
-    if (image) {
-      updateMeta("og:image", image, "property");
-    }
-
-    updateMeta("twitter:card", image ? "summary_large_image" : "summary");
-    updateMeta("twitter:url", pageUrl);
-    updateMeta("twitter:title", fullTitle);
-    updateMeta("twitter:description", description);
-    if (image) {
-      updateMeta("twitter:image", image);
-    }
-
-    updateLink("canonical", canonicalUrl);
-  }, [canonicalUrl, description, fullTitle, image, noindex, pageUrl, type]);
-
-  return null;
+      <link rel="canonical" href={resolvedCanonicalUrl} />
+    </Helmet>
+  );
 };
 
 export default SEOHead;

--- a/openeire/src/config/site.ts
+++ b/openeire/src/config/site.ts
@@ -1,0 +1,48 @@
+export const SITE_TITLE = "OpenÉire Studios";
+
+export const getSiteOrigin = (): string => {
+  const configured = import.meta.env.VITE_SITE_URL?.trim().replace(/\/+$/, "");
+  if (configured) {
+    try {
+      const normalized = new URL(configured);
+      if (normalized.protocol === "http:" || normalized.protocol === "https:") {
+        normalized.pathname = "";
+        normalized.search = "";
+        normalized.hash = "";
+        return normalized.toString().replace(/\/+$/, "");
+      }
+    } catch {
+      // Fall back to the current origin when VITE_SITE_URL is misconfigured.
+    }
+  }
+
+  if (typeof window === "undefined") return "";
+  return window.location.origin;
+};
+
+export const buildAbsoluteSiteUrl = (value: string): string => {
+  if (/^https?:\/\//i.test(value)) return value;
+  const origin = getSiteOrigin();
+  if (!origin) return value;
+  return new URL(value, `${origin}/`).toString();
+};
+
+export const getCurrentPageUrl = (): string => {
+  if (typeof window === "undefined") return "";
+  const origin = getSiteOrigin();
+  const current = new URL(window.location.href);
+  return origin
+    ? new URL(`${current.pathname}${current.search}${current.hash}`, `${origin}/`).toString()
+    : current.toString();
+};
+
+export const getCurrentCanonicalUrl = (): string => {
+  if (typeof window === "undefined") return "";
+  const origin = getSiteOrigin();
+  const current = new URL(window.location.href);
+  current.search = "";
+  current.hash = "";
+  return origin
+    ? new URL(current.pathname, `${origin}/`).toString()
+    : current.toString();
+};

--- a/openeire/src/pages/BlogDetailPage.tsx
+++ b/openeire/src/pages/BlogDetailPage.tsx
@@ -111,6 +111,7 @@ const BlogDetailPage: React.FC = () => {
             : undefined
         }
         canonicalUrl={seoCanonicalUrl}
+        url={seoCanonicalUrl}
         type="article"
         appendSiteTitle={false}
       />

--- a/openeire/src/pages/BlogDetailPage.tsx
+++ b/openeire/src/pages/BlogDetailPage.tsx
@@ -17,6 +17,7 @@ import SocialShareButtons from "../components/SocialShareButtons";
 import SEOHead from "../components/SEOHead";
 import { sanitizeRichHtml } from "../utils/sanitizeHtml";
 import { resolveMediaUrl } from "../config/backend";
+import { buildAbsoluteSiteUrl } from "../config/site";
 import {
   FaArrowLeft,
   FaHeart,
@@ -95,18 +96,23 @@ const BlogDetailPage: React.FC = () => {
       </div>
     );
 
+  const seoTitle = post.meta_title || post.title;
+  const seoDescription = post.meta_description || post.excerpt || "";
+  const seoCanonicalUrl = post.canonical_url || buildAbsoluteSiteUrl(`/blog/${post.slug}/`);
+
   return (
     <div className="bg-black min-h-screen text-white pt-24 pb-20 mobile-page-offset">
       <SEOHead
-        title={post.title}
-        description={post.excerpt}
+        title={seoTitle}
+        description={seoDescription}
         image={
           post.featured_image
             ? resolveMediaUrl(post.featured_image)
             : undefined
         }
-        canonicalPath={`/blog/${post.slug}`}
+        canonicalUrl={seoCanonicalUrl}
         type="article"
+        appendSiteTitle={false}
       />
 
       {/* HERO SECTION */}
@@ -155,6 +161,8 @@ const BlogDetailPage: React.FC = () => {
 
         {/* CONTENT (Use prose-invert for dark mode) */}
         <article className="prose prose-invert prose-lg max-w-none text-gray-300 leading-loose prose-a:text-accent prose-headings:font-serif prose-headings:text-white prose-blockquote:border-l-accent prose-img:rounded-xl">
+          {/* Blog HTML is authored by trusted admins in Summernote and sanitized on save and render.
+              Internal links should point to public React routes like /blog/<slug>/, /licensing/, /contact/, or /footage/, not API endpoints. */}
           <div dangerouslySetInnerHTML={{ __html: sanitizedContent }} />
         </article>
 
@@ -238,4 +246,3 @@ const BlogDetailPage: React.FC = () => {
 };
 
 export default BlogDetailPage;
-

--- a/openeire/src/services/api.ts
+++ b/openeire/src/services/api.ts
@@ -226,6 +226,9 @@ export interface BlogPostListItem {
   author: string;
   featured_image: string | null;
   excerpt: string;
+  meta_title: string;
+  meta_description: string;
+  canonical_url: string;
   created_at: string;
   tags: string[]; 
   likes_count: number;


### PR DESCRIPTION
## Summary

This PR adds per-post SEO tag support to the React blog detail page.

## Why

The backend blog now exposes SEO metadata per post, but the frontend still needed to apply that data dynamically so blog detail pages render the correct title, meta description, and canonical URL.

The goal was to add this cleanly without changing the existing blog rendering flow or replacing the current Summernote-based authoring model.

## Changes

- Frontend:
  - Added `react-helmet`
  - Refactored `SEOHead` to use `react-helmet` instead of imperative `document.head` updates
  - Added a small shared site config helper in:
    - `src/config/site.ts`
  - Updated blog API types to include:
    - `meta_title`
    - `meta_description`
    - `canonical_url`
  - Updated `BlogDetailPage.tsx` to set:
    - `<title>` using `post.meta_title || post.title`
    - description using `post.meta_description || post.excerpt || ""`
    - canonical URL using `post.canonical_url || <site-origin>/blog/<slug>/`
  - Passed the same resolved canonical URL into social URL metadata so:
    - `og:url`
    - `twitter:url`
    - `<link rel="canonical">`
    stay aligned
  - Kept the existing rich HTML render path
  - Added a short inline note clarifying that:
    - blog HTML is admin-authored in Summernote
    - internal links should point to public React routes, not API endpoints
- Backend:
  - N/A in this repo
- Infra/Config:
  - Uses existing `VITE_SITE_URL` when present for canonical URL generation
  - Falls back to `window.location.origin` when unset

## Fallback Behavior

The blog detail page now applies frontend-only SEO fallbacks without mutating stored blog data:

- `meta_title` fallback: `title`
- `meta_description` fallback: `excerpt`
- `canonical_url` fallback: `/blog/<slug>/` resolved against site origin

## Testing

- [x] React build passes locally
- [ ] Django tests pass locally
- [x] Manual smoke test completed

### Manual smoke test checklist (quick)

- [x] Blog detail page still renders Summernote-authored content
- [x] Blog SEO tags are populated per post
- [x] Fallback SEO behavior works when metadata is empty
- [x] Canonical URL resolves correctly from configured site origin
- [x] Canonical and social URL metadata stay aligned
- [x] Existing blog list/detail rendering is not broken

## Risk & Rollback

Risk level: Low

Why low:
- Focused frontend-only change
- No API contract changes in this repo
- Existing blog rendering flow remains intact

Rollback plan:

- [x] Revert PR
- [ ] Feature flag off
- [ ] Hotfix path described:

## Notes for Reviewer (Codex/Copilot)

Focus review on:

- [x] Blog detail SEO fallback behavior
- [x] Canonical URL generation via shared site helper
- [x] Canonical/social URL alignment
- [x] `SEOHead` refactor not breaking existing page-level SEO usage
- [x] No changes to the existing Summernote HTML rendering flow

## Reviewer Note

`react-helmet` is working correctly in the current app/build, but its transitive peer metadata is not fully aligned with React 19. This is not blocking current functionality, but it is worth keeping in mind for future dependency maintenance.
