### PR TITLE
Fix/large video download

### DIFF
--- a/openeire/src/components/OrderHistoryCard.tsx
+++ b/openeire/src/components/OrderHistoryCard.tsx
@@ -22,10 +22,11 @@ const OrderHistoryCard: React.FC<OrderHistoryCardProps> = ({ order }) => {
     productId: number,
     type: "photo" | "video",
     fallbackFilename: string,
+    directUrl?: string | null,
   ) => {
     setDownloadingItemId(orderItemId);
     try {
-      await downloadProduct(type, productId, fallbackFilename);
+      await downloadProduct(type, productId, fallbackFilename, directUrl);
       toast.success("Download started.");
     } catch (error) {
       console.error(error);
@@ -157,6 +158,7 @@ const OrderHistoryCard: React.FC<OrderHistoryCardProps> = ({ order }) => {
                           productId,
                           digitalType,
                           `${item.product.title}.${digitalType === "video" ? "mp4" : "jpg"}`,
+                          item.download_url,
                         )
                       }
                       disabled={downloadingItemId === item.id}

--- a/openeire/src/services/api.ts
+++ b/openeire/src/services/api.ts
@@ -815,56 +815,22 @@ export const getShoppingBagRecommendations = async (): Promise<GalleryItem[]> =>
   return response.data;
 };
 
-const extractFilenameFromDisposition = (disposition?: string): string | null => {
-  if (!disposition) return null;
-
-  const encodedMatch = disposition.match(/filename\*\s*=\s*UTF-8''([^;]+)/i);
-  if (encodedMatch?.[1]) {
-    try {
-      return decodeURIComponent(encodedMatch[1]);
-    } catch {
-      return encodedMatch[1];
-    }
-  }
-
-  const filenameMatch = disposition.match(/filename="?([^";]+)"?/i);
-  return filenameMatch?.[1] ?? null;
-};
-
-const sanitizeDownloadFilename = (filename: string): string => {
-  const sanitized = filename
-    .replace(/[\\/]+/g, "_")
-    .replace(/[\u0000-\u001f\u007f]+/g, "")
-    .trim();
-  return sanitized || "download";
-};
-
 export const downloadProduct = async (
   type: "photo" | "video",
   id: number,
-  fallbackFilename: string,
+  _fallbackFilename: string,
 ) => {
-  const response = await api.get(
-    normalizeApiPath(`/products/download/${type}/${id}/`),
-    {
-      responseType: 'blob',
-    },
-  );
-
-  const disposition = response.headers["content-disposition"] as string | undefined;
-  const resolvedFilename = sanitizeDownloadFilename(
-    extractFilenameFromDisposition(disposition) || fallbackFilename,
-  );
-
-  const url = window.URL.createObjectURL(response.data);
+  const url = normalizeApiPath(`/products/download/${type}/${id}/`);
   const link = document.createElement('a');
   link.href = url;
-  link.setAttribute('download', resolvedFilename);
+  link.rel = 'noreferrer';
+  link.style.display = 'none';
   document.body.appendChild(link);
   link.click();
 
-  link.parentNode?.removeChild(link);
-  window.URL.revokeObjectURL(url);
+  window.setTimeout(() => {
+    link.parentNode?.removeChild(link);
+  }, 0);
   return true;
 };
 

--- a/openeire/src/services/api.ts
+++ b/openeire/src/services/api.ts
@@ -819,8 +819,9 @@ export const downloadProduct = async (
   type: "photo" | "video",
   id: number,
   _fallbackFilename: string,
+  directUrl?: string | null,
 ) => {
-  const url = normalizeApiPath(`/products/download/${type}/${id}/`);
+  const url = directUrl || normalizeApiPath(`/products/download/${type}/${id}/`);
   const link = document.createElement('a');
   link.href = url;
   link.rel = 'noreferrer';


### PR DESCRIPTION
## Summary

This PR updates the order-history download button to use the backend-issued personal download URL instead of navigating to the authenticated asset route directly.

## Why

The previous browser navigation path could land on a 404 or otherwise fail to restart the download cleanly. The backend already exposes a personal-download token URL, which is the correct user-facing delivery path for these digital orders.

## Changes

- Frontend:
  - Updated `src/components/OrderHistoryCard.tsx` to use the `download_url` provided by the order-history API
  - Updated `src/services/api.ts` so `downloadProduct(...)` supports a direct download URL when available
  - Kept the native browser download behavior for large files
- Backend:
  - N/A in this repo
- Infra/Config:
  - No new environment changes

## Result

- The order-history download button now restarts the download from a backend-issued token URL
- The browser no longer tries to force the authenticated API download route directly
- Large file downloads still use the native browser path rather than buffering the full asset in JS memory

## Testing

- [x] `npm run build`

### Manual smoke test checklist

- [x] Order-history download button triggers a valid download URL
- [x] Large video downloads still use the native browser flow
- [x] Mobile order-history layout remains intact
- [x] No regression in authenticated app navigation

## Risk & Rollback

Risk level: Low

Why low:
- Frontend-only change
- No API contract changes beyond consuming the existing `download_url`
- No change to account/session behavior

Rollback plan:

- [x] Revert PR

## Notes for Reviewer

Focus review on:
- consumption of backend-issued `download_url`
- preservation of the native browser download flow
- no impact to unrelated profile or order-history behavior