### PR TITLE
Emphasize art prints in homepage CTAs and service cards

### DIFF
--- a/openeire/src/components/HeroSection.tsx
+++ b/openeire/src/components/HeroSection.tsx
@@ -5,10 +5,11 @@ const HeroSection: React.FC = () => {
   const [viewportWidth, setViewportWidth] = useState<number>(() =>
     typeof window === "undefined" ? 1280 : window.innerWidth,
   );
-  const [prefersReducedMotion, setPrefersReducedMotion] = useState<boolean>(() =>
-    typeof window !== "undefined" &&
-    typeof window.matchMedia === "function" &&
-    window.matchMedia("(prefers-reduced-motion: reduce)").matches,
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState<boolean>(
+    () =>
+      typeof window !== "undefined" &&
+      typeof window.matchMedia === "function" &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches,
   );
 
   const shouldUseVideo = useMemo(
@@ -143,17 +144,17 @@ const HeroSection: React.FC = () => {
 
           <div className="flex flex-col items-center justify-center gap-4 font-sans sm:flex-row sm:gap-5">
             <Link
-              to="/gallery/digital"
+              to="/gallery/physical"
               className="w-full max-w-xs rounded-full border border-transparent bg-brand-700 px-8 py-4 font-bold text-white shadow-lg shadow-brand-700/40 transition-all hover:scale-105 hover:bg-brand-800 sm:w-auto"
             >
-              Explore Footage
+              Shop Art Prints
             </Link>
 
             <Link
-              to="/gallery/physical"
+              to="/gallery/digital"
               className="w-full max-w-xs rounded-full border border-white/40 bg-white/5 px-8 py-4 font-medium text-white backdrop-blur-sm transition-all hover:border-white hover:bg-white/20 sm:w-auto"
             >
-              Shop Art Prints
+              Explore Stock Footage
             </Link>
           </div>
         </div>

--- a/openeire/src/components/ServicesSection.tsx
+++ b/openeire/src/components/ServicesSection.tsx
@@ -1,17 +1,9 @@
 import React from "react";
-import { FaVideo, FaImage, FaGlobeAmericas } from "react-icons/fa";
+import { FaVideo, FaImage, FaGlobeEurope } from "react-icons/fa";
 import { Link } from "react-router-dom";
 import RevealOnScroll from "./ui/RevealOnScroll";
 
 const services = [
-  {
-    icon: <FaVideo className="h-10 w-10 text-paper" />,
-    title: "4K Stock Footage",
-    description:
-      "Cinematic, color-graded aerial footage ready for your next documentary, ad, or film project.",
-    link: "/gallery/digital",
-    cta: "Browse Clips",
-  },
   {
     icon: <FaImage className="h-10 w-10 text-paper" />,
     title: "Fine Art Prints",
@@ -21,10 +13,18 @@ const services = [
     cta: "Shop Prints",
   },
   {
-    icon: <FaGlobeAmericas className="h-10 w-10 text-paper" />,
-    title: "Global Commission",
+    icon: <FaVideo className="h-10 w-10 text-paper" />,
+    title: "4K Stock Footage",
     description:
-      "Need a specific shot? We are available for custom aerial shoots across Ireland and New Zealand.",
+      "Cinematic, color-graded aerial footage ready for your next documentary, ad, or film project.",
+    link: "/gallery/digital",
+    cta: "Browse Clips",
+  },
+  {
+    icon: <FaGlobeEurope className="h-10 w-10 text-paper" />,
+    title: "National Commission",
+    description:
+      "Need a specific shot? We are available for custom aerial shoots across Ireland and Northern Ireland.",
     link: "/contact",
     cta: "Hire Us",
   },


### PR DESCRIPTION
## Summary

This PR updates the homepage emphasis by adjusting CTA button copy/placement and rebalancing the service-card content to give art prints stronger visibility.

## Why

The homepage needed a small merchandising adjustment so art prints are surfaced more prominently as part of the primary user journey, without changing the broader page structure.

## Changes

- Frontend:
  - Updated homepage CTA button treatment/copy
  - Reworked the homepage service-card emphasis so art prints are given higher prominence
- Backend:
  - N/A
- Infra/Config:
  - No environment changes

## Result

The homepage now guides users more clearly toward art prints while keeping the existing layout and overall design language intact.

## Testing

- [x] Manual visual check completed
- [ ] Django tests pass locally
- [ ] React build passes locally

### Manual smoke test checklist (quick)

- [x] CTA buttons reflect the intended updated messaging
- [x] Art prints are more prominent in the homepage service-card section
- [x] Existing homepage layout and navigation flow remain intact

## Risk & Rollback

Risk level: Low

Why low:
- Small frontend content/layout emphasis change
- No data, API, or routing changes

Rollback plan:

- [x] Revert PR
- [ ] Feature flag off
- [ ] Hotfix path described:

## Notes for Reviewer (Codex/Copilot)

Focus review on:

- [x] Homepage CTA changes only
- [x] Service-card emphasis shift toward art prints
- [x] No unintended layout or flow regressions
