### PR TITLE
Style rendered Summernote content on blog detail pages

### DIFF
--- a/openeire/src/index.css
+++ b/openeire/src/index.css
@@ -135,3 +135,88 @@ h1, h2, h3, h4, h5, h6 {
     from { opacity: 0; transform: translateY(20px); }
     to { opacity: 1; transform: translateY(0); }
 }
+
+.blog-content {
+  @apply max-w-none text-gray-300 leading-loose;
+}
+
+.blog-content p {
+  @apply mb-6 text-lg leading-9 text-gray-300;
+}
+
+.blog-content h1,
+.blog-content h2,
+.blog-content h3,
+.blog-content h4,
+.blog-content h5,
+.blog-content h6 {
+  @apply font-serif text-white leading-tight;
+}
+
+.blog-content h1 {
+  @apply mt-10 mb-6 text-4xl font-bold;
+}
+
+.blog-content h2 {
+  @apply mt-10 mb-5 text-3xl font-bold;
+}
+
+.blog-content h3 {
+  @apply mt-8 mb-4 text-2xl font-semibold;
+}
+
+.blog-content h4 {
+  @apply mt-6 mb-3 text-xl font-semibold;
+}
+
+.blog-content ul,
+.blog-content ol {
+  @apply mb-6 ml-7 space-y-3 text-lg leading-9 text-gray-300;
+  list-style-position: outside;
+}
+
+.blog-content ul {
+  list-style-type: disc;
+}
+
+.blog-content ol {
+  list-style-type: decimal;
+}
+
+.blog-content li {
+  @apply pl-1;
+}
+
+.blog-content blockquote {
+  @apply my-8 border-l-4 border-accent pl-6 italic text-gray-200;
+}
+
+.blog-content a {
+  @apply text-accent underline underline-offset-4 transition-colors hover:text-white;
+}
+
+.blog-content img {
+  @apply my-8 rounded-xl;
+}
+
+.blog-content hr {
+  @apply my-8 border-white/10;
+}
+
+.blog-content table {
+  @apply my-8 w-full border-collapse overflow-hidden rounded-xl border border-white/10;
+}
+
+.blog-content th,
+.blog-content td {
+  @apply border border-white/10 px-4 py-3 text-left;
+}
+
+.blog-content th {
+  @apply bg-white/5 font-semibold text-white;
+}
+
+.blog-content pre,
+.blog-content code {
+  @apply rounded bg-white/5;
+}

--- a/openeire/src/pages/BlogDetailPage.tsx
+++ b/openeire/src/pages/BlogDetailPage.tsx
@@ -161,7 +161,7 @@ const BlogDetailPage: React.FC = () => {
         )}
 
         {/* CONTENT (Use prose-invert for dark mode) */}
-        <article className="prose prose-invert prose-lg max-w-none text-gray-300 leading-loose prose-a:text-accent prose-headings:font-serif prose-headings:text-white prose-blockquote:border-l-accent prose-img:rounded-xl">
+        <article className="blog-content">
           {/* Blog HTML is authored by trusted admins in Summernote and sanitized on save and render.
               Internal links should point to public React routes like /blog/<slug>/, /licensing/, /contact/, or /footage/, not API endpoints. */}
           <div dangerouslySetInnerHTML={{ __html: sanitizedContent }} />


### PR DESCRIPTION
## Summary

This PR fixes the presentation of Summernote-authored blog content on the React blog detail page.

## Why

The backend fixes restored proper HTML delivery for blog content, but the live page was still not presenting that content correctly.

In practice:

- headings such as `h2` / `h3` did not look like headings
- bullet and numbered lists lost their visible markers
- Summernote rich-text content looked flattened on the live page even though it appeared correctly formatted in the editor

The issue was not the HTML itself at that point. It was the frontend typography layer applied to rendered blog content.

## Changes

- Frontend:
  - Updated `BlogDetailPage.tsx`
    - replaced the previous `prose`-based blog body styling hook with a dedicated `blog-content` class
  - Added explicit `blog-content` rich-text styles in `src/index.css` for:
    - paragraphs
    - headings (`h1`–`h6`)
    - unordered and ordered lists
    - list items
    - blockquotes
    - links
    - images
    - horizontal rules
    - tables / table cells
    - `pre` / `code`
  - Kept the existing HTML render path unchanged:
    - `dangerouslySetInnerHTML`
    - frontend sanitization
    - backend-authored Summernote HTML flow
- Backend:
  - N/A in this repo
- Infra/Config:
  - No environment changes

## Result

Summernote-authored blog posts now render with the expected visual hierarchy and structure on the live site:

- headings look like headings
- bullet lists show bullets
- ordered lists show numbering
- paragraphs and rich-text blocks have proper spacing
- links, blockquotes, tables, and images are styled consistently with the rest of the site

## Testing

- [x] React build passes locally
- [ ] Django tests pass locally
- [x] Manual smoke test completed

### Manual smoke test checklist (quick)

- [x] Blog detail page still renders Summernote-authored HTML
- [x] `h2` / `h3` headings display with clear hierarchy
- [x] unordered lists show visible bullets
- [x] ordered lists show visible numbering
- [x] paragraph spacing looks correct
- [x] blockquotes and links remain styled appropriately
- [x] tables render with readable structure
- [x] frontend build still succeeds

## Risk & Rollback

Risk level: Low

Why low:
- Frontend-only presentation change
- No API contract changes
- No content model changes
- Existing blog HTML render flow remains intact

Rollback plan:

- [x] Revert PR
- [ ] Feature flag off
- [ ] Hotfix path described:

## Notes for Reviewer (Codex/Copilot)

Focus review on:

- [x] Whether `blog-content` now styles rendered Summernote HTML correctly
- [x] Removal of ineffective reliance on the previous `prose` class setup
- [x] No changes to blog data fetching or HTML rendering logic
- [x] Styling consistency with the existing site visual language
