### PR TITLE
Improve gallery browsing context and access flow

### DIFF
--- a/openeire/src/components/MinimalToolbar.tsx
+++ b/openeire/src/components/MinimalToolbar.tsx
@@ -35,7 +35,7 @@ const MinimalToolbar: React.FC<Props> = ({
   showMediaFilter = false,
 }) => {
   return (
-    <div className="container mx-auto px-4 lg:px-8 mb-12">
+    <div className="container mx-auto px-4 lg:px-8 mb-8 sm:mb-10 lg:mb-12">
       <div className="rounded-[28px] border border-white/10 bg-white/5 px-4 py-4 shadow-[0_24px_80px_rgba(0,0,0,0.38)] backdrop-blur-xl sm:px-5 sm:py-5">
         <div className="flex flex-col gap-5 lg:flex-row lg:items-end lg:justify-between">
           <div className="min-w-0 flex-1">

--- a/openeire/src/components/VisualCategoryHero.tsx
+++ b/openeire/src/components/VisualCategoryHero.tsx
@@ -1,10 +1,6 @@
 import React from "react";
 import { Swiper, SwiperSlide } from "swiper/react";
-import {
-  EffectCoverflow,
-  Navigation,
-  Mousewheel,
-} from "swiper/modules";
+import { EffectCoverflow, Navigation, Mousewheel } from "swiper/modules";
 
 import "swiper/css";
 import "swiper/css/effect-coverflow";
@@ -26,7 +22,7 @@ const VisualCategoryHero: React.FC<VisualCategoryHeroProps> = ({
       <div className="absolute inset-0 bg-[radial-gradient(circle_at_center,_#1a1a1a_0%,_#000000_100%)] z-0 pointer-events-none" />
 
       {/* Header Text */}
-      <div className="relative z-10 mt-[var(--site-header-height)] md:mt-0 text-center mb-10">
+      <div className="relative z-10 mt-20 md:mt-0 text-center mb-10">
         <h2 className="text-white font-serif text-4xl md:text-5xl font-bold mb-3 tracking-tight drop-shadow-lg">
           Explore the World
         </h2>

--- a/openeire/src/pages/GalleryGatePage.tsx
+++ b/openeire/src/pages/GalleryGatePage.tsx
@@ -92,7 +92,8 @@ const GalleryGatePage = () => {
 
           <p className="mx-auto max-w-md text-base leading-relaxed text-brand-100 opacity-80 sm:text-lg md:mx-0">
             Our digital stock footage vault is reserved for verified creators.
-            Enter your access code to view our 4K library.
+            Request access if you need a pass, or enter your code if you
+            already have one.
           </p>
 
           <div className="mx-auto h-1 w-24 rounded bg-accent opacity-80 md:mx-0"></div>
@@ -109,9 +110,46 @@ const GalleryGatePage = () => {
 
         <div className="w-full max-w-full rounded-2xl border border-white/10 bg-white p-6 shadow-2xl transition-all hover:scale-[1.01] sm:p-8 lg:p-10">
           <div className="mb-10 border-b border-gray-100 pb-10">
+            <h2 className="mb-3 flex items-center gap-3 text-xl font-bold font-sans text-brand-900">
+              <span className="flex h-8 w-8 items-center justify-center rounded-full bg-gray-100 text-sm text-gray-500">
+                01
+              </span>
+              Request Access
+            </h2>
+            <p className="mb-5 text-sm text-gray-500 font-sans leading-relaxed sm:ml-11">
+              Don&apos;t have a code? We&apos;ll email you a 30-day guest pass
+              immediately.
+            </p>
+            <p className="mb-5 text-xs text-gray-400 font-sans leading-relaxed sm:ml-11">
+              By requesting access, you agree to receive this gallery-pass email
+              and any follow-up access-related messages for the private
+              collection.
+            </p>
+            <form
+              onSubmit={handleRequestAccess}
+              className="flex flex-col gap-3 sm:ml-11 sm:flex-row"
+            >
+              <input
+                type="email"
+                placeholder="creators@studio.com"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                className="w-full flex-1 rounded-lg border border-gray-200 bg-gray-50 p-3 text-sm outline-none focus:ring-1 focus:ring-accent"
+              />
+              <button
+                type="submit"
+                disabled={isLoading}
+                className="w-full rounded-lg border border-brand-200 px-6 py-3 text-sm font-bold text-brand-700 transition-colors hover:bg-brand-50 hover:text-brand-900 sm:w-auto"
+              >
+                Send
+              </button>
+            </form>
+          </div>
+
+          <div>
             <h2 className="mb-6 flex items-center gap-3 text-xl font-bold font-sans text-brand-900">
               <span className="flex h-8 w-8 items-center justify-center rounded-full bg-brand-100 text-sm text-brand-700">
-                01
+                02
               </span>
               Enter Access Code
             </h2>
@@ -156,43 +194,6 @@ const GalleryGatePage = () => {
                 ) : (
                   "Unlock Vault"
                 )}
-              </button>
-            </form>
-          </div>
-
-          <div>
-            <h2 className="mb-3 flex items-center gap-3 text-xl font-bold font-sans text-brand-900">
-              <span className="flex h-8 w-8 items-center justify-center rounded-full bg-gray-100 text-sm text-gray-500">
-                02
-              </span>
-              Request Access
-            </h2>
-            <p className="mb-5 text-sm text-gray-500 font-sans leading-relaxed sm:ml-11">
-              Don&apos;t have a code? We&apos;ll email you a 30-day guest pass
-              immediately.
-            </p>
-            <p className="mb-5 text-xs text-gray-400 font-sans leading-relaxed sm:ml-11">
-              By requesting access, you agree to receive this gallery-pass email
-              and any follow-up access-related messages for the private
-              collection.
-            </p>
-            <form
-              onSubmit={handleRequestAccess}
-              className="flex flex-col gap-3 sm:ml-11 sm:flex-row"
-            >
-              <input
-                type="email"
-                placeholder="creators@studio.com"
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                className="w-full flex-1 rounded-lg border border-gray-200 bg-gray-50 p-3 text-sm outline-none focus:ring-1 focus:ring-accent"
-              />
-              <button
-                type="submit"
-                disabled={isLoading}
-                className="w-full rounded-lg border border-brand-200 px-6 py-3 text-sm font-bold text-brand-700 transition-colors hover:bg-brand-50 hover:text-brand-900 sm:w-auto"
-              >
-                Send
               </button>
             </form>
           </div>

--- a/openeire/src/pages/GalleryPage.tsx
+++ b/openeire/src/pages/GalleryPage.tsx
@@ -1,9 +1,17 @@
-import React, { useState, useEffect, useMemo, useCallback, useRef } from "react";
+import React, {
+  useState,
+  useEffect,
+  useMemo,
+  useCallback,
+  useRef,
+} from "react";
 import { useParams, useLocation } from "react-router-dom";
 import { getGalleryProducts, GalleryItem } from "../services/api";
 import ProductCard from "../components/ProductCard";
 import VisualCategoryHero from "../components/VisualCategoryHero";
-import MinimalToolbar, { GalleryMediaFilter } from "../components/MinimalToolbar";
+import MinimalToolbar, {
+  GalleryMediaFilter,
+} from "../components/MinimalToolbar";
 import SEOHead from "../components/SEOHead";
 import {
   GALLERY_COLLECTION_LABELS,
@@ -127,19 +135,52 @@ const GalleryPage: React.FC = () => {
   );
   const [gridTop, setGridTop] = useState(0);
   const [containerWidth, setContainerWidth] = useState(0);
-  const [measuredHeights, setMeasuredHeights] = useState<Record<string, number>>({});
+  const [measuredHeights, setMeasuredHeights] = useState<
+    Record<string, number>
+  >({});
   const normalizedSearchTerm = searchTerm.trim();
   const collectionLabel = GALLERY_COLLECTION_LABELS[collection] ?? "Gallery";
   const isCollectionComingSoon =
     collection !== "all" && !isGalleryCollectionAvailable(collection);
   const typeLabel =
-    type === "physical" ? "Art Prints" : type === "digital" ? "Stock Footage" : "Gallery";
+    type === "physical"
+      ? "Art Prints"
+      : type === "digital"
+        ? "Stock Footage"
+        : "Gallery";
   const galleryDescription = useMemo(() => {
     if (collection !== "all") {
       return `Browse ${collectionLabel} ${typeLabel.toLowerCase()} from Open\u00C9ire Studios, including curated visuals, licensing details, and limited releases.`;
     }
     return "Browse stock footage and art prints from Open\u00C9ire Studios, with curated collections, licensing details, and gallery access options.";
   }, [collection, collectionLabel, typeLabel]);
+
+  const mobileGalleryIntro = useMemo(() => {
+    if (type === "digital") {
+      return {
+        eyebrow: "Stock footage that sells",
+        title: "Find the shot that closes the brief.",
+        description:
+          "Use the Photos and Videos filters to cut straight to what your project needs, then open any card for licensing details and purchase options.",
+      };
+    }
+
+    if (type === "physical") {
+      return {
+        eyebrow: "Art prints with impact",
+        title: "Shop statement pieces that elevate a space.",
+        description:
+          "Scroll the collection, open any print for details, and use search to find a piece that feels ready to hang.",
+      };
+    }
+
+    return {
+      eyebrow: "Curated for buyers",
+      title: "Discover footage and prints built to stand out.",
+      description:
+        "Use search to move fast, then switch collections or filters to get straight to the format you want to license or buy.",
+    };
+  }, [type]);
 
   useEffect(() => {
     if (type !== "digital") {
@@ -280,11 +321,15 @@ const GalleryPage: React.FC = () => {
   const columns = useMemo<
     Array<Array<{ product: GalleryItem; index: number; productKey: string }>>
   >(() => {
-    const grouped = Array.from({ length: columnCount }, () => [] as Array<{
-      product: GalleryItem;
-      index: number;
-      productKey: string;
-    }>);
+    const grouped = Array.from(
+      { length: columnCount },
+      () =>
+        [] as Array<{
+          product: GalleryItem;
+          index: number;
+          productKey: string;
+        }>,
+    );
     displayProducts.forEach((product, index) => {
       grouped[index % columnCount].push({
         product,
@@ -428,13 +473,21 @@ const GalleryPage: React.FC = () => {
     return () => {
       isCurrent = false;
     };
-  }, [type, collection, normalizedSearchTerm, sortOrder, isCollectionComingSoon]);
+  }, [
+    type,
+    collection,
+    normalizedSearchTerm,
+    sortOrder,
+    isCollectionComingSoon,
+  ]);
 
   return (
     // Dark mode background for the gallery canvas
     <div ref={pageRef} className="bg-black min-h-screen pb-20">
       <SEOHead
-        title={collection === "all" ? typeLabel : `${collectionLabel} ${typeLabel}`}
+        title={
+          collection === "all" ? typeLabel : `${collectionLabel} ${typeLabel}`
+        }
         description={galleryDescription}
         canonicalPath={type === "physical" ? "/gallery/physical" : "/gallery"}
         noindex={type === "digital"}
@@ -445,6 +498,31 @@ const GalleryPage: React.FC = () => {
         onSelectCollection={setCollection}
         isPaused={isGridHovered || isAnyModalOpen}
       />
+
+      <div className="container mx-auto px-4 lg:px-8 mt-2 mb-4 lg:hidden">
+        <div className="rounded-[24px] border border-white/10 bg-white/5 px-4 py-4 shadow-[0_18px_50px_rgba(0,0,0,0.28)] backdrop-blur-xl">
+          <div className="text-[11px] font-semibold uppercase tracking-[0.26em] text-gray-400">
+            {mobileGalleryIntro.eyebrow}
+          </div>
+          <h2 className="mt-2 text-lg font-serif font-bold text-white">
+            {mobileGalleryIntro.title}
+          </h2>
+          <p className="mt-2 text-sm leading-relaxed text-gray-300">
+            {mobileGalleryIntro.description}
+          </p>
+          <div className="mt-4 flex flex-wrap gap-2 text-[11px] font-semibold uppercase tracking-[0.22em] text-gray-300">
+            <span className="rounded-full border border-white/10 bg-black/35 px-3 py-1">
+              Search
+            </span>
+            <span className="rounded-full border border-white/10 bg-black/35 px-3 py-1">
+              Filter
+            </span>
+            <span className="rounded-full border border-white/10 bg-black/35 px-3 py-1">
+              Open cards
+            </span>
+          </div>
+        </div>
+      </div>
 
       {/* 2. MINIMAL TOOLBAR (Search & Sort) */}
       <MinimalToolbar
@@ -463,7 +541,10 @@ const GalleryPage: React.FC = () => {
       >
         {/* Loading */}
         {loading && (
-          <div className="flex justify-center py-20 min-h-[320px]" aria-live="polite">
+          <div
+            className="flex justify-center py-20 min-h-[320px]"
+            aria-live="polite"
+          >
             <div
               className="animate-spin rounded-full h-12 w-12 border-t-2 border-b-2 border-accent"
               aria-hidden="true"
@@ -517,8 +598,7 @@ const GalleryPage: React.FC = () => {
             ) : isCollectionComingSoon ? (
               <>
                 <div className="text-2xl font-serif font-bold text-white">
-                  {collectionLabel} is coming
-                  soon!
+                  {collectionLabel} is coming soon!
                 </div>
                 <p className="mt-3 text-gray-400">
                   We&apos;re curating this collection now. Check back soon for
@@ -527,8 +607,8 @@ const GalleryPage: React.FC = () => {
               </>
             ) : type === "digital" && mediaFilter !== "all" ? (
               <div className="text-gray-500">
-                No {mediaFilter === "photos" ? "photos" : "videos"} found in this
-                selection.
+                No {mediaFilter === "photos" ? "photos" : "videos"} found in
+                this selection.
               </div>
             ) : (
               <div className="text-gray-500">No results found.</div>
@@ -541,4 +621,3 @@ const GalleryPage: React.FC = () => {
 };
 
 export default GalleryPage;
-


### PR DESCRIPTION
## Summary

This PR makes the gallery and gated-access experience feel clearer and more intentional on mobile and first-time visits.

## Why

A few small UX issues were making the gallery less intuitive:

- the stock gallery filled the initial mobile viewport without much context
- the gated gallery page led with the access code field, which made some users feel like they were in the wrong place
- the gallery spacing felt a little too loose above the main content

This update keeps the existing structure, but improves the way it introduces the gallery and its access flow.

## Changes

- Frontend:
  - Added a mobile-only intro card above the gallery toolbar
    - gives short, sales-focused context for what the gallery offers
    - explains how to use the filters/search more quickly
  - Tightened the spacing above the gallery intro slightly on mobile
  - Reworded the mobile gallery intro to be more conversion-focused
    - stronger purchase/licensing language
    - clearer call to action for browsing and filtering
  - Reordered the gated gallery page so:
    - `Request Access` appears first
    - `Enter Access Code` is shown as the secondary path
  - Updated the gated gallery intro copy to make it clearer that:
    - users can request a pass
    - users with an existing code can enter it
- Backend:
  - N/A
- Infra/Config:
  - No environment changes

## Result

The gallery now gives mobile users a bit more context before the masonry grid takes over, and the gated access page feels less intimidating for first-time visitors.

## Testing

- [ ] Frontend build passes locally
- [ ] Manual mobile gallery check completed
- [ ] Gated access page copy/order verified

### Manual smoke test checklist

- [x] Mobile gallery shows the short intro before the toolbar
- [x] Gallery intro copy is sales-focused
- [x] Gallery spacing feels slightly tighter on mobile
- [x] Request Access appears before Enter Access Code
- [x] Gated page still supports both access flows

## Risk & Rollback

Risk level: Low

Why low:
- frontend-only changes
- no API or data model changes
- no auth flow changes

Rollback plan:
- [x] Revert PR

## Notes for Reviewer

Focus review on:
- mobile gallery intro placement and copy
- small spacing adjustment on the gallery page
- reordered gated access card flow
- no change to underlying gallery access logic
