### PR TITLE
fix(frontend): scope GA page view dedupe to navigations

### DIFF
--- a/openeire/src/components/AddToCartForm.tsx
+++ b/openeire/src/components/AddToCartForm.tsx
@@ -1,5 +1,10 @@
 import React, { useState } from "react";
 import { PhysicalCartProduct, useCart } from "../context/CartContext";
+import {
+  formatAnalyticsVariantLabel,
+  toAnalyticsMoney,
+  trackEcommerceEvent,
+} from "../lib/ecommerceAnalytics";
 
 interface AddToCartFormProps {
   product: PhysicalCartProduct;
@@ -18,6 +23,26 @@ const AddToCartForm: React.FC<AddToCartFormProps> = ({ product }) => {
       type: "physical",
       variantId: Number(product.id),
       sourceProductId: Number(product.photo_id ?? product.id),
+    });
+
+    const unitPrice = toAnalyticsMoney(product.price);
+    trackEcommerceEvent("add_to_cart", {
+      currency: "EUR",
+      ...(unitPrice !== undefined ? { value: unitPrice * quantity } : {}),
+      items: [
+        {
+          item_id: String(product.id),
+          item_name: product.title,
+          item_category: "physical",
+          item_category2: product.collection || undefined,
+          item_variant: formatAnalyticsVariantLabel(
+            product.material_display,
+            product.size_display,
+          ),
+          price: unitPrice,
+          quantity,
+        },
+      ],
     });
 
     setAdded(true);

--- a/openeire/src/components/AnalyticsListener.tsx
+++ b/openeire/src/components/AnalyticsListener.tsx
@@ -2,48 +2,67 @@ import React, { useEffect } from "react";
 import { useLocation } from "react-router-dom";
 import { trackPageView } from "../lib/analytics";
 
