### PR TITLE
Staff route upload large videos frontend

### DIFF
--- a/openeire/src/App.tsx
+++ b/openeire/src/App.tsx
@@ -9,6 +9,7 @@ import BackToTop from "./components/BackToTop";
 import Breadcrumbs from "./components/Breadcrumbs";
 import ScrollToTop from "./components/ScrollToTop";
 import ProtectedRoute from "./components/ProtectedRoute";
+import StaffRoute from "./components/StaffRoute";
 import GalleryGuard from "./components/GalleryGuard";
 import HomePage from "./pages/HomePage";
 import GalleryPage from "./pages/GalleryPage";
@@ -52,6 +53,7 @@ const TermsAndConditions = lazy(() => import("./pages/TermsAndConditions"));
 const ShippingPolicy = lazy(() => import("./pages/ShippingPolicy"));
 const RefundPolicy = lazy(() => import("./pages/RefundPolicy"));
 const PrivacyPolicy = lazy(() => import("./pages/PrivacyPolicy"));
+const StaffVideoUploadsPage = lazy(() => import("./pages/StaffVideoUploadsPage"));
 
 function App() {
   const navigate = useNavigate();
@@ -159,6 +161,14 @@ function App() {
                   <ProtectedRoute>
                     <ProfilePage />
                   </ProtectedRoute>
+                }
+              />
+              <Route
+                path="/staff/uploads/videos"
+                element={
+                  <StaffRoute>
+                    <StaffVideoUploadsPage />
+                  </StaffRoute>
                 }
               />
 

--- a/openeire/src/components/HeroSection.tsx
+++ b/openeire/src/components/HeroSection.tsx
@@ -5,10 +5,11 @@ const HeroSection: React.FC = () => {
   const [viewportWidth, setViewportWidth] = useState<number>(() =>
     typeof window === "undefined" ? 1280 : window.innerWidth,
   );
-  const [prefersReducedMotion, setPrefersReducedMotion] = useState<boolean>(() =>
-    typeof window !== "undefined" &&
-    typeof window.matchMedia === "function" &&
-    window.matchMedia("(prefers-reduced-motion: reduce)").matches,
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState<boolean>(
+    () =>
+      typeof window !== "undefined" &&
+      typeof window.matchMedia === "function" &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches,
   );
 
   const shouldUseVideo = useMemo(
@@ -143,17 +144,17 @@ const HeroSection: React.FC = () => {
 
           <div className="flex flex-col items-center justify-center gap-4 font-sans sm:flex-row sm:gap-5">
             <Link
-              to="/gallery/digital"
+              to="/gallery/physical"
               className="w-full max-w-xs rounded-full border border-transparent bg-brand-700 px-8 py-4 font-bold text-white shadow-lg shadow-brand-700/40 transition-all hover:scale-105 hover:bg-brand-800 sm:w-auto"
             >
-              Explore Footage
+              Shop Art Prints
             </Link>
 
             <Link
-              to="/gallery/physical"
+              to="/gallery/digital"
               className="w-full max-w-xs rounded-full border border-white/40 bg-white/5 px-8 py-4 font-medium text-white backdrop-blur-sm transition-all hover:border-white hover:bg-white/20 sm:w-auto"
             >
-              Shop Art Prints
+              Explore Stock Footage
             </Link>
           </div>
         </div>

--- a/openeire/src/components/ProductCard.tsx
+++ b/openeire/src/components/ProductCard.tsx
@@ -44,7 +44,7 @@ const ProductCard: React.FC<ProductCardProps> = ({
   const imageUrl =
     resolveMediaUrl(rawImageUrl) || "https://via.placeholder.com/400x300?text=No+Preview";
 
-  const rawVideoFile = product.file;
+  const rawVideoFile = product.preview_video_url || product.file;
   const fullVideoUrl = resolveMediaUrl(rawVideoFile) ?? null;
   const videoUrl = shouldLoadVideo ? fullVideoUrl : null;
 

--- a/openeire/src/components/ServicesSection.tsx
+++ b/openeire/src/components/ServicesSection.tsx
@@ -1,17 +1,9 @@
 import React from "react";
-import { FaVideo, FaImage, FaGlobeAmericas } from "react-icons/fa";
+import { FaVideo, FaImage, FaGlobeEurope } from "react-icons/fa";
 import { Link } from "react-router-dom";
 import RevealOnScroll from "./ui/RevealOnScroll";
 
 const services = [
-  {
-    icon: <FaVideo className="h-10 w-10 text-paper" />,
-    title: "4K Stock Footage",
-    description:
-      "Cinematic, color-graded aerial footage ready for your next documentary, ad, or film project.",
-    link: "/gallery/digital",
-    cta: "Browse Clips",
-  },
   {
     icon: <FaImage className="h-10 w-10 text-paper" />,
     title: "Fine Art Prints",
@@ -21,10 +13,18 @@ const services = [
     cta: "Shop Prints",
   },
   {
-    icon: <FaGlobeAmericas className="h-10 w-10 text-paper" />,
-    title: "Global Commission",
+    icon: <FaVideo className="h-10 w-10 text-paper" />,
+    title: "4K Stock Footage",
     description:
-      "Need a specific shot? We are available for custom aerial shoots across Ireland and New Zealand.",
+      "Cinematic, color-graded aerial footage ready for your next documentary, ad, or film project.",
+    link: "/gallery/digital",
+    cta: "Browse Clips",
+  },
+  {
+    icon: <FaGlobeEurope className="h-10 w-10 text-paper" />,
+    title: "National Commission",
+    description:
+      "Need a specific shot? We are available for custom aerial shoots across Ireland and Northern Ireland.",
     link: "/contact",
     cta: "Hire Us",
   },

--- a/openeire/src/components/StaffRoute.tsx
+++ b/openeire/src/components/StaffRoute.tsx
@@ -9,7 +9,9 @@ interface StaffRouteProps {
 const StaffRoute: React.FC<StaffRouteProps> = ({ children }) => {
   const { isAuthenticated, user, refreshUser } = useAuth();
   const location = useLocation();
-  const [isCheckingAccess, setIsCheckingAccess] = useState(false);
+  const [isCheckingAccess, setIsCheckingAccess] = useState(
+    () => isAuthenticated && !user,
+  );
 
   useEffect(() => {
     if (!isAuthenticated || user) {

--- a/openeire/src/components/StaffRoute.tsx
+++ b/openeire/src/components/StaffRoute.tsx
@@ -1,0 +1,59 @@
+import React, { useEffect, useState } from "react";
+import { Navigate, useLocation } from "react-router-dom";
+import { useAuth } from "../context/AuthContext";
+
+interface StaffRouteProps {
+  children: React.ReactElement;
+}
+
+const StaffRoute: React.FC<StaffRouteProps> = ({ children }) => {
+  const { isAuthenticated, user, refreshUser } = useAuth();
+  const location = useLocation();
+  const [isCheckingAccess, setIsCheckingAccess] = useState(false);
+
+  useEffect(() => {
+    if (!isAuthenticated || user) {
+      setIsCheckingAccess(false);
+      return;
+    }
+
+    let isMounted = true;
+    setIsCheckingAccess(true);
+
+    refreshUser().finally(() => {
+      if (isMounted) {
+        setIsCheckingAccess(false);
+      }
+    });
+
+    return () => {
+      isMounted = false;
+    };
+  }, [isAuthenticated, user, refreshUser]);
+
+  if (!isAuthenticated) {
+    return <Navigate to="/login" state={{ from: location }} replace />;
+  }
+
+  if (isCheckingAccess) {
+    return (
+      <div className="flex min-h-[50vh] items-center justify-center">
+        <div className="animate-pulse text-gray-500 font-medium tracking-widest uppercase">
+          Checking access...
+        </div>
+      </div>
+    );
+  }
+
+  if (!user) {
+    return <Navigate to="/login" state={{ from: location }} replace />;
+  }
+
+  if (!user.is_staff) {
+    return <Navigate to="/403" replace />;
+  }
+
+  return children;
+};
+
+export default StaffRoute;

--- a/openeire/src/context/AuthContext.tsx
+++ b/openeire/src/context/AuthContext.tsx
@@ -11,6 +11,7 @@ import { loginUser, api } from "../services/api";
 interface User {
   username: string;
   email: string;
+  is_staff?: boolean;
   first_name?: string;
   last_name?: string;
   country?: string;

--- a/openeire/src/pages/ProductDetailPage.tsx
+++ b/openeire/src/pages/ProductDetailPage.tsx
@@ -317,8 +317,10 @@ const ProductDetailPage: React.FC = () => {
     ? product.photo.preview_image || product.preview_image || ""
     : product.preview_image || product.thumbnail_image || "";
   const videoPreviewUrl =
-    isVideo && isVideoDetail(product) && typeof product.file === "string"
-      ? product.file
+    isVideo &&
+    isVideoDetail(product) &&
+    typeof (product.preview_video_url || product.file) === "string"
+      ? product.preview_video_url || product.file
       : "";
   const reviewProductId = isPhysicalNestedDetail(product)
     ? String(product.photo.id)

--- a/openeire/src/pages/ProfilePage.tsx
+++ b/openeire/src/pages/ProfilePage.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import { Link } from "react-router-dom";
 import { UserProfile } from "../services/api";
 import EditProfileForm from "../components/EditProfileForm";
 import OrderHistoryList from "../components/OrderHistoryList";
@@ -50,6 +51,16 @@ const ProfilePage: React.FC = () => {
           <p className="text-gray-400">
             Manage your profile, orders, and preferences.
           </p>
+          {user.is_staff && (
+            <div className="mt-5">
+              <Link
+                to="/staff/uploads/videos"
+                className="inline-flex items-center rounded-xl bg-brand-500 px-5 py-3 text-sm font-bold text-black transition hover:bg-white"
+              >
+                Open Staff Video Uploader
+              </Link>
+            </div>
+          )}
         </div>
 
         <div className="flex flex-col lg:flex-row gap-12">

--- a/openeire/src/pages/StaffVideoUploadsPage.tsx
+++ b/openeire/src/pages/StaffVideoUploadsPage.tsx
@@ -1,0 +1,378 @@
+import React, { useEffect, useMemo, useState } from "react";
+import toast from "react-hot-toast";
+import {
+  createMultipartVideoUpload,
+  type MultipartUploadProgress,
+} from "../utils/multipartVideoUpload";
+import {
+  searchVideoUploadTargets,
+  type VideoUploadPurpose,
+  type VideoUploadTarget,
+} from "../services/videoUploads";
+
+const StaffVideoUploadsPage: React.FC = () => {
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [purpose, setPurpose] = useState<VideoUploadPurpose>("master");
+  const [attachToVideo, setAttachToVideo] = useState(true);
+  const [targetQuery, setTargetQuery] = useState("");
+  const [targets, setTargets] = useState<VideoUploadTarget[]>([]);
+  const [selectedTargetId, setSelectedTargetId] = useState<number | null>(null);
+  const [isLoadingTargets, setIsLoadingTargets] = useState(false);
+  const [isUploading, setIsUploading] = useState(false);
+  const [statusMessage, setStatusMessage] = useState("Choose a file to begin.");
+  const [uploadError, setUploadError] = useState<string | null>(null);
+  const [progress, setProgress] = useState<MultipartUploadProgress | null>(null);
+  const [completedObjectKey, setCompletedObjectKey] = useState<string | null>(null);
+  const [completionVideoId, setCompletionVideoId] = useState<number | null>(null);
+  const [cancelUpload, setCancelUpload] = useState<(() => Promise<void>) | null>(null);
+
+  useEffect(() => {
+    let isMounted = true;
+    const timeoutId = window.setTimeout(async () => {
+      if (!attachToVideo) {
+        setTargets([]);
+        setSelectedTargetId(null);
+        return;
+      }
+
+      setIsLoadingTargets(true);
+      try {
+        const results = await searchVideoUploadTargets(targetQuery.trim());
+        if (!isMounted) return;
+        setTargets(results);
+        setSelectedTargetId((currentTarget) => {
+          if (currentTarget && results.some((target) => target.id === currentTarget)) {
+            return currentTarget;
+          }
+          return results[0]?.id ?? null;
+        });
+      } catch {
+        if (!isMounted) return;
+        setTargets([]);
+      } finally {
+        if (isMounted) {
+          setIsLoadingTargets(false);
+        }
+      }
+    }, 250);
+
+    return () => {
+      isMounted = false;
+      window.clearTimeout(timeoutId);
+    };
+  }, [attachToVideo, targetQuery]);
+
+  const selectedTarget = useMemo(
+    () => targets.find((target) => target.id === selectedTargetId) ?? null,
+    [targets, selectedTargetId],
+  );
+
+  const resetUploadState = () => {
+    setUploadError(null);
+    setCompletedObjectKey(null);
+    setCompletionVideoId(null);
+    setProgress(null);
+  };
+
+  const handleStartUpload = async () => {
+    if (!selectedFile) {
+      toast.error("Choose a video file first.");
+      return;
+    }
+
+    if (attachToVideo && !selectedTargetId) {
+      toast.error("Choose a target video before uploading.");
+      return;
+    }
+
+    resetUploadState();
+    setIsUploading(true);
+
+    const uploadTask = createMultipartVideoUpload({
+      file: selectedFile,
+      purpose,
+      targetVideoId: attachToVideo ? selectedTargetId : null,
+      onStatusChange: setStatusMessage,
+      onProgress: setProgress,
+    });
+
+    setCancelUpload(() => uploadTask.cancel);
+
+    try {
+      const result = await uploadTask.promise;
+      setCompletedObjectKey(result.completion.object_key);
+      setCompletionVideoId(result.completion.video_id ?? null);
+      setStatusMessage("Upload complete.");
+      toast.success("Video uploaded successfully.");
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Video upload failed.";
+      setUploadError(message);
+      setStatusMessage("Upload failed.");
+      toast.error(message);
+    } finally {
+      setIsUploading(false);
+      setCancelUpload(null);
+    }
+  };
+
+  const handleCancelUpload = async () => {
+    if (!cancelUpload) return;
+
+    setStatusMessage("Cancelling upload...");
+    try {
+      await cancelUpload();
+      setStatusMessage("Upload cancelled.");
+      toast("Upload cancelled.", { icon: "i" });
+    } catch {
+      setStatusMessage("Could not cancel cleanly. The upload may already be stopping.");
+      toast.error("Could not cancel upload cleanly.");
+    } finally {
+      setIsUploading(false);
+      setCancelUpload(null);
+    }
+  };
+
+  return (
+    <div className="bg-black min-h-screen text-white pt-24 pb-20 mobile-page-offset">
+      <div className="container mx-auto max-w-5xl px-4 lg:px-8">
+        <div className="mb-10 border-b border-white/10 pb-6">
+          <p className="text-xs uppercase tracking-[0.3em] text-accent mb-3">
+            Staff Tools
+          </p>
+          <h1 className="text-4xl font-serif font-bold mb-3">
+            Multipart Video Uploads
+          </h1>
+          <p className="max-w-3xl text-gray-400 leading-relaxed">
+            Upload large private master videos or public preview clips directly to
+            Cloudflare R2 without pushing file bytes through Django.
+          </p>
+        </div>
+
+        <div className="grid gap-8 lg:grid-cols-[1.15fr_0.85fr]">
+          <section className="rounded-3xl border border-white/10 bg-gray-900 p-6 md:p-8 shadow-2xl">
+            <div className="space-y-6">
+              <div>
+                <label className="mb-2 block text-xs font-bold uppercase tracking-[0.25em] text-gray-400">
+                  Upload purpose
+                </label>
+                <select
+                  value={purpose}
+                  onChange={(event) =>
+                    setPurpose(event.target.value as VideoUploadPurpose)
+                  }
+                  disabled={isUploading}
+                  className="w-full rounded-xl border border-white/10 bg-black px-4 py-3 text-white outline-none transition focus:border-accent"
+                >
+                  <option value="master">Private master video</option>
+                  <option value="preview">Public preview clip</option>
+                </select>
+                <p className="mt-2 text-sm text-gray-500">
+                  {purpose === "master"
+                    ? "Master uploads stay private and feed secure purchase/licence delivery."
+                    : "Preview uploads are public-safe watermarked clips used for storefront playback."}
+                </p>
+              </div>
+
+              <div>
+                <label className="mb-2 block text-xs font-bold uppercase tracking-[0.25em] text-gray-400">
+                  Video file
+                </label>
+                <input
+                  type="file"
+                  accept="video/mp4,video/quicktime,video/webm,video/x-m4v"
+                  disabled={isUploading}
+                  onChange={(event) => {
+                    setSelectedFile(event.target.files?.[0] ?? null);
+                    resetUploadState();
+                    setStatusMessage("Ready to upload.");
+                  }}
+                  className="block w-full rounded-xl border border-dashed border-white/20 bg-black px-4 py-4 text-sm text-gray-300 file:mr-4 file:rounded-lg file:border-0 file:bg-brand-500 file:px-4 file:py-2 file:font-semibold file:text-black hover:file:bg-white"
+                />
+                {selectedFile && (
+                  <p className="mt-3 text-sm text-gray-400">
+                    {selectedFile.name} · {(selectedFile.size / 1024 / 1024).toFixed(1)} MB
+                  </p>
+                )}
+              </div>
+
+              <div className="rounded-2xl border border-white/10 bg-black/40 p-5">
+                <label className="flex items-start gap-3">
+                  <input
+                    type="checkbox"
+                    checked={attachToVideo}
+                    disabled={isUploading}
+                    onChange={(event) => setAttachToVideo(event.target.checked)}
+                    className="mt-1 h-4 w-4 rounded border-white/20 bg-black text-accent focus:ring-accent"
+                  />
+                  <span>
+                    <span className="block font-semibold text-white">
+                      Attach to an existing video record
+                    </span>
+                    <span className="mt-1 block text-sm text-gray-400">
+                      Leave this on to write the final object key straight onto a
+                      `Video` record. Turn it off if you only want to park the
+                      upload in R2 for later admin work.
+                    </span>
+                  </span>
+                </label>
+
+                {attachToVideo && (
+                  <div className="mt-5 space-y-4">
+                    <input
+                      type="text"
+                      value={targetQuery}
+                      disabled={isUploading}
+                      onChange={(event) => setTargetQuery(event.target.value)}
+                      placeholder="Search videos by title..."
+                      className="w-full rounded-xl border border-white/10 bg-gray-950 px-4 py-3 text-white outline-none transition focus:border-accent"
+                    />
+
+                    <div className="max-h-64 overflow-y-auto rounded-2xl border border-white/10 bg-gray-950">
+                      {isLoadingTargets ? (
+                        <div className="px-4 py-5 text-sm text-gray-500">
+                          Loading videos...
+                        </div>
+                      ) : targets.length === 0 ? (
+                        <div className="px-4 py-5 text-sm text-gray-500">
+                          No matching videos found.
+                        </div>
+                      ) : (
+                        <ul className="divide-y divide-white/5">
+                          {targets.map((target) => (
+                            <li key={target.id}>
+                              <button
+                                type="button"
+                                disabled={isUploading}
+                                onClick={() => setSelectedTargetId(target.id)}
+                                className={`flex w-full items-center justify-between px-4 py-4 text-left transition ${
+                                  selectedTargetId === target.id
+                                    ? "bg-brand-500/10 text-white"
+                                    : "text-gray-300 hover:bg-white/5"
+                                }`}
+                              >
+                                <div>
+                                  <p className="font-semibold">{target.title}</p>
+                                  <p className="mt-1 text-xs uppercase tracking-[0.2em] text-gray-500">
+                                    {target.collection} · #{target.id}
+                                  </p>
+                                </div>
+                                {!target.is_active && (
+                                  <span className="rounded-full border border-white/10 px-3 py-1 text-[10px] uppercase tracking-[0.2em] text-gray-400">
+                                    Inactive
+                                  </span>
+                                )}
+                              </button>
+                            </li>
+                          ))}
+                        </ul>
+                      )}
+                    </div>
+                  </div>
+                )}
+              </div>
+
+              <div className="flex flex-wrap gap-3">
+                <button
+                  type="button"
+                  onClick={handleStartUpload}
+                  disabled={isUploading || !selectedFile}
+                  className="rounded-xl bg-brand-500 px-6 py-3 text-sm font-bold text-black transition hover:bg-white disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  {isUploading ? "Uploading..." : "Start upload"}
+                </button>
+                <button
+                  type="button"
+                  onClick={handleCancelUpload}
+                  disabled={!isUploading || !cancelUpload}
+                  className="rounded-xl border border-white/15 px-6 py-3 text-sm font-bold text-white transition hover:border-white hover:bg-white/5 disabled:cursor-not-allowed disabled:opacity-40"
+                >
+                  Cancel upload
+                </button>
+              </div>
+            </div>
+          </section>
+
+          <aside className="rounded-3xl border border-white/10 bg-gray-900 p-6 md:p-8 shadow-2xl">
+            <h2 className="text-2xl font-serif font-bold mb-6">Upload status</h2>
+
+            <div className="space-y-5">
+              <div>
+                <p className="text-xs font-bold uppercase tracking-[0.25em] text-gray-500 mb-2">
+                  Current state
+                </p>
+                <p className="text-sm leading-relaxed text-gray-300">{statusMessage}</p>
+              </div>
+
+              {progress && (
+                <div>
+                  <div className="mb-2 flex items-center justify-between text-xs uppercase tracking-[0.2em] text-gray-500">
+                    <span>Progress</span>
+                    <span>{progress.percentage.toFixed(1)}%</span>
+                  </div>
+                  <div className="h-3 overflow-hidden rounded-full bg-black">
+                    <div
+                      className="h-full rounded-full bg-brand-500 transition-all"
+                      style={{ width: `${progress.percentage}%` }}
+                    />
+                  </div>
+                  <p className="mt-3 text-sm text-gray-400">
+                    {progress.uploadedParts} / {progress.totalParts} parts uploaded ·{" "}
+                    {(progress.bytesUploaded / 1024 / 1024).toFixed(1)} MB of{" "}
+                    {(progress.totalBytes / 1024 / 1024).toFixed(1)} MB
+                  </p>
+                </div>
+              )}
+
+              <div className="rounded-2xl border border-white/10 bg-black/40 p-5">
+                <p className="text-xs font-bold uppercase tracking-[0.25em] text-gray-500 mb-2">
+                  Target
+                </p>
+                {attachToVideo ? (
+                  selectedTarget ? (
+                    <div>
+                      <p className="font-semibold text-white">{selectedTarget.title}</p>
+                      <p className="mt-1 text-sm text-gray-400">
+                        #{selectedTarget.id} · {selectedTarget.collection}
+                      </p>
+                    </div>
+                  ) : (
+                    <p className="text-sm text-gray-500">No target selected yet.</p>
+                  )
+                ) : (
+                  <p className="text-sm text-gray-500">
+                    This upload will remain unattached until you wire it to a video later.
+                  </p>
+                )}
+              </div>
+
+              {uploadError && (
+                <div className="rounded-2xl border border-red-500/20 bg-red-500/10 p-5 text-sm text-red-100">
+                  {uploadError}
+                </div>
+              )}
+
+              {completedObjectKey && (
+                <div className="rounded-2xl border border-emerald-500/20 bg-emerald-500/10 p-5">
+                  <p className="text-xs font-bold uppercase tracking-[0.25em] text-emerald-200 mb-2">
+                    Uploaded object key
+                  </p>
+                  <code className="block break-all rounded-xl bg-black/40 px-3 py-3 text-sm text-emerald-100">
+                    {completedObjectKey}
+                  </code>
+                  <p className="mt-3 text-sm text-emerald-100">
+                    {completionVideoId
+                      ? `Attached to video #${completionVideoId}.`
+                      : "Stored in R2 and ready to attach later."}
+                  </p>
+                </div>
+              )}
+            </div>
+          </aside>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default StaffVideoUploadsPage;

--- a/openeire/src/pages/StaffVideoUploadsPage.tsx
+++ b/openeire/src/pages/StaffVideoUploadsPage.tsx
@@ -1,7 +1,8 @@
-import React, { useEffect, useMemo, useState } from "react";
+﻿import React, { useEffect, useMemo, useState } from "react";
 import toast from "react-hot-toast";
 import {
   createMultipartVideoUpload,
+  isMultipartUploadCancelledError,
   type MultipartUploadProgress,
 } from "../utils/multipartVideoUpload";
 import {
@@ -105,6 +106,11 @@ const StaffVideoUploadsPage: React.FC = () => {
       setStatusMessage("Upload complete.");
       toast.success("Video uploaded successfully.");
     } catch (error) {
+      if (isMultipartUploadCancelledError(error)) {
+        setUploadError(null);
+        setStatusMessage("Upload cancelled.");
+        return;
+      }
       const message =
         error instanceof Error ? error.message : "Video upload failed.";
       setUploadError(message);
@@ -376,3 +382,4 @@ const StaffVideoUploadsPage: React.FC = () => {
 };
 
 export default StaffVideoUploadsPage;
+

--- a/openeire/src/services/api.ts
+++ b/openeire/src/services/api.ts
@@ -134,6 +134,7 @@ export interface UserProfile {
   first_name: string | null;
   last_name: string | null;
   email: string;
+  is_staff: boolean;
   default_phone_number: string | null;
   default_street_address1: string | null;
   default_street_address2: string | null;
@@ -201,6 +202,7 @@ export interface GalleryItem {
   title: string;
   preview_image?: string;
   thumbnail_image?: string;
+  preview_video_url?: string;
   collection: string;
   price: string;
   product_type: "photo" | "video" | "physical";

--- a/openeire/src/services/videoUploads.ts
+++ b/openeire/src/services/videoUploads.ts
@@ -1,0 +1,84 @@
+import { api } from "./api";
+
+export type VideoUploadPurpose = "master" | "preview";
+
+export interface VideoUploadTarget {
+  id: number;
+  title: string;
+  collection: string;
+  is_active: boolean;
+}
+
+export interface StartedVideoUpload {
+  upload_id: string;
+  object_key: string;
+  bucket: string;
+  part_size: number;
+  max_concurrency: number;
+  purpose: VideoUploadPurpose;
+  target_video_id?: number | null;
+}
+
+export interface CompletedVideoUploadPart {
+  part_number: number;
+  etag: string;
+}
+
+export interface CompletedVideoUpload {
+  success: boolean;
+  object_key: string;
+  status: string;
+  video_id?: number | null;
+}
+
+export const requestVideoUploadStart = async (payload: {
+  filename: string;
+  content_type: string;
+  file_size: number;
+  purpose: VideoUploadPurpose;
+  target_video_id?: number | null;
+}): Promise<StartedVideoUpload> => {
+  const response = await api.post<StartedVideoUpload>("uploads/videos/start/", payload);
+  return response.data;
+};
+
+export const requestVideoUploadPartUrl = async (payload: {
+  upload_id: string;
+  object_key: string;
+  part_number: number;
+}): Promise<{ url: string }> => {
+  const response = await api.post<{ url: string }>("uploads/videos/part-url/", payload);
+  return response.data;
+};
+
+export const completeVideoUpload = async (payload: {
+  upload_id: string;
+  object_key: string;
+  parts: CompletedVideoUploadPart[];
+}): Promise<CompletedVideoUpload> => {
+  const response = await api.post<CompletedVideoUpload>(
+    "uploads/videos/complete/",
+    payload,
+  );
+  return response.data;
+};
+
+export const abortVideoUpload = async (payload: {
+  upload_id: string;
+  object_key: string;
+}): Promise<{ success: boolean; status: string }> => {
+  const response = await api.post<{ success: boolean; status: string }>(
+    "uploads/videos/abort/",
+    payload,
+  );
+  return response.data;
+};
+
+export const searchVideoUploadTargets = async (
+  query = "",
+): Promise<VideoUploadTarget[]> => {
+  const response = await api.get<VideoUploadTarget[]>("uploads/videos/targets/", {
+    params: query ? { query } : undefined,
+  });
+  return response.data;
+};

--- a/openeire/src/utils/multipartVideoUpload.ts
+++ b/openeire/src/utils/multipartVideoUpload.ts
@@ -1,0 +1,254 @@
+import axios from "axios";
+import {
+  abortVideoUpload,
+  completeVideoUpload,
+  requestVideoUploadPartUrl,
+  requestVideoUploadStart,
+  type CompletedVideoUpload,
+  type CompletedVideoUploadPart,
+  type StartedVideoUpload,
+  type VideoUploadPurpose,
+} from "../services/videoUploads";
+
+const DEFAULT_RETRY_LIMIT = 3;
+
+const R2_CORS_ERROR_MESSAGE =
+  "Upload blocked by Cloudflare R2 CORS. Allow this frontend origin on the target bucket and expose the ETag header.";
+
+export interface MultipartUploadProgress {
+  bytesUploaded: number;
+  totalBytes: number;
+  percentage: number;
+  uploadedParts: number;
+  totalParts: number;
+}
+
+export interface MultipartUploadResult {
+  upload: StartedVideoUpload;
+  completion: CompletedVideoUpload;
+}
+
+interface UploadMultipartVideoOptions {
+  file: File;
+  purpose: VideoUploadPurpose;
+  targetVideoId?: number | null;
+  retryLimit?: number;
+  onProgress?: (progress: MultipartUploadProgress) => void;
+  onStatusChange?: (status: string) => void;
+}
+
+const buildProgressSnapshot = (
+  partProgress: Map<number, number>,
+  totalBytes: number,
+  uploadedParts: number,
+  totalParts: number,
+): MultipartUploadProgress => {
+  const bytesUploaded = Array.from(partProgress.values()).reduce(
+    (sum, current) => sum + current,
+    0,
+  );
+
+  return {
+    bytesUploaded,
+    totalBytes,
+    percentage: totalBytes > 0 ? Math.min(100, (bytesUploaded / totalBytes) * 100) : 0,
+    uploadedParts,
+    totalParts,
+  };
+};
+
+const sortCompletedParts = (
+  completedParts: Map<number, string>,
+): CompletedVideoUploadPart[] =>
+  Array.from(completedParts.entries())
+    .sort(([partA], [partB]) => partA - partB)
+    .map(([part_number, etag]) => ({ part_number, etag }));
+
+const getMultipartUploadErrorMessage = (error: unknown): string => {
+  if (axios.isAxiosError(error)) {
+    const requestUrl = typeof error.config?.url === "string" ? error.config.url : "";
+    const isDirectR2Request =
+      requestUrl.startsWith("http://") || requestUrl.startsWith("https://");
+
+    if ((error.code === "ERR_NETWORK" || !error.response) && isDirectR2Request) {
+      return R2_CORS_ERROR_MESSAGE;
+    }
+
+    if (error.response?.status === 403 && isDirectR2Request) {
+      return R2_CORS_ERROR_MESSAGE;
+    }
+
+    const detail =
+      (typeof error.response?.data?.detail === "string" && error.response.data.detail) ||
+      (typeof error.response?.data?.message === "string" && error.response.data.message);
+
+    if (detail) {
+      return detail;
+    }
+  }
+
+  if (error instanceof Error && error.message) {
+    return error.message;
+  }
+
+  return "Video upload failed.";
+};
+
+export const createMultipartVideoUpload = ({
+  file,
+  purpose,
+  targetVideoId,
+  retryLimit = DEFAULT_RETRY_LIMIT,
+  onProgress,
+  onStatusChange,
+}: UploadMultipartVideoOptions) => {
+  const abortController = new AbortController();
+  let startedUpload: StartedVideoUpload | null = null;
+  let hasCompleted = false;
+
+  const uploadPromise = (async (): Promise<MultipartUploadResult> => {
+    onStatusChange?.("Starting upload session...");
+
+    const upload = await requestVideoUploadStart({
+      filename: file.name,
+      content_type: file.type,
+      file_size: file.size,
+      purpose,
+      target_video_id: targetVideoId ?? null,
+    });
+    startedUpload = upload;
+
+    const totalParts = Math.ceil(file.size / upload.part_size);
+    const completedParts = new Map<number, string>();
+    const partProgress = new Map<number, number>();
+    const uploadedPartNumbers = new Set<number>();
+
+    const emitProgress = () => {
+      onProgress?.(
+        buildProgressSnapshot(
+          partProgress,
+          file.size,
+          uploadedPartNumbers.size,
+          totalParts,
+        ),
+      );
+    };
+
+    const uploadSinglePart = async (partNumber: number) => {
+      const partStart = (partNumber - 1) * upload.part_size;
+      const partEnd = Math.min(file.size, partStart + upload.part_size);
+      const chunk = file.slice(partStart, partEnd);
+
+      let lastError: unknown = null;
+
+      for (let attempt = 1; attempt <= retryLimit; attempt += 1) {
+        try {
+          onStatusChange?.(
+            `Uploading part ${partNumber} of ${totalParts}${
+              attempt > 1 ? ` (retry ${attempt}/${retryLimit})` : ""
+            }...`,
+          );
+
+          const { url } = await requestVideoUploadPartUrl({
+            upload_id: upload.upload_id,
+            object_key: upload.object_key,
+            part_number: partNumber,
+          });
+
+          const response = await axios.put(url, chunk, {
+            signal: abortController.signal,
+            headers: {
+              "Content-Type": file.type || "application/octet-stream",
+            },
+            onUploadProgress: (event) => {
+              partProgress.set(partNumber, Math.min(event.loaded, chunk.size));
+              emitProgress();
+            },
+          });
+
+          const etagHeader = response.headers.etag || response.headers.ETag;
+          const etag = String(etagHeader || "").trim();
+          if (!etag) {
+            throw new Error(`Missing ETag for uploaded part ${partNumber}.`);
+          }
+
+          partProgress.set(partNumber, chunk.size);
+          uploadedPartNumbers.add(partNumber);
+          completedParts.set(partNumber, etag);
+          emitProgress();
+          return;
+        } catch (error) {
+          lastError = error;
+          if (abortController.signal.aborted) {
+            throw error;
+          }
+          if (attempt === retryLimit) {
+            break;
+          }
+        }
+      }
+
+      throw lastError instanceof Error
+        ? lastError
+        : new Error(`Failed to upload part ${partNumber}.`);
+    };
+
+    const queue = Array.from({ length: totalParts }, (_, index) => index + 1);
+    const workerCount = Math.max(1, Math.min(upload.max_concurrency, queue.length));
+
+    const workers = Array.from({ length: workerCount }, async () => {
+      while (queue.length > 0) {
+        const nextPart = queue.shift();
+        if (!nextPart) {
+          return;
+        }
+        await uploadSinglePart(nextPart);
+      }
+    });
+
+    try {
+      await Promise.all(workers);
+      onStatusChange?.("Finalising upload...");
+
+      const completion = await completeVideoUpload({
+        upload_id: upload.upload_id,
+        object_key: upload.object_key,
+        parts: sortCompletedParts(completedParts),
+      });
+
+      hasCompleted = true;
+      onStatusChange?.("Upload complete.");
+      return { upload, completion };
+    } catch (error) {
+      if (startedUpload && !hasCompleted) {
+        try {
+          await abortVideoUpload({
+            upload_id: startedUpload.upload_id,
+            object_key: startedUpload.object_key,
+          });
+        } catch {
+          // Best-effort cleanup only.
+        }
+      }
+      throw new Error(getMultipartUploadErrorMessage(error));
+    }
+  })();
+
+  return {
+    promise: uploadPromise,
+    cancel: async () => {
+      abortController.abort();
+
+      if (startedUpload && !hasCompleted) {
+        try {
+          await abortVideoUpload({
+            upload_id: startedUpload.upload_id,
+            object_key: startedUpload.object_key,
+          });
+        } catch {
+          // Best-effort cleanup only.
+        }
+      }
+    },
+  };
+};

--- a/openeire/src/utils/multipartVideoUpload.ts
+++ b/openeire/src/utils/multipartVideoUpload.ts
@@ -14,6 +14,14 @@ const DEFAULT_RETRY_LIMIT = 3;
 
 const R2_CORS_ERROR_MESSAGE =
   "Upload blocked by Cloudflare R2 CORS. Allow this frontend origin on the target bucket and expose the ETag header.";
+const UPLOAD_CANCELLED_MESSAGE = "Upload cancelled.";
+
+const VIDEO_CONTENT_TYPE_BY_EXTENSION: Record<string, string> = {
+  ".mp4": "video/mp4",
+  ".mov": "video/quicktime",
+  ".webm": "video/webm",
+  ".m4v": "video/x-m4v",
+};
 
 export interface MultipartUploadProgress {
   bytesUploaded: number;
@@ -26,6 +34,13 @@ export interface MultipartUploadProgress {
 export interface MultipartUploadResult {
   upload: StartedVideoUpload;
   completion: CompletedVideoUpload;
+}
+
+export class MultipartUploadCancelledError extends Error {
+  constructor(message = UPLOAD_CANCELLED_MESSAGE) {
+    super(message);
+    this.name = "MultipartUploadCancelledError";
+  }
 }
 
 interface UploadMultipartVideoOptions {
@@ -57,20 +72,42 @@ const buildProgressSnapshot = (
   };
 };
 
-const sortCompletedParts = (
+export const sortCompletedParts = (
   completedParts: Map<number, string>,
 ): CompletedVideoUploadPart[] =>
   Array.from(completedParts.entries())
     .sort(([partA], [partB]) => partA - partB)
     .map(([part_number, etag]) => ({ part_number, etag }));
 
-const getMultipartUploadErrorMessage = (error: unknown): string => {
+export const inferVideoContentType = (file: File): string => {
+  if (file.type) {
+    return file.type;
+  }
+
+  const filename = file.name.toLowerCase();
+  const matchedExtension = Object.keys(VIDEO_CONTENT_TYPE_BY_EXTENSION).find((extension) =>
+    filename.endsWith(extension),
+  );
+
+  return matchedExtension
+    ? VIDEO_CONTENT_TYPE_BY_EXTENSION[matchedExtension]
+    : "application/octet-stream";
+};
+
+const isDirectRequestUrl = (value?: string): boolean =>
+  typeof value === "string" &&
+  (value.startsWith("http://") || value.startsWith("https://"));
+
+export const getMultipartUploadErrorMessage = (error: unknown): string => {
+  if (axios.isAxiosError(error) && error.code === "ERR_CANCELED") {
+    return UPLOAD_CANCELLED_MESSAGE;
+  }
+
   if (axios.isAxiosError(error)) {
     const requestUrl = typeof error.config?.url === "string" ? error.config.url : "";
-    const isDirectR2Request =
-      requestUrl.startsWith("http://") || requestUrl.startsWith("https://");
+    const isDirectR2Request = isDirectRequestUrl(requestUrl);
 
-    if ((error.code === "ERR_NETWORK" || !error.response) && isDirectR2Request) {
+    if (error.code === "ERR_NETWORK" && isDirectR2Request) {
       return R2_CORS_ERROR_MESSAGE;
     }
 
@@ -94,6 +131,14 @@ const getMultipartUploadErrorMessage = (error: unknown): string => {
   return "Video upload failed.";
 };
 
+const isCancellationError = (error: unknown): boolean =>
+  error instanceof MultipartUploadCancelledError ||
+  (axios.isAxiosError(error) && error.code === "ERR_CANCELED");
+
+export const isMultipartUploadCancelledError = (
+  error: unknown,
+): error is MultipartUploadCancelledError => error instanceof MultipartUploadCancelledError;
+
 export const createMultipartVideoUpload = ({
   file,
   purpose,
@@ -105,13 +150,32 @@ export const createMultipartVideoUpload = ({
   const abortController = new AbortController();
   let startedUpload: StartedVideoUpload | null = null;
   let hasCompleted = false;
+  let hasCancelled = false;
+  let abortPromise: Promise<void> | null = null;
+  let fatalError: unknown = null;
+
+  const abortMultipartUploadOnce = async () => {
+    if (!startedUpload || hasCompleted) {
+      return;
+    }
+    if (!abortPromise) {
+      abortPromise = abortVideoUpload({
+        upload_id: startedUpload.upload_id,
+        object_key: startedUpload.object_key,
+      })
+        .then(() => undefined)
+        .catch(() => undefined);
+    }
+    await abortPromise;
+  };
 
   const uploadPromise = (async (): Promise<MultipartUploadResult> => {
     onStatusChange?.("Starting upload session...");
+    const uploadContentType = inferVideoContentType(file);
 
     const upload = await requestVideoUploadStart({
       filename: file.name,
-      content_type: file.type,
+      content_type: uploadContentType,
       file_size: file.size,
       purpose,
       target_video_id: targetVideoId ?? null,
@@ -143,6 +207,8 @@ export const createMultipartVideoUpload = ({
 
       for (let attempt = 1; attempt <= retryLimit; attempt += 1) {
         try {
+          partProgress.set(partNumber, 0);
+          emitProgress();
           onStatusChange?.(
             `Uploading part ${partNumber} of ${totalParts}${
               attempt > 1 ? ` (retry ${attempt}/${retryLimit})` : ""
@@ -158,7 +224,7 @@ export const createMultipartVideoUpload = ({
           const response = await axios.put(url, chunk, {
             signal: abortController.signal,
             headers: {
-              "Content-Type": file.type || "application/octet-stream",
+              "Content-Type": uploadContentType,
             },
             onUploadProgress: (event) => {
               partProgress.set(partNumber, Math.min(event.loaded, chunk.size));
@@ -180,7 +246,7 @@ export const createMultipartVideoUpload = ({
         } catch (error) {
           lastError = error;
           if (abortController.signal.aborted) {
-            throw error;
+            throw new MultipartUploadCancelledError();
           }
           if (attempt === retryLimit) {
             break;
@@ -188,26 +254,37 @@ export const createMultipartVideoUpload = ({
         }
       }
 
-      throw lastError instanceof Error
-        ? lastError
-        : new Error(`Failed to upload part ${partNumber}.`);
+      const resolvedError =
+        lastError instanceof Error
+          ? lastError
+          : new Error(`Failed to upload part ${partNumber}.`);
+      fatalError = resolvedError;
+      abortController.abort();
+      throw resolvedError;
     };
 
-    const queue = Array.from({ length: totalParts }, (_, index) => index + 1);
-    const workerCount = Math.max(1, Math.min(upload.max_concurrency, queue.length));
+    let nextPartIndex = 0;
+    const workerCount = Math.max(1, Math.min(upload.max_concurrency, totalParts));
 
     const workers = Array.from({ length: workerCount }, async () => {
-      while (queue.length > 0) {
-        const nextPart = queue.shift();
-        if (!nextPart) {
+      while (!fatalError && !abortController.signal.aborted) {
+        const currentIndex = nextPartIndex;
+        nextPartIndex += 1;
+        if (currentIndex >= totalParts) {
           return;
         }
+        const nextPart = currentIndex + 1;
         await uploadSinglePart(nextPart);
       }
     });
 
     try {
       await Promise.all(workers);
+
+      if (hasCancelled || abortController.signal.aborted) {
+        throw new MultipartUploadCancelledError();
+      }
+
       onStatusChange?.("Finalising upload...");
 
       const completion = await completeVideoUpload({
@@ -220,35 +297,23 @@ export const createMultipartVideoUpload = ({
       onStatusChange?.("Upload complete.");
       return { upload, completion };
     } catch (error) {
-      if (startedUpload && !hasCompleted) {
-        try {
-          await abortVideoUpload({
-            upload_id: startedUpload.upload_id,
-            object_key: startedUpload.object_key,
-          });
-        } catch {
-          // Best-effort cleanup only.
-        }
+      if (hasCancelled || isCancellationError(error)) {
+        throw new MultipartUploadCancelledError();
       }
-      throw new Error(getMultipartUploadErrorMessage(error));
+
+      if (startedUpload && !hasCompleted) {
+        await abortMultipartUploadOnce();
+      }
+      throw new Error(getMultipartUploadErrorMessage(fatalError ?? error));
     }
   })();
 
   return {
     promise: uploadPromise,
     cancel: async () => {
+      hasCancelled = true;
       abortController.abort();
-
-      if (startedUpload && !hasCompleted) {
-        try {
-          await abortVideoUpload({
-            upload_id: startedUpload.upload_id,
-            object_key: startedUpload.object_key,
-          });
-        } catch {
-          // Best-effort cleanup only.
-        }
-      }
+      await abortMultipartUploadOnce();
     },
   };
 };

--- a/openeire/tests/multipartVideoUpload.test.ts
+++ b/openeire/tests/multipartVideoUpload.test.ts
@@ -1,0 +1,137 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import axios from "axios";
+import {
+  MultipartUploadCancelledError,
+  createMultipartVideoUpload,
+  getMultipartUploadErrorMessage,
+  inferVideoContentType,
+  sortCompletedParts,
+} from "../src/utils/multipartVideoUpload";
+import {
+  abortVideoUpload,
+  requestVideoUploadPartUrl,
+  requestVideoUploadStart,
+} from "../src/services/videoUploads";
+
+vi.mock("axios", () => ({
+  default: {
+    put: vi.fn(),
+    isAxiosError: (error: unknown) =>
+      typeof error === "object" &&
+      error !== null &&
+      "isAxiosError" in error &&
+      (error as { isAxiosError?: boolean }).isAxiosError === true,
+  },
+}));
+
+vi.mock("../src/services/videoUploads", () => ({
+  requestVideoUploadStart: vi.fn(),
+  requestVideoUploadPartUrl: vi.fn(),
+  completeVideoUpload: vi.fn(),
+  abortVideoUpload: vi.fn(),
+}));
+
+describe("multipartVideoUpload helpers", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("sorts completed parts by ascending part number", () => {
+    const parts = sortCompletedParts(
+      new Map([
+        [3, '"etag-3"'],
+        [1, '"etag-1"'],
+        [2, '"etag-2"'],
+      ]),
+    );
+
+    expect(parts).toEqual([
+      { part_number: 1, etag: '"etag-1"' },
+      { part_number: 2, etag: '"etag-2"' },
+      { part_number: 3, etag: '"etag-3"' },
+    ]);
+  });
+
+  it("infers a supported video content type from the filename when File.type is empty", () => {
+    const file = new File(["video"], "Fanore-Beach.MP4", { type: "" });
+    expect(inferVideoContentType(file)).toBe("video/mp4");
+  });
+
+  it("maps direct R2 network failures to the CORS guidance message", () => {
+    const message = getMultipartUploadErrorMessage({
+      isAxiosError: true,
+      code: "ERR_NETWORK",
+      config: { url: "https://r2.example.com/upload-part" },
+    });
+
+    expect(message).toContain("Cloudflare R2 CORS");
+  });
+
+  it("maps cancelled uploads to an explicit cancellation message", () => {
+    const message = getMultipartUploadErrorMessage({
+      isAxiosError: true,
+      code: "ERR_CANCELED",
+      config: { url: "https://r2.example.com/upload-part" },
+    });
+
+    expect(message).toBe("Upload cancelled.");
+  });
+});
+
+describe("createMultipartVideoUpload", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("aborts only once and rejects with MultipartUploadCancelledError on cancel", async () => {
+    vi.mocked(requestVideoUploadStart).mockResolvedValue({
+      upload_id: "upload-123",
+      object_key: "previews/videos/fanore-beach.mp4",
+      bucket: "public-bucket",
+      part_size: 1024,
+      max_concurrency: 1,
+      purpose: "preview",
+    });
+    vi.mocked(requestVideoUploadPartUrl).mockResolvedValue({
+      url: "https://r2.example.com/upload-part",
+    });
+    vi.mocked(abortVideoUpload).mockResolvedValue({
+      success: true,
+      status: "aborted",
+    });
+    vi.mocked(axios.put).mockImplementation(
+      (_url, _chunk, config?: { signal?: AbortSignal }) =>
+        new Promise((_resolve, reject) => {
+          if (config?.signal?.aborted) {
+            reject({
+              isAxiosError: true,
+              code: "ERR_CANCELED",
+              config: { url: "https://r2.example.com/upload-part" },
+            });
+            return;
+          }
+          config?.signal?.addEventListener("abort", () => {
+            reject({
+              isAxiosError: true,
+              code: "ERR_CANCELED",
+              config: { url: "https://r2.example.com/upload-part" },
+            });
+          });
+        }),
+    );
+
+    const file = new File(["preview-video"], "preview.mp4", { type: "video/mp4" });
+    const task = createMultipartVideoUpload({
+      file,
+      purpose: "preview",
+    });
+
+    await Promise.resolve();
+
+    const cancelPromise = task.cancel();
+    await expect(task.promise).rejects.toBeInstanceOf(MultipartUploadCancelledError);
+    await cancelPromise;
+
+    expect(abortVideoUpload).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

This PR adds the React side of the staff-only multipart video uploader for Cloudflare R2 and updates the storefront to use explicit video preview clip URLs.

## Why

The backend now supports multipart R2 uploads for video masters and preview clips, but the frontend needed:

- a reusable multipart uploader
- a staff-only route and UI for admin/media workflows
- clean progress, cancellation, and retry handling
- safe usage of preview clips on storefront video surfaces

The goal was to keep the upload workflow operationally simple while ensuring it is not accessible to the public or to non-staff accounts.

## Changes

- Frontend:
  - Added a new staff-only route:
    - `/staff/uploads/videos`
  - Added `StaffRoute` to enforce:
    - unauthenticated users -> `/login`
    - authenticated non-staff users -> `/403`
  - Added a reusable multipart upload API/service layer:
    - start
    - part-url
    - complete
    - abort
    - target search
  - Added a reusable multipart upload utility that:
    - splits files into backend-sized chunks
    - uploads parts in parallel
    - tracks progress
    - retries failed parts
    - completes uploads
    - supports cancellation
    - performs best-effort abort cleanup
  - Added a staff-facing upload page with:
    - file picker
    - purpose selector (`master` / `preview`)
    - optional attach-to-existing-video behavior
    - video search
    - progress bar
    - upload status
    - cancel action
    - success object-key output
    - error state
  - Updated auth typing to include `is_staff`
  - Added a staff entry point from the profile page for staff users
  - Updated video preview consumption so storefront video cards/detail pages use:
    - `preview_video_url`
    - with fallback to legacy `file` if needed
  - Improved multipart error handling so R2 CORS/preflight failures surface a useful message instead of a generic network error
- Backend:
  - N/A in this repo
- Infra/Config:
  - No frontend secrets added
  - Depends on backend upload endpoints and correct R2 bucket CORS config

## Staff Access Behavior

This route is intentionally not public.

Rules:
- public users cannot access it
- logged-out users are sent to login
- authenticated non-staff users are sent to `/403`
- only staff users can use the uploader

This is enforced at the route level, not just hidden in UI.

## Upload Workflow

The uploader:
1. starts a backend upload session
2. requests presigned part URLs
3. uploads file chunks directly to R2
4. collects `ETag` values
5. completes the multipart upload through Django
6. optionally attaches the uploaded object key to an existing `Video`

Django does not proxy file bytes.

## Storefront Preview Changes

Video previews now prefer:
- `preview_video_url`

This keeps preview playback explicitly separate from:
- private downloadable master assets

## Testing

- [x] React build passes locally
- [ ] Django tests pass locally
- [x] Manual smoke test completed

### Manual smoke test checklist (quick)

- [x] Staff-only route blocks non-staff users with `/403`
- [x] Upload page allows master uploads
- [x] Upload page allows preview uploads
- [x] Upload progress updates during multipart transfer
- [x] Upload cancellation works
- [x] Upload completion returns final object key
- [x] Storefront video previews use explicit preview clip URLs
- [x] R2 CORS failures now show a useful frontend error message
- [x] Frontend build still succeeds

## Risk & Rollback

Risk level: Medium

Why medium:
- new staff-only operational workflow
- multipart upload orchestration in browser
- depends on backend upload endpoints and bucket CORS
- changes storefront video preview source selection

Rollback plan:

- [x] Revert PR
- [ ] Feature flag off
- [ ] Hotfix path described:

## Notes for Reviewer (Codex/Copilot)

Focus review on:

- [x] Staff-only route enforcement via `StaffRoute`
- [x] Clean separation between upload UI and upload utility
- [x] Multipart retry/cancel behavior
- [x] No leakage of bucket credentials to the client
- [x] Preview clip URL usage instead of relying only on the legacy `file` field
- [x] Helpful error handling for R2 CORS failures

## Follow-up hardening

This PR also tightens the React multipart uploader so it behaves more predictably in real admin workflows.

### What changed

- Fixed `StaffRoute` so restored authenticated staff sessions no longer get redirected before profile state finishes loading
- Replaced the internal `queue.shift()` worker loop with an index cursor for cleaner concurrent part scheduling
- Stopped multipart workers promptly when one part fails fatally
- Treated user-initiated cancellation explicitly instead of misclassifying it as an R2 CORS/network failure
- Prevented duplicate abort handling during cancellation
- Reset per-part progress on retry so progress reporting stays consistent
- Added content-type inference from the filename when `File.type` is empty
- Added focused Vitest coverage for multipart upload helpers:
  - part sorting
  - MIME fallback
  - CORS error mapping
  - cancellation error mapping
  - cancel/abort behavior

### Why this matters

These fixes improve correctness and operator trust in the uploader:

- staff-only access now works reliably with restored sessions
- cancellation behaves like cancellation, not failure
- fatal upload errors stop wasting bandwidth
- progress reporting remains more consistent during retries
- helper behavior now has targeted regression coverage

### Validation

- [x] `npm test -- multipartVideoUpload.test.ts`
- [x] `npm run build`

### Reviewer note

Please focus review on:
- `StaffRoute` loading/checking behavior for authenticated staff users
- cancellation semantics in the multipart uploader
- stop-on-failure behavior for concurrent part uploads
- focused test coverage for multipart helper logic