### PR TITLE
Normalize recommendation card sizing

### DIFF
--- a/openeire/src/components/ProductCard.tsx
+++ b/openeire/src/components/ProductCard.tsx
@@ -140,7 +140,7 @@ const ProductCard: React.FC<ProductCardProps> = ({
     <>
       <div
         ref={cardRef}
-        className="group relative bg-black rounded-2xl overflow-hidden shadow-sm hover:shadow-2xl transition-all duration-500 transform hover:-translate-y-1 border border-white/10"
+        className="group relative flex h-full flex-col bg-black rounded-2xl overflow-hidden shadow-sm hover:shadow-2xl transition-all duration-500 transform hover:-translate-y-1 border border-white/10"
         onMouseEnter={handleMouseEnter}
         onMouseLeave={() => setIsHovered(false)}
       >
@@ -220,13 +220,13 @@ const ProductCard: React.FC<ProductCardProps> = ({
           </div>
         </Link>
 
-        <div className="p-5">
+        <div className="flex flex-1 flex-col p-5">
           <Link to={detailUrl}>
-            <h3 className="text-white font-bold font-serif text-lg leading-tight mb-1 truncate hover:text-accent transition-colors">
+            <h3 className="line-clamp-2 min-h-[3.5rem] text-white font-bold font-serif text-lg leading-tight mb-1 hover:text-accent transition-colors">
               {product.title}
             </h3>
           </Link>
-          <div className="flex justify-between items-center mt-2">
+          <div className="mt-auto flex min-h-[2rem] justify-between items-center gap-3 pt-2">
             <p className="text-gray-500 text-xs uppercase tracking-wider font-bold">
               {product.collection}
             </p>

--- a/openeire/src/components/RelatedProducts.tsx
+++ b/openeire/src/components/RelatedProducts.tsx
@@ -61,7 +61,7 @@ const RelatedProducts: React.FC<RelatedProductsProps> = ({
         {products.map((item) => (
           <div
             key={item.id}
-            className="min-w-[280px] md:min-w-[320px] snap-start flex-shrink-0"
+            className="flex min-w-[280px] md:min-w-[320px] snap-start flex-shrink-0"
           >
             <ProductCard product={item} />
           </div>


### PR DESCRIPTION
## Summary

This PR fixes inconsistent product card sizing in the shared recommendation carousel used on both the product detail page and the shopping bag page.

## Why

The “You Might Also Like” section looked uneven on both desktop and mobile because cards with longer titles or different content lengths ended up taller than adjacent cards.

That inconsistency made the carousel feel visually broken and reduced the polish of two important conversion surfaces:

- product detail recommendations
- shopping bag recommendations

## Changes

- Frontend:
  - Updated `src/components/ProductCard.tsx`
    - made the card a full-height flex column
    - made the content area flexible so it fills available space consistently
    - clamped product titles to 2 lines
    - added a minimum height for the title block so cards stay visually aligned
    - anchored the bottom metadata row consistently with `mt-auto`
  - Updated `src/components/RelatedProducts.tsx`
    - made each carousel item wrapper a flex container so shared card height behavior works consistently
- Backend:
  - N/A
- Infra/Config:
  - No environment changes

## Result

Recommendation cards now keep a consistent footprint even when:

- product titles vary in length
- card metadata differs slightly between items
- the carousel is viewed on desktop or mobile

This affects both places where the shared `RelatedProducts` component is used:

- product detail page
- shopping bag page

## Testing

- [x] React build passes locally
- [ ] Django tests pass locally
- [x] Manual smoke test completed

### Manual smoke test checklist (quick)

- [x] Product detail recommendation cards render at consistent heights
- [x] Shopping bag recommendation cards render at consistent heights
- [x] Long titles no longer stretch individual cards unevenly
- [x] Card metadata rows align consistently
- [x] Frontend build still succeeds

## Risk & Rollback

Risk level: Low

Why low:
- Frontend-only layout fix
- Shared component improvement without data or API changes
- No change to recommendation fetching logic

Rollback plan:

- [x] Revert PR
- [ ] Feature flag off
- [ ] Hotfix path described:

## Notes for Reviewer (Codex/Copilot)

Focus review on:

- [x] Shared `ProductCard` layout changes only
- [x] Consistent card height behavior in both recommendation surfaces
- [x] Long-title handling via line clamp and fixed content rhythm
- [x] No change to recommendation data flow or click behavior
