### PR TITLE
fix(blog): keep safe Summernote formatting on blog detail pages

### DIFF
--- a/openeire/src/utils/sanitizeHtml.ts
+++ b/openeire/src/utils/sanitizeHtml.ts
@@ -17,6 +17,5 @@ export const sanitizeRichHtml = (html: string): string =>
       "meta",
       "link",
     ],
-    FORBID_ATTR: ["style"],
     ALLOW_DATA_ATTR: false,
   });


### PR DESCRIPTION
## Follow-up fix: preserve rendered Summernote formatting

This PR also fixes the frontend half of the Summernote formatting issue.

### What was happening

Even after backend sanitization, the blog detail page was sanitizing rich HTML again with a frontend config that explicitly stripped `style` attributes. That caused legitimate Summernote formatting to be lost on the rendered page.

### Changes

- Frontend:
  - Updated the rich HTML sanitizer used by `BlogDetailPage`
  - Stopped stripping safe inline style attributes a second time
  - Continued blocking dangerous content such as:
    - `script`
    - `iframe`
    - `object`
    - `embed`
    - form controls
    - `meta`
    - `link`

### Result

Summernote-authored formatting now survives end-to-end as expected, while the dangerous content that should never render in blog posts remains blocked.

### Validation

- [x] `npm run build`