-const TITLE_SETTLE_TIMEOUT_MS = 1200;
+const TITLE_SETTLE_TIMEOUT_MS = 5000;
+const TITLE_POLL_INTERVAL_MS = 100;
+const PAGE_VIEW_DEDUPE_PREFIX = "openeire:page_view:";
 
 const AnalyticsListener: React.FC = () => {
   const location = useLocation();
 
   useEffect(() => {
     const fullPath = `${location.pathname}${location.search}${location.hash}`;
+    const navigationKey = location.key || fullPath;
+    const dedupeKey = `${PAGE_VIEW_DEDUPE_PREFIX}${navigationKey}`;
     const initialTitle = document.title;
     let settled = false;
     let observer: MutationObserver | null = null;
     let timeoutId = 0;
-    let rafId = 0;
+    let pollId = 0;
 
     const cleanup = () => {
       window.clearTimeout(timeoutId);
-      window.cancelAnimationFrame(rafId);
+      window.clearInterval(pollId);
       observer?.disconnect();
     };
 
-    const sendPageView = () => {
+    const sendPageView = (force = false) => {
       if (settled) return;
+      if (!force && document.title === initialTitle) return;
+
       settled = true;
       cleanup();
       trackPageView(fullPath, document.title);
+
+      try {
+        window.sessionStorage.setItem(dedupeKey, "1");
+      } catch {
+        // Best-effort only; the in-memory settled flag still prevents duplicates.
+      }
     };
+
+    try {
+      if (window.sessionStorage.getItem(dedupeKey) === "1") {
+        return;
+      }
+    } catch {
+      // Session storage may be unavailable in hardened browser contexts.
+    }
 
     const titleNode = document.querySelector("title");
     observer =
       typeof MutationObserver === "undefined"
         ? null
         : new MutationObserver(() => {
-            if (document.title !== initialTitle) {
-              sendPageView();
-            }
+            sendPageView(false);
           });
 
-    timeoutId = window.setTimeout(sendPageView, TITLE_SETTLE_TIMEOUT_MS);
-    rafId = window.requestAnimationFrame(() => {
-      if (document.title !== initialTitle) {
-        sendPageView();
-      }
-    });
+    pollId = window.setInterval(() => {
+      sendPageView(false);
+    }, TITLE_POLL_INTERVAL_MS);
+
+    timeoutId = window.setTimeout(() => {
+      sendPageView(true);
+    }, TITLE_SETTLE_TIMEOUT_MS);
 
     if (observer && titleNode) {
       observer.observe(titleNode, {

--- a/openeire/src/components/AnalyticsListener.tsx
+++ b/openeire/src/components/AnalyticsListener.tsx
@@ -6,12 +6,23 @@ const TITLE_SETTLE_TIMEOUT_MS = 5000;
 const TITLE_POLL_INTERVAL_MS = 100;
 const PAGE_VIEW_DEDUPE_PREFIX = "openeire:page_view:";
 
+const getNavigationInstanceId = (): string => {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+
+  return `nav-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+};
+
 const AnalyticsListener: React.FC = () => {
   const location = useLocation();
 
   useEffect(() => {
     const fullPath = `${location.pathname}${location.search}${location.hash}`;
-    const navigationKey = location.key || fullPath;
+    const navigationKey =
+      location.key && location.key !== "default"
+        ? location.key
+        : `${fullPath}:${getNavigationInstanceId()}`;
     const dedupeKey = `${PAGE_VIEW_DEDUPE_PREFIX}${navigationKey}`;
     const initialTitle = document.title;
     let settled = false;

--- a/openeire/src/components/LicenseRequestModal.tsx
+++ b/openeire/src/components/LicenseRequestModal.tsx
@@ -5,6 +5,7 @@ import { submitLicenseRequest, LicenseRequestPayload } from "../services/api";
 import { useAuth } from "../context/AuthContext";
 import toast from "react-hot-toast";
 import { getLicenseRequestToastErrorMessage } from "../utils/toast";
+import { trackEvent } from "../lib/analytics";
 
 interface LicenseRequestModalProps {
   isOpen: boolean;
@@ -103,6 +104,15 @@ const LicenseRequestModal: React.FC<LicenseRequestModalProps> = ({
         ...formData,
         asset_id: assetId,
         asset_type: assetType,
+      });
+      trackEvent("generate_lead", {
+        asset_id: String(assetId),
+        asset_type: assetType,
+        licence_type: "commercial",
+        territory: formData.territory,
+        exclusivity: formData.exclusivity,
+        permitted_media: formData.permitted_media,
+        duration: formData.duration,
       });
       toast.success(
         "License request submitted! We will be in touch shortly with a custom quote.",

--- a/openeire/src/components/OrderSummary.tsx
+++ b/openeire/src/components/OrderSummary.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from "react";
+import React, { useCallback, useMemo } from "react";
 import { getCartItemUnitPrice, useCart } from "../context/CartContext";
 import { useAuth } from "../context/AuthContext";
 import { Link } from "react-router-dom";
@@ -9,11 +9,17 @@ import {
   isPhysicalProductType,
 } from "../utils/purchaseFlow";
 import {
+  buildAnalyticsItemFromCartItem,
+  trackEcommerceEvent,
+} from "../lib/ecommerceAnalytics";
+import {
   FREE_SHIPPING_COUNTRY_LABEL,
   FREE_SHIPPING_PROMO_ENABLED,
   FREE_SHIPPING_THRESHOLD,
   isFreeShippingCountryEligible,
 } from "../utils/freeShipping";
+
+const BEGIN_CHECKOUT_TRACKING_KEY = "openeire_begin_checkout_signature";
 
 interface OrderSummaryProps {
   isCheckoutPage?: boolean;
@@ -60,6 +66,33 @@ const OrderSummary: React.FC<OrderSummaryProps> = ({
 
   const grandTotal =
     cartTotal + (hasPhysicalItems && !isPhysicalShippingPending ? shippingCost : 0);
+
+  const handleBeginCheckout = useCallback(() => {
+    if (typeof window === "undefined") return;
+
+    const checkoutSignature = cart
+      .map((item) => `${item.cartId}:${item.quantity}`)
+      .join("|");
+    if (!checkoutSignature) return;
+
+    try {
+      if (window.sessionStorage.getItem(BEGIN_CHECKOUT_TRACKING_KEY) === checkoutSignature) {
+        return;
+      }
+      trackEcommerceEvent("begin_checkout", {
+        currency: "EUR",
+        value: cartTotal,
+        items: cart.map(buildAnalyticsItemFromCartItem),
+      });
+      window.sessionStorage.setItem(BEGIN_CHECKOUT_TRACKING_KEY, checkoutSignature);
+    } catch {
+      trackEcommerceEvent("begin_checkout", {
+        currency: "EUR",
+        value: cartTotal,
+        items: cart.map(buildAnalyticsItemFromCartItem),
+      });
+    }
+  }, [cart, cartTotal]);
 
   return (
     <div className="bg-gray-900 border border-white/10 p-8 rounded-2xl shadow-xl">
@@ -141,6 +174,7 @@ const OrderSummary: React.FC<OrderSummaryProps> = ({
             <Link
               to="/login"
               state={{ from: { pathname: "/checkout" } }}
+              onClick={handleBeginCheckout}
               className="block w-full text-center bg-brand-500 text-black font-bold text-lg py-4 rounded-xl hover:bg-white transition-all shadow-[0_0_20px_rgba(0,196,0,0.3)] hover:shadow-[0_0_25px_rgba(255,255,255,0.4)] transform active:scale-[0.98]"
             >
               Log In to Checkout
@@ -148,6 +182,7 @@ const OrderSummary: React.FC<OrderSummaryProps> = ({
           ) : (
             <Link
               to="/checkout"
+              onClick={handleBeginCheckout}
               className="block w-full text-center bg-brand-500 text-black font-bold text-lg py-4 rounded-xl hover:bg-white transition-all shadow-[0_0_20px_rgba(0,196,0,0.3)] hover:shadow-[0_0_25px_rgba(255,255,255,0.4)] transform active:scale-[0.98]"
             >
               Checkout

--- a/openeire/src/components/QuickAddModal.tsx
+++ b/openeire/src/components/QuickAddModal.tsx
@@ -10,6 +10,11 @@ import {
 import { PhysicalCartProduct, useCart } from "../context/CartContext";
 import { FaTimes, FaCheck, FaShoppingBag } from "react-icons/fa";
 import toast from "react-hot-toast";
+import {
+  formatAnalyticsVariantLabel,
+  toAnalyticsMoney,
+  trackEcommerceEvent,
+} from "../lib/ecommerceAnalytics";
 
 interface QuickAddModalProps {
   productId: number;
@@ -146,6 +151,27 @@ const QuickAddModal: React.FC<QuickAddModalProps> = ({
       variantId: variant.id,
       sourceProductId: product.sourceProductId,
     });
+
+    const unitPrice = toAnalyticsMoney(variant.price);
+    trackEcommerceEvent("add_to_cart", {
+      currency: "EUR",
+      ...(unitPrice !== undefined ? { value: unitPrice } : {}),
+      items: [
+        {
+          item_id: String(variant.id),
+          item_name: product.product.title,
+          item_category: "physical",
+          item_category2: product.product.collection || undefined,
+          item_variant: formatAnalyticsVariantLabel(
+            variant.material_display,
+            variant.size_display,
+          ),
+          price: unitPrice,
+          quantity: 1,
+        },
+      ],
+    });
+
     toast.success("Added to Bag");
     onClose();
   };

--- a/openeire/src/lib/analytics.ts
+++ b/openeire/src/lib/analytics.ts
@@ -3,7 +3,6 @@ const GA_SCRIPT_ID = "openeire-ga-script";
 let gaInitialized = false;
 let gaInitPromise: Promise<void> | null = null;
 let gaScriptPromise: Promise<void> | null = null;
-let lastTrackedPageSignature: string | null = null;
 
 const getMeasurementId = (): string | null => {
   const measurementId = import.meta.env.VITE_GA_MEASUREMENT_ID?.trim();
@@ -106,10 +105,6 @@ export const trackPageView = (path: string, title?: string): void => {
   ensureGtagStub();
 
   const pageTitle = title ?? document.title;
-  const pageSignature = `${path}::${pageTitle}`;
-  if (pageSignature === lastTrackedPageSignature) return;
-  lastTrackedPageSignature = pageSignature;
-
   window.gtag?.("event", "page_view", {
     page_path: path,
     page_title: pageTitle,

--- a/openeire/src/lib/ecommerceAnalytics.ts
+++ b/openeire/src/lib/ecommerceAnalytics.ts
@@ -1,0 +1,82 @@
+import { trackEvent } from "./analytics";
+import {
+  CartItem,
+  getCartItemUnitPrice,
+  isPhysicalCartOptions,
+} from "../context/CartContext";
+import { isPhysicalProductType } from "../utils/purchaseFlow";
+
+type NullableString = string | undefined | null;
+
+export type AnalyticsItem = {
+  item_id: string;
+  item_name: string;
+  item_category: string;
+  item_category2?: string;
+  item_variant?: string;
+  price?: number;
+  quantity: number;
+};
+
+export type AnalyticsEventPayload = {
+  currency: "EUR";
+  value?: number;
+  items: AnalyticsItem[];
+};
+
+export const toAnalyticsMoney = (
+  value: string | number | undefined | null,
+): number | undefined => {
+  if (value === undefined || value === null) return undefined;
+  const parsed = Number.parseFloat(String(value));
+  return Number.isFinite(parsed) ? parsed : undefined;
+};
+
+export const formatAnalyticsVariantLabel = (
+  ...parts: NullableString[]
+): string | undefined => {
+  const label = parts
+    .map((part) => (typeof part === "string" ? part.trim() : ""))
+    .filter(Boolean)
+    .join(" / ");
+
+  return label.length > 0 ? label : undefined;
+};
+
+const compactRecord = <T extends Record<string, unknown>>(value: T): T =>
+  Object.fromEntries(
+    Object.entries(value).filter(([, entry]) => entry !== undefined),
+  ) as T;
+
+export const trackEcommerceEvent = (
+  name: string,
+  payload: AnalyticsEventPayload,
+): void => {
+  trackEvent(name, {
+    currency: payload.currency,
+    ...(typeof payload.value === "number" ? { value: payload.value } : {}),
+    items: payload.items.map((item) => compactRecord(item)),
+  });
+};
+
+export const buildAnalyticsItemFromCartItem = (
+  item: CartItem,
+): AnalyticsItem => {
+  const unitPrice = getCartItemUnitPrice(item);
+  const isPhysical = isPhysicalProductType(item.product?.product_type);
+  const physicalOptions = isPhysicalCartOptions(item.options) ? item.options : undefined;
+
+  return compactRecord({
+    item_id: String(
+      isPhysical ? physicalOptions?.variantId ?? item.product.id : item.product.id,
+    ),
+    item_name: item.product.title,
+    item_category: item.product.product_type,
+    item_category2: item.product.collection || undefined,
+    item_variant: isPhysical
+      ? formatAnalyticsVariantLabel(physicalOptions?.material, physicalOptions?.size)
+      : undefined,
+    price: unitPrice,
+    quantity: item.quantity,
+  });
+};

--- a/openeire/src/pages/CheckoutPage.tsx
+++ b/openeire/src/pages/CheckoutPage.tsx
@@ -19,6 +19,7 @@ import {
 } from "../utils/purchaseFlow";
 import { CheckoutSuccessContext } from "../utils/checkoutSuccessContext";
 import { EMPTY_SHIPPING_DETAILS, ShippingDetails } from "../types/checkout";
+import { buildAnalyticsItemFromCartItem } from "../lib/ecommerceAnalytics";
 
 const stripePromise = loadStripe(import.meta.env.VITE_STRIPE_PUBLIC_KEY);
 
@@ -157,6 +158,11 @@ const CheckoutPage: React.FC = () => {
   const [isUpdatingIntent, setIsUpdatingIntent] = useState(false);
   const [checkoutError, setCheckoutError] = useState<string | null>(null);
   const latestIntentRequestId = useRef(0);
+  const checkoutAttemptIdRef = useRef<string>(
+    typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
+      ? crypto.randomUUID()
+      : `checkout-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`,
+  );
 
   const resetCheckoutIntentState = () => {
     setClientSecret("");
@@ -165,7 +171,7 @@ const CheckoutPage: React.FC = () => {
     setFreeShippingThreshold(null);
   };
 
-  const { cartItems } = useCart();
+  const { cartItems, cartTotal } = useCart();
   const { isAuthenticated } = useAuth();
   const hasPhysicalItems = useMemo(
     () => cartHasPhysicalItems(cartItems),
@@ -184,8 +190,22 @@ const CheckoutPage: React.FC = () => {
         (total, item) => total + item.quantity,
         0,
       ),
+      purchase: {
+        transaction_id: checkoutAttemptIdRef.current,
+        value: cartTotal + (hasPhysicalItems ? calculatedShippingCost : 0),
+        currency: "EUR",
+        tax: 0,
+        shipping: hasPhysicalItems ? calculatedShippingCost : 0,
+        items: checkoutCartItems.map(buildAnalyticsItemFromCartItem),
+      },
     }),
-    [checkoutCartItems, hasDigitalItems, hasPhysicalItems],
+    [
+      calculatedShippingCost,
+      cartTotal,
+      checkoutCartItems,
+      hasDigitalItems,
+      hasPhysicalItems,
+    ],
   );
   const requiresAuthenticatedCheckout = hasDigitalItems;
   const physicalAddressKey = useMemo(

--- a/openeire/src/pages/CheckoutSuccessPage.tsx
+++ b/openeire/src/pages/CheckoutSuccessPage.tsx
@@ -1,5 +1,5 @@
-import React, { useEffect, useMemo, useState } from "react";
-import { Link } from "react-router-dom";
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { Link, useLocation } from "react-router-dom";
 import { useCart } from "../context/CartContext";
 import { FaCheckCircle, FaDownload, FaHome, FaBoxOpen } from "react-icons/fa";
 import {
@@ -7,6 +7,7 @@ import {
   CheckoutSuccessContext,
   readCheckoutSuccessContext,
 } from "../utils/checkoutSuccessContext";
+import { trackEvent } from "../lib/analytics";
 
 type SuccessCard = {
   title: string;
@@ -103,9 +104,54 @@ const getSuccessContent = (context: CheckoutSuccessContext | null): SuccessConte
 
 const CheckoutSuccessPage: React.FC = () => {
   const { clearCart } = useCart();
+  const location = useLocation();
   const [successContext] = useState<CheckoutSuccessContext | null>(() =>
     readCheckoutSuccessContext(),
   );
+  const purchaseDedupeKeyRef = useRef<string | null>(null);
+
+  const transactionId = useMemo(() => {
+    const searchParams = new URLSearchParams(location.search);
+    return (
+      searchParams.get("payment_intent") ||
+      successContext?.purchase?.transaction_id ||
+      null
+    );
+  }, [location.search, successContext?.purchase?.transaction_id]);
+
+  useEffect(() => {
+    const purchase = successContext?.purchase;
+    if (!purchase || !transactionId || purchase.items.length === 0) return;
+
+    const dedupeKey = `openeire:purchase:${transactionId}`;
+    if (purchaseDedupeKeyRef.current === dedupeKey) return;
+
+    try {
+      if (window.sessionStorage.getItem(dedupeKey) === "1") {
+        purchaseDedupeKeyRef.current = dedupeKey;
+        return;
+      }
+    } catch {
+      // Session storage is a best-effort dedupe guard only.
+    }
+
+    trackEvent("purchase", {
+      transaction_id: transactionId,
+      value: purchase.value,
+      currency: "EUR",
+      tax: purchase.tax ?? 0,
+      shipping: purchase.shipping ?? 0,
+      items: purchase.items,
+    });
+
+    purchaseDedupeKeyRef.current = dedupeKey;
+
+    try {
+      window.sessionStorage.setItem(dedupeKey, "1");
+    } catch {
+      // Ignore storage failures; the ref guard still prevents duplicate renders.
+    }
+  }, [successContext, transactionId]);
 
   useEffect(() => {
     clearCart();

--- a/openeire/src/pages/ContactPage.tsx
+++ b/openeire/src/pages/ContactPage.tsx
@@ -3,6 +3,7 @@ import SEOHead from "../components/SEOHead";
 import { sendContactMessage } from "../services/api";
 import toast from "react-hot-toast";
 import { getContactToastErrorMessage } from "../utils/toast";
+import { trackEvent } from "../lib/analytics";
 import {
   registerIubendaConsentForm,
   submitIubendaConsentForm,
@@ -56,6 +57,9 @@ const ContactPage = () => {
     try {
       await sendContactMessage(formData);
       submitIubendaConsentForm("contact-form");
+      trackEvent("generate_lead", {
+        form_name: "contact",
+      });
       setStatus("success");
       toast.success("Message sent successfully!");
       setFormData({ name: "", email: "", subject: "", message: "" });

--- a/openeire/src/pages/ProductDetailPage.tsx
+++ b/openeire/src/pages/ProductDetailPage.tsx
@@ -35,6 +35,11 @@ import {
   shouldShowGalleryAccessCodeUx,
 } from "../utils/purchaseFlow";
 import {
+  formatAnalyticsVariantLabel,
+  toAnalyticsMoney,
+  trackEcommerceEvent,
+} from "../lib/ecommerceAnalytics";
+import {
   FaPlay,
   FaShieldAlt,
   FaShippingFast,
@@ -97,6 +102,7 @@ const ProductDetailPage: React.FC = () => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [reviewRefreshKey, setReviewRefreshKey] = useState(0);
+  const trackedViewItemSignature = useRef<string | null>(null);
 
   // --- 3. DATA FETCHING ---
   const fetchProductDetail = useCallback(async () => {
@@ -212,6 +218,67 @@ const ProductDetailPage: React.FC = () => {
     return "0.00";
   }, [isPhysical, activePhysicalVariant]);
 
+  useEffect(() => {
+    if (!product || !resolvedType) return;
+
+    const signature = `${location.pathname}:${product.id}`;
+    if (trackedViewItemSignature.current === signature) return;
+
+    if (isPhysical) {
+      if (!activePhysicalVariant) return;
+
+      const variantPrice = toAnalyticsMoney(activePhysicalVariant.price);
+      trackedViewItemSignature.current = signature;
+      trackEcommerceEvent("view_item", {
+        currency: "EUR",
+        ...(variantPrice !== undefined ? { value: variantPrice } : {}),
+        items: [
+          {
+            item_id: String(activePhysicalVariant.id),
+            item_name: product.title,
+            item_category: "physical",
+            item_category2: product.collection || undefined,
+            item_variant: formatAnalyticsVariantLabel(
+              activePhysicalVariant.material_display,
+              activePhysicalVariant.size_display,
+            ),
+            price: variantPrice,
+            quantity: 1,
+          },
+        ],
+      });
+      return;
+    }
+
+    if (!digitalProduct || !isDigital) return;
+
+    const digitalPrice = selectedDigitalPrice > 0 ? selectedDigitalPrice : undefined;
+    trackedViewItemSignature.current = signature;
+    trackEcommerceEvent("view_item", {
+      currency: "EUR",
+      ...(digitalPrice !== undefined ? { value: digitalPrice } : {}),
+      items: [
+        {
+          item_id: String(product.id),
+          item_name: product.title,
+          item_category: product.product_type,
+          item_category2: product.collection || undefined,
+          price: digitalPrice,
+          quantity: 1,
+        },
+      ],
+    });
+  }, [
+    activePhysicalVariant,
+    digitalProduct,
+    isDigital,
+    isPhysical,
+    location.pathname,
+    product,
+    resolvedType,
+    selectedDigitalPrice,
+  ]);
+
   const activePhysicalProductForCart = useMemo<
     (GalleryItem & { product_type: "physical" }) | null
   >(() => {
@@ -254,6 +321,29 @@ const ProductDetailPage: React.FC = () => {
           : physicalProduct.photo_id ?? physicalProduct.id,
       ),
     });
+
+    const quantity = 1;
+    const variantPrice = toAnalyticsMoney(activePhysicalVariant.price);
+    trackEcommerceEvent("add_to_cart", {
+      currency: "EUR",
+      ...(variantPrice !== undefined
+        ? { value: variantPrice * quantity }
+        : {}),
+      items: [
+        {
+          item_id: String(activePhysicalVariant.id),
+          item_name: physicalProduct.title,
+          item_category: "physical",
+          item_category2: physicalProduct.collection || undefined,
+          item_variant: formatAnalyticsVariantLabel(
+            activePhysicalVariant.material_display,
+            activePhysicalVariant.size_display,
+          ),
+          price: variantPrice,
+          quantity,
+        },
+      ],
+    });
     toast.success("Added to Bag");
   };
 
@@ -275,6 +365,24 @@ const ProductDetailPage: React.FC = () => {
     addToCart(digitalProduct, 1, {
       type: "digital",
       sourceProductId: Number(digitalProduct.id),
+    });
+
+    const quantity = 1;
+    trackEcommerceEvent("add_to_cart", {
+      currency: "EUR",
+      ...(selectedDigitalPrice > 0
+        ? { value: selectedDigitalPrice * quantity }
+        : {}),
+      items: [
+        {
+          item_id: String(digitalProduct.id),
+          item_name: digitalProduct.title,
+          item_category: digitalProduct.product_type,
+          item_category2: digitalProduct.collection || undefined,
+          price: selectedDigitalPrice > 0 ? selectedDigitalPrice : undefined,
+          quantity,
+        },
+      ],
     });
 
     toast.success("Added to Bag");

--- a/openeire/src/pages/ProductDetailPage.tsx
+++ b/openeire/src/pages/ProductDetailPage.tsx
@@ -221,7 +221,9 @@ const ProductDetailPage: React.FC = () => {
   useEffect(() => {
     if (!product || !resolvedType) return;
 
-    const signature = `${location.pathname}:${product.id}`;
+    const signature = isPhysical && activePhysicalVariant
+      ? `${location.pathname}:${product.id}:${activePhysicalVariant.id}`
+      : `${location.pathname}:${product.id}`;
     if (trackedViewItemSignature.current === signature) return;
 
     if (isPhysical) {

--- a/openeire/src/utils/checkoutSuccessContext.ts
+++ b/openeire/src/utils/checkoutSuccessContext.ts
@@ -1,10 +1,25 @@
+import type { AnalyticsItem } from "../lib/ecommerceAnalytics";
+
 export const CHECKOUT_SUCCESS_CONTEXT_KEY = "checkoutSuccessContext";
+
+export type CheckoutPurchaseContext = {
+  transaction_id: string;
+  value: number;
+  currency: "EUR";
+  tax: number;
+  shipping: number;
+  items: AnalyticsItem[];
+};
 
 export type CheckoutSuccessContext = {
   hasDigitalItems: boolean;
   hasPhysicalItems: boolean;
   itemCount: number;
+  purchase?: CheckoutPurchaseContext;
 };
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
 
 export const readCheckoutSuccessContext = (): CheckoutSuccessContext | null => {
   if (typeof window === "undefined") return null;
@@ -14,10 +29,27 @@ export const readCheckoutSuccessContext = (): CheckoutSuccessContext | null => {
     if (!raw) return null;
 
     const parsed = JSON.parse(raw) as Partial<CheckoutSuccessContext>;
+    const purchase = isRecord(parsed.purchase)
+      ? {
+          transaction_id:
+            typeof parsed.purchase.transaction_id === "string"
+              ? parsed.purchase.transaction_id
+              : "",
+          value: Number(parsed.purchase.value ?? 0),
+          currency: "EUR" as const,
+          tax: Number(parsed.purchase.tax ?? 0),
+          shipping: Number(parsed.purchase.shipping ?? 0),
+          items: Array.isArray(parsed.purchase.items)
+            ? (parsed.purchase.items as AnalyticsItem[])
+            : [],
+        }
+      : undefined;
+
     return {
       hasDigitalItems: Boolean(parsed.hasDigitalItems),
       hasPhysicalItems: Boolean(parsed.hasPhysicalItems),
       itemCount: Number(parsed.itemCount || 0),
+      ...(purchase?.transaction_id ? { purchase } : {}),
     };
   } catch {
     return null;

--- a/openeire/src/utils/checkoutSuccessContext.ts
+++ b/openeire/src/utils/checkoutSuccessContext.ts
@@ -21,6 +21,51 @@ export type CheckoutSuccessContext = {
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   typeof value === "object" && value !== null;
 
+const parseFiniteNumber = (value: unknown, fallback = 0): number => {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : fallback;
+};
+
+const sanitizeAnalyticsItem = (
+  value: unknown,
+): AnalyticsItem | null => {
+  if (!isRecord(value)) return null;
+
+  const item_id =
+    typeof value.item_id === "string" ? value.item_id.trim() : "";
+  const item_name =
+    typeof value.item_name === "string" ? value.item_name.trim() : "";
+  const item_category =
+    typeof value.item_category === "string" ? value.item_category.trim() : "";
+  const quantity = parseFiniteNumber(value.quantity, 0);
+
+  if (!item_id || !item_name || !item_category || quantity <= 0) {
+    return null;
+  }
+
+  const sanitizedItem: AnalyticsItem = {
+    item_id,
+    item_name,
+    item_category,
+    quantity,
+  };
+
+  if (typeof value.item_category2 === "string" && value.item_category2.trim()) {
+    sanitizedItem.item_category2 = value.item_category2.trim();
+  }
+
+  if (typeof value.item_variant === "string" && value.item_variant.trim()) {
+    sanitizedItem.item_variant = value.item_variant.trim();
+  }
+
+  const price = parseFiniteNumber(value.price, Number.NaN);
+  if (Number.isFinite(price)) {
+    sanitizedItem.price = price;
+  }
+
+  return sanitizedItem;
+};
+
 export const readCheckoutSuccessContext = (): CheckoutSuccessContext | null => {
   if (typeof window === "undefined") return null;
 
@@ -29,19 +74,22 @@ export const readCheckoutSuccessContext = (): CheckoutSuccessContext | null => {
     if (!raw) return null;
 
     const parsed = JSON.parse(raw) as Partial<CheckoutSuccessContext>;
+    const sanitizedItems = Array.isArray(parsed.purchase?.items)
+      ? parsed.purchase.items
+          .map((item) => sanitizeAnalyticsItem(item))
+          .filter((item): item is AnalyticsItem => item !== null)
+      : [];
     const purchase = isRecord(parsed.purchase)
       ? {
           transaction_id:
             typeof parsed.purchase.transaction_id === "string"
               ? parsed.purchase.transaction_id
               : "",
-          value: Number(parsed.purchase.value ?? 0),
+          value: parseFiniteNumber(parsed.purchase.value, 0),
           currency: "EUR" as const,
-          tax: Number(parsed.purchase.tax ?? 0),
-          shipping: Number(parsed.purchase.shipping ?? 0),
-          items: Array.isArray(parsed.purchase.items)
-            ? (parsed.purchase.items as AnalyticsItem[])
-            : [],
+          tax: parseFiniteNumber(parsed.purchase.tax, 0),
+          shipping: parseFiniteNumber(parsed.purchase.shipping, 0),
+          items: sanitizedItems,
         }
       : undefined;
 
@@ -49,7 +97,9 @@ export const readCheckoutSuccessContext = (): CheckoutSuccessContext | null => {
       hasDigitalItems: Boolean(parsed.hasDigitalItems),
       hasPhysicalItems: Boolean(parsed.hasPhysicalItems),
       itemCount: Number(parsed.itemCount || 0),
-      ...(purchase?.transaction_id ? { purchase } : {}),
+      ...(purchase?.transaction_id && purchase.items.length > 0
+        ? { purchase }
+        : {}),
     };
   } catch {
     return null;


### PR DESCRIPTION
## Summary

This PR fixes the GA4 page-view tracking edge cases identified in review.

## Why

The previous implementation had two subtle issues:

- page-view dedupe lived in the analytics helper as a module-global signature, which could suppress real revisits later in the same session
- the route listener could still capture a stale page title on slower pages if the title settled after the initial timeout

## Changes

- Frontend:
  - Removed module-global page-view dedupe from `src/lib/analytics.ts`
  - Kept `trackPageView()` stateless so it always records the page view it is asked to send
  - Updated `src/components/AnalyticsListener.tsx`
    - dedupe is now scoped to each navigation via `sessionStorage`
    - page views wait for the document title to settle before firing
    - added a polling loop plus a fallback timeout so slower routes still track reliably
- Backend:
  - N/A
- Infra/Config:
  - No environment changes

## Result

GA page views now behave more like real navigations:

- repeated visits to the same route later in the session are counted again
- duplicate firing for the same navigation is still avoided
- page titles are less likely to be stale on async routes

## Testing

- [x] `git diff --check`
- [ ] Frontend build passes locally
- [ ] Manual route navigation verified
- [ ] GA4 DebugView shows clean route-based `page_view` events

## Risk & Rollback

Risk level: Low

Why low:
- analytics-only change
- no backend impact
- no product, checkout, or cart logic changed

Rollback plan:
- [x] Revert PR

## Notes for Reviewer

Focus review on:
- navigation-scoped page-view dedupe
- title-settlement behavior in `AnalyticsListener`
- no session-global suppression of revisits
