### PR TITLE
Fix/uneven product cards

### DIFF
--- a/openeire/src/components/ProductCard.tsx
+++ b/openeire/src/components/ProductCard.tsx
@@ -140,13 +140,13 @@ const ProductCard: React.FC<ProductCardProps> = ({
     <>
       <div
         ref={cardRef}
-        className="group relative flex h-full flex-col bg-black rounded-2xl overflow-hidden shadow-sm hover:shadow-2xl transition-all duration-500 transform hover:-translate-y-1 border border-white/10"
+        className="group relative flex h-full w-full flex-col bg-black rounded-2xl overflow-hidden shadow-sm hover:shadow-2xl transition-all duration-500 transform hover:-translate-y-1 border border-white/10"
         onMouseEnter={handleMouseEnter}
         onMouseLeave={() => setIsHovered(false)}
       >
         <Link
           to={detailUrl}
-          className="block relative aspect-[4/3] overflow-hidden bg-gray-900"
+          className="block relative w-full aspect-[4/3] overflow-hidden bg-gray-900"
         >
           <img
             src={imageUrl}

--- a/openeire/src/components/ProductCard.tsx
+++ b/openeire/src/components/ProductCard.tsx
@@ -140,7 +140,7 @@ const ProductCard: React.FC<ProductCardProps> = ({
     <>
       <div
         ref={cardRef}
-        className="group relative bg-black rounded-2xl overflow-hidden shadow-sm hover:shadow-2xl transition-all duration-500 transform hover:-translate-y-1 border border-white/10"
+        className="group relative flex h-full flex-col bg-black rounded-2xl overflow-hidden shadow-sm hover:shadow-2xl transition-all duration-500 transform hover:-translate-y-1 border border-white/10"
         onMouseEnter={handleMouseEnter}
         onMouseLeave={() => setIsHovered(false)}
       >
@@ -220,13 +220,13 @@ const ProductCard: React.FC<ProductCardProps> = ({
           </div>
         </Link>
 
-        <div className="p-5">
+        <div className="flex flex-1 flex-col p-5">
           <Link to={detailUrl}>
-            <h3 className="text-white font-bold font-serif text-lg leading-tight mb-1 truncate hover:text-accent transition-colors">
+            <h3 className="line-clamp-2 min-h-[3.5rem] text-white font-bold font-serif text-lg leading-tight mb-1 hover:text-accent transition-colors">
               {product.title}
             </h3>
           </Link>
-          <div className="flex justify-between items-center mt-2">
+          <div className="mt-auto flex min-h-[2rem] justify-between items-center gap-3 pt-2">
             <p className="text-gray-500 text-xs uppercase tracking-wider font-bold">
               {product.collection}
             </p>

--- a/openeire/src/components/RelatedProducts.tsx
+++ b/openeire/src/components/RelatedProducts.tsx
@@ -61,7 +61,7 @@ const RelatedProducts: React.FC<RelatedProductsProps> = ({
         {products.map((item) => (
           <div
             key={item.id}
-            className="min-w-[280px] md:min-w-[320px] snap-start flex-shrink-0"
+            className="flex min-w-[280px] md:min-w-[320px] snap-start flex-shrink-0"
           >
             <ProductCard product={item} />
           </div>

--- a/openeire/src/components/RelatedProducts.tsx
+++ b/openeire/src/components/RelatedProducts.tsx
@@ -61,7 +61,7 @@ const RelatedProducts: React.FC<RelatedProductsProps> = ({
         {products.map((item) => (
           <div
             key={item.id}
-            className="flex min-w-[280px] md:min-w-[320px] snap-start flex-shrink-0"
+            className="flex w-[280px] md:w-[320px] snap-start flex-shrink-0"
           >
             <ProductCard product={item} />
           </div>


### PR DESCRIPTION
## Summary

This PR fixes the remaining recommendation-card sizing issue in the shared “You Might Also Like” carousel.

## Why

The first layout pass improved card height consistency, but the live UI still showed uneven card sizing because some carousel items were allowed to shrink horizontally.

As a result:
- one or more recommendation cards could render narrower than adjacent cards
- the carousel looked uneven on both desktop and mobile
- the shared recommendation surface still felt visually broken

## Changes

- Frontend:
  - Updated `src/components/RelatedProducts.tsx`
    - changed the carousel item wrapper from `min-width` sizing to explicit fixed widths
    - this ensures every shared recommendation item gets the same footprint
  - Updated `src/components/ProductCard.tsx`
    - added `w-full` to the card root
    - added `w-full` to the media/link wrapper
    - this ensures each card fully fills the width allocated by the carousel item
- Backend:
  - N/A
- Infra/Config:
  - No environment changes

## Result

Recommendation cards now stay visually consistent in both dimensions:

- equal width
- equal height rhythm
- aligned metadata and title areas

This affects both places where the shared `RelatedProducts` component is used:

- product detail page
- shopping bag page

## Testing

- [x] React build passes locally
- [ ] Django tests pass locally
- [x] Manual smoke test completed

### Manual smoke test checklist (quick)

- [x] Product detail recommendation cards render at consistent widths
- [x] Shopping bag recommendation cards render at consistent widths
- [x] Cards no longer collapse unevenly when titles/content differ
- [x] Frontend build still succeeds

## Risk & Rollback

Risk level: Low

Why low:
- Frontend-only layout fix
- Shared component sizing change only
- No API or recommendation logic changes

Rollback plan:

- [x] Revert PR
- [ ] Feature flag off
- [ ] Hotfix path described:

## Notes for Reviewer (Codex/Copilot)

Focus review on:

- [x] Fixed-width carousel item sizing in `RelatedProducts`
- [x] Full-width card fill behavior in `ProductCard`
- [x] Consistent recommendation card footprint on both major usage surfaces
- [x] No change to recommendation fetching or interaction behavior
