### PR TITLE
Use native browser downloads for large video files

### DIFF
--- a/openeire/src/services/api.ts
+++ b/openeire/src/services/api.ts
@@ -815,56 +815,22 @@ export const getShoppingBagRecommendations = async (): Promise<GalleryItem[]> =>
   return response.data;
 };
 
-const extractFilenameFromDisposition = (disposition?: string): string | null => {
-  if (!disposition) return null;
-
-  const encodedMatch = disposition.match(/filename\*\s*=\s*UTF-8''([^;]+)/i);
-  if (encodedMatch?.[1]) {
-    try {
-      return decodeURIComponent(encodedMatch[1]);
-    } catch {
-      return encodedMatch[1];
-    }
-  }
-
-  const filenameMatch = disposition.match(/filename="?([^";]+)"?/i);
-  return filenameMatch?.[1] ?? null;
-};
-
-const sanitizeDownloadFilename = (filename: string): string => {
-  const sanitized = filename
-    .replace(/[\\/]+/g, "_")
-    .replace(/[\u0000-\u001f\u007f]+/g, "")
-    .trim();
-  return sanitized || "download";
-};
-
 export const downloadProduct = async (
   type: "photo" | "video",
   id: number,
-  fallbackFilename: string,
+  _fallbackFilename: string,
 ) => {
-  const response = await api.get(
-    normalizeApiPath(`/products/download/${type}/${id}/`),
-    {
-      responseType: 'blob',
-    },
-  );
-
-  const disposition = response.headers["content-disposition"] as string | undefined;
-  const resolvedFilename = sanitizeDownloadFilename(
-    extractFilenameFromDisposition(disposition) || fallbackFilename,
-  );
-
-  const url = window.URL.createObjectURL(response.data);
+  const url = normalizeApiPath(`/products/download/${type}/${id}/`);
   const link = document.createElement('a');
   link.href = url;
-  link.setAttribute('download', resolvedFilename);
+  link.rel = 'noreferrer';
+  link.style.display = 'none';
   document.body.appendChild(link);
   link.click();
 
-  link.parentNode?.removeChild(link);
-  window.URL.revokeObjectURL(url);
+  window.setTimeout(() => {
+    link.parentNode?.removeChild(link);
+  }, 0);
   return true;
 };
 


### PR DESCRIPTION
## Summary

This PR fixes large video downloads on the frontend by switching the download helper from a Blob-based JavaScript save path to a native browser navigation download.

## Why

The backend was already returning valid download responses, including `Content-Disposition`, but the frontend was still fetching the full file into memory as a Blob before creating a temporary object URL.

That approach is fragile for large video files and can fail on memory-constrained devices, especially mobile.

## Changes

- Frontend:
  - Updated `src/services/api.ts`
    - `downloadProduct(...)` now uses a native browser download flow instead of buffering the response into a Blob
    - removed the object URL / Blob save path for product downloads
    - keeps the filename behavior aligned with the server-provided download URL
- Backend:
  - N/A in this repo
- Infra/Config:
  - No environment changes

## Result

Large video downloads now rely on the browser to handle the transfer directly instead of loading the entire file into JavaScript memory first.

This should improve reliability for:
- emailed personal download links
- profile order-history download buttons
- mobile users
- large video files in general

## Testing

- [x] `npm run build`

### Manual smoke test checklist (quick)

- [x] Download button triggers a native browser download flow
- [x] Large video downloads no longer depend on Blob buffering
- [x] Download behavior remains available from order history
- [ ] Retest the real purchased video after deploy

## Risk & Rollback

Risk level: Low

Why low:
- frontend-only change
- no API contract changes
- no backend delivery behavior changes

Rollback plan:

- [x] Revert PR
- [ ] Feature flag off
- [ ] Hotfix path described:

## Notes for Reviewer (Codex/Copilot)

Focus review on:

- [x] Removal of Blob/object URL handling for product downloads
- [x] Native browser download path
- [x] No impact to backend download authorization logic
