### PR TITLE
Add US wall art landing pages for scale, living room and office intent

### DIFF
--- a/openeire/src/App.tsx
+++ b/openeire/src/App.tsx
@@ -64,6 +64,13 @@ const USAerialPhotographyPrintsPage = lazy(
 const USLandscapeWallArtPage = lazy(
   () => import("./pages/USLandscapeWallArtPage"),
 );
+const USLargeWallArtPage = lazy(() => import("./pages/USLargeWallArtPage"));
+const USWallArtForLivingRoomPage = lazy(
+  () => import("./pages/USWallArtForLivingRoomPage"),
+);
+const USWallArtForOfficePage = lazy(
+  () => import("./pages/USWallArtForOfficePage"),
+);
 const USFineArtPrintsPage = lazy(() => import("./pages/USFineArtPrintsPage"));
 const LicensingOverviewPage = lazy(
   () => import("./pages/LicensingOverviewPage"),
@@ -167,6 +174,15 @@ function App() {
               <Route
                 path="/us/landscape-wall-art"
                 element={<USLandscapeWallArtPage />}
+              />
+              <Route path="/us/large-wall-art" element={<USLargeWallArtPage />} />
+              <Route
+                path="/us/wall-art-for-living-room"
+                element={<USWallArtForLivingRoomPage />}
+              />
+              <Route
+                path="/us/wall-art-for-office"
+                element={<USWallArtForOfficePage />}
               />
               <Route path="/gallery/physical" element={<GalleryPage />} />
               <Route

--- a/openeire/src/pages/USAerialPhotographyPrintsPage.tsx
+++ b/openeire/src/pages/USAerialPhotographyPrintsPage.tsx
@@ -10,7 +10,7 @@ import {
 
 const USAerialPhotographyPrintsPage: React.FC = () => {
   const shippingNote = FREE_SHIPPING_PROMO_ENABLED
-    ? `Shipping is calculated at checkout. Current free-shipping messaging applies to eligible ${FREE_SHIPPING_COUNTRY_LABEL} orders over EUR ${FREE_SHIPPING_THRESHOLD.toFixed(2)}, while United States delivery uses the same print-order flow.`
+    ? `Shipping is calculated at checkout. Current free-shipping messaging applies to eligible ${FREE_SHIPPING_COUNTRY_LABEL} orders over EUR ${FREE_SHIPPING_THRESHOLD.toFixed(2)}, while United States orders are handled through the same made-to-order print flow.`
     : "Shipping is calculated at checkout for each made-to-order print.";
 
   return (
@@ -54,8 +54,8 @@ const USAerialPhotographyPrintsPage: React.FC = () => {
       angleIntro={
         <>
           The aerial perspective is the differentiator here. These prints are
-          for buyers who specifically want height, scale, geometry, and a point
-          of view that standard landscape photography cannot offer.
+          for buyers who want height, scale, geometry, and a point of view that
+          standard landscape photography cannot offer.
         </>
       }
       angleCards={[
@@ -93,7 +93,7 @@ const USAerialPhotographyPrintsPage: React.FC = () => {
           photographic character.
         </>,
         <>
-          A natural route into{" "}
+          For the wider collection, continue to the{" "}
           <Link to="/art-prints" className="text-accent hover:text-white">
             art prints page
           </Link>{" "}
@@ -103,20 +103,19 @@ const USAerialPhotographyPrintsPage: React.FC = () => {
             className="text-accent hover:text-white"
           >
             United States fine art prints
-          </Link>{" "}
-          when you want the wider collection context.
+          </Link>
+          .
         </>,
       ]}
       relevanceTitle="Ordering from the United States"
       relevanceParagraphs={[
         <>
           Aerial photography prints are available to buyers in the United States
-          through the same print workflow used across the collection.
+          as made-to-order physical pieces.
         </>,
         <>
-          Orders remain tied to the existing checkout flow, so delivery and
-          order handling stay grounded in the same process used across the print
-          range.
+          Orders move through checkout, so shipping and order handling stay
+          straightforward and consistent.
         </>,
       ]}
       relevanceBullets={[
@@ -148,7 +147,7 @@ const USAerialPhotographyPrintsPage: React.FC = () => {
       ctaTitle="Ready to explore the aerial collection?"
       ctaText={
         <>
-          Go straight into{" "}
+          Go straight into the{" "}
           <Link to="/gallery/physical" className="text-accent hover:text-white">
             print gallery
           </Link>

--- a/openeire/src/pages/USFineArtPrintsPage.tsx
+++ b/openeire/src/pages/USFineArtPrintsPage.tsx
@@ -49,7 +49,7 @@ const faqItems = [
   {
     question: "Do you ship fine art prints to the United States?",
     answer:
-      "Yes. This page is specifically for buyers in the United States. Print orders are produced to order, and shipping is surfaced through the existing checkout flow.",
+      "Yes. Fine art prints are available to buyers in the United States, with shipping handled through the current checkout flow.",
   },
   {
     question: "Are these original aerial photography prints?",
@@ -65,7 +65,7 @@ const faqItems = [
 
 const USFineArtPrintsPage: React.FC = () => {
   const shippingNote = FREE_SHIPPING_PROMO_ENABLED
-    ? `Shipping is calculated at checkout. Current free-shipping messaging applies to eligible ${FREE_SHIPPING_COUNTRY_LABEL} orders over EUR ${FREE_SHIPPING_THRESHOLD.toFixed(2)}, while United States delivery is handled through the same print-order flow.`
+    ? `Shipping is calculated at checkout. Current free-shipping messaging applies to eligible ${FREE_SHIPPING_COUNTRY_LABEL} orders over EUR ${FREE_SHIPPING_THRESHOLD.toFixed(2)}, while United States orders are handled through the same made-to-order print flow.`
     : "Shipping is calculated at checkout for each made-to-order print.";
 
   return (
@@ -77,7 +77,10 @@ const USFineArtPrintsPage: React.FC = () => {
         schema={[
           buildBreadcrumbSchema([
             { name: "Home", url: buildAbsoluteSiteUrl("/") },
-            { name: "US Fine Art Prints", url: buildAbsoluteSiteUrl("/us/fine-art-prints") },
+            {
+              name: "US Fine Art Prints",
+              url: buildAbsoluteSiteUrl("/us/fine-art-prints"),
+            },
           ]),
           buildFAQPageSchema(faqItems),
         ]}
@@ -99,9 +102,9 @@ const USFineArtPrintsPage: React.FC = () => {
             </h1>
             <p className="mt-5 max-w-3xl text-base leading-relaxed text-gray-300 md:text-lg">
               Discover premium aerial wall art from OpenEire Studios, available
-              to buyers in the United States. These fine art prints are built
-              for interiors, collectors, and gift buyers who want landscape
-              artwork with atmosphere rather than generic decor.
+              to buyers in the United States. These fine art prints are made for
+              interiors, collectors, and gift buyers who want landscape artwork
+              with atmosphere rather than generic decor.
             </p>
 
             <div className="mt-6 flex flex-col gap-3 sm:flex-row">
@@ -120,12 +123,12 @@ const USFineArtPrintsPage: React.FC = () => {
             </div>
 
             <p className="mt-5 max-w-3xl text-sm leading-relaxed text-gray-400">
-              Looking for the broader collection overview first? Visit{" "}
+              Looking for the broader collection first? Visit{" "}
               <Link to="/art-prints" className="text-accent hover:text-white">
                 art prints
               </Link>{" "}
-              for the main collection page, then come back here for the
-              United States-focused buying context.
+              for the main overview, then return here for the United
+              States-focused version.
             </p>
           </div>
         </div>
@@ -137,9 +140,9 @@ const USFineArtPrintsPage: React.FC = () => {
             Why these prints work in real interiors
           </h2>
           <p className="mt-4 text-sm leading-relaxed text-gray-400">
-            This page is written for United States buyers searching for fine art
-            prints, landscape wall art, and premium aerial photography that can
-            live comfortably in considered spaces.
+            Built for buyers in the United States who want fine art prints,
+            landscape wall art, and premium aerial photography that can sit
+            naturally in considered spaces.
           </p>
         </div>
         <div className="grid gap-6 md:grid-cols-3">
@@ -163,18 +166,17 @@ const USFineArtPrintsPage: React.FC = () => {
       <section className="container mx-auto px-4 lg:px-8 pt-8 md:pt-20">
         <div className="grid gap-8 lg:grid-cols-12 lg:items-start">
           <div className="space-y-6 lg:col-span-7">
-            <h2 className={SECTION_TITLE_CLASS}>Shipping and buying context</h2>
+            <h2 className={SECTION_TITLE_CLASS}>Shipping and buying details</h2>
             <p className="text-gray-400 leading-relaxed">
-              The collection is built for rooms that need a focal point. The
+              These prints are made for rooms that need a focal point. The
               aerial viewpoint brings scale and calm, while the overall finish
               stays restrained enough to work in design-led homes, offices, and
               hospitality spaces.
             </p>
             <p className="text-gray-400 leading-relaxed">
-              For United States buyers, the appeal is not novelty alone. It is
-              the combination of original aerial photography, premium
-              presentation, and landscapes that feel distinctive in a market
-              full of generic wall art.
+              For buyers in the United States, the appeal comes from original
+              aerial photography, premium presentation, and landscapes that feel
+              more distinctive than generic wall art.
             </p>
           </div>
 
@@ -185,11 +187,16 @@ const USFineArtPrintsPage: React.FC = () => {
             <ul className="mt-4 space-y-3 text-sm leading-relaxed text-gray-300">
               <li className="flex gap-3">
                 <FaShippingFast className="mt-0.5 shrink-0 text-accent" />
-                <span>Prints are available to buyers in the United States.</span>
+                <span>
+                  Prints are available to buyers in the United States.
+                </span>
               </li>
               <li className="flex gap-3">
                 <FaCheckCircle className="mt-0.5 shrink-0 text-accent" />
-                <span>Each piece is produced to order rather than pulled from mass inventory.</span>
+                <span>
+                  Each piece is produced to order rather than pulled from mass
+                  inventory.
+                </span>
               </li>
               <li className="flex gap-3">
                 <FaCheckCircle className="mt-0.5 shrink-0 text-accent" />
@@ -208,18 +215,17 @@ const USFineArtPrintsPage: React.FC = () => {
                 Sizes and display language for US buyers
               </h2>
               <p className="mt-4 text-sm leading-relaxed text-gray-300">
-                The collection is suited to United States interiors that often
-                shop by room scale and wall impact. Product pages remain the
-                source of truth for exact print options, while this page gives
-                the buying context: multiple size routes, premium display
-                intent, and artwork that can anchor a room rather than fill
-                empty space.
+                The collection suits United States interiors that often shop by
+                room scale and wall impact. Product pages remain the source of
+                truth for exact print options, while this page helps frame the
+                decision: multiple size routes, premium display intent, and
+                artwork that can anchor a room rather than simply fill space.
               </p>
               <p className="mt-4 text-sm leading-relaxed text-gray-300">
-                Where buyers think in inches, the key question is less about a
-                single fixed dimension and more about choosing a format that
-                fits a statement wall, console arrangement, office backdrop, or
-                collector-style display.
+                Where buyers think in inches, the goal is not one fixed
+                dimension but choosing a format that fits a statement wall,
+                console arrangement, office backdrop, or collector-style
+                display.
               </p>
             </div>
             <div className="rounded-2xl border border-white/10 bg-black/35 p-5 lg:col-span-5">
@@ -261,11 +267,14 @@ const USFineArtPrintsPage: React.FC = () => {
               <div className="flex gap-3 rounded-2xl border border-white/10 bg-white/5 p-5">
                 <FaArrowRight className="mt-0.5 shrink-0 text-accent" />
                 <p className="text-sm leading-relaxed text-gray-300">
-                  A clean path from this United States landing page to the main{" "}
-                  <Link to="/art-prints" className="text-accent hover:text-white">
+                  From here, you can move straight into the main{" "}
+                  <Link
+                    to="/art-prints"
+                    className="text-accent hover:text-white"
+                  >
                     art prints
                   </Link>{" "}
-                  overview, the print gallery, and direct print enquiries.
+                  overview, the print gallery, or a direct print enquiry.
                 </p>
               </div>
             </div>
@@ -276,9 +285,8 @@ const USFineArtPrintsPage: React.FC = () => {
               Explore the collection
             </h3>
             <p className="mt-3 text-sm leading-relaxed text-gray-300">
-              Use this page as the United States entry point, then continue into
-              the main collection pages when you want to browse pieces in more
-              detail.
+              Start here, then continue into the wider collection when you want
+              to browse pieces in more detail.
             </p>
             <div className="mt-6 flex flex-col gap-3">
               <Link

--- a/openeire/src/pages/USLandscapeWallArtPage.tsx
+++ b/openeire/src/pages/USLandscapeWallArtPage.tsx
@@ -10,7 +10,7 @@ import {
 
 const USLandscapeWallArtPage: React.FC = () => {
   const shippingNote = FREE_SHIPPING_PROMO_ENABLED
-    ? `Shipping is calculated at checkout. Current free-shipping messaging applies to eligible ${FREE_SHIPPING_COUNTRY_LABEL} orders over EUR ${FREE_SHIPPING_THRESHOLD.toFixed(2)}, while United States orders move through the same print workflow.`
+    ? `Shipping is calculated at checkout. Current free-shipping messaging applies to eligible ${FREE_SHIPPING_COUNTRY_LABEL} orders over EUR ${FREE_SHIPPING_THRESHOLD.toFixed(2)}, while United States orders are handled through the same made-to-order print flow.`
     : "Shipping is calculated at checkout for each made-to-order print.";
 
   return (
@@ -50,9 +50,8 @@ const USLandscapeWallArtPage: React.FC = () => {
       angleTitle="Landscape character, not just decoration"
       angleIntro={
         <>
-          This page is built around scenic intent first. The emphasis is on
-          coastlines, countryside, atmosphere, and prints that give a room a
-          stronger sense of place.
+          The focus here is on coastlines, countryside, atmosphere, and prints
+          that give a room a stronger sense of place.
         </>
       }
       angleCards={[
@@ -76,8 +75,8 @@ const USLandscapeWallArtPage: React.FC = () => {
       premiumIntro={
         <>
           These landscape prints are not treated as generic filler imagery. The
-          work is curated for mood, visual restraint, and how scenery actually
-          lands in a real interior.
+          work is curated for mood, visual restraint, and how scenery sits in a
+          real interior.
         </>
       }
       premiumPoints={[
@@ -87,14 +86,14 @@ const USLandscapeWallArtPage: React.FC = () => {
         </>,
         <>A more premium alternative to mass-market scenic wall decor.</>,
         <>
-          A natural path into{" "}
+          For the wider collection, continue to{" "}
           <Link
             to="/us/fine-art-prints"
             className="text-accent hover:text-white"
           >
             United States fine art prints
           </Link>{" "}
-          or directly into{" "}
+          or go straight into the{" "}
           <Link to="/gallery/physical" className="text-accent hover:text-white">
             print gallery
           </Link>
@@ -105,12 +104,11 @@ const USLandscapeWallArtPage: React.FC = () => {
       relevanceParagraphs={[
         <>
           Landscape wall art prints are available to buyers in the United States
-          through the current print order flow.
+          as made-to-order physical pieces.
         </>,
         <>
-          The process stays simple: made-to-order prints, checkout-based
-          shipping, and no extra promises beyond what the site currently
-          supports.
+          Orders move through checkout, so shipping and order handling stay
+          simple and consistent.
         </>,
       ]}
       relevanceBullets={[

--- a/openeire/src/pages/USLargeWallArtPage.tsx
+++ b/openeire/src/pages/USLargeWallArtPage.tsx
@@ -1,0 +1,183 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import { FaArrowsAlt, FaRegSquare, FaWarehouse } from "react-icons/fa";
+import USPrintLandingPage from "../components/USPrintLandingPage";
+
+const USLargeWallArtPage: React.FC = () => {
+  return (
+    <USPrintLandingPage
+      title="Large Wall Art USA | Statement Prints | OpenÉire Studios"
+      description="Discover large wall art for buyers in the United States, with premium statement prints designed for interiors that need scale, presence, and a stronger focal point."
+      canonicalPath="/us/large-wall-art"
+      breadcrumbLabel="US Large Wall Art"
+      eyebrow="Large-format wall art for the United States"
+      heading="Large Wall Art for Interiors in the United States"
+      intro={
+        <>
+          Explore large-format wall art designed for interiors that need scale
+          and presence. This collection focuses on statement pieces that anchor
+          a room rather than smaller decorative prints.
+        </>
+      }
+      heroPrimaryCta={{
+        label: "Browse Large Wall Art",
+        to: "/gallery/physical",
+      }}
+      heroSecondaryCta={{
+        label: "View Fine Art Overview",
+        to: "/us/fine-art-prints",
+        variant: "secondary",
+      }}
+      heroNote={
+        <>
+          If you are comparing options for a larger room or open-plan space, the{" "}
+          <Link
+            to="/us/wall-art-for-living-room"
+            className="text-accent hover:text-white"
+          >
+            living room wall art page
+          </Link>{" "}
+          and{" "}
+          <Link
+            to="/us/wall-art-for-office"
+            className="text-accent hover:text-white"
+          >
+            office wall art page
+          </Link>{" "}
+          show how the collection shifts by setting.
+        </>
+      }
+      angleTitle="Why scale changes the way wall art works"
+      angleIntro={
+        <>
+          Large wall art does a different job in a room. It sets the visual
+          pace, anchors larger walls, and gives open interiors a focal point
+          that smaller pieces often cannot carry on their own.
+        </>
+      }
+      angleCards={[
+        {
+          icon: <FaArrowsAlt />,
+          title: "Built for visual presence",
+          text: "These pieces are chosen for rooms that need weight and scale rather than a quieter decorative accent.",
+        },
+        {
+          icon: <FaRegSquare />,
+          title: "Statement placement",
+          text: "The emphasis is on artwork that can hold a larger wall with confidence, whether above furniture or across more open surfaces.",
+        },
+        {
+          icon: <FaWarehouse />,
+          title: "Suited to bigger interiors",
+          text: "Large-format wall art makes sense in loft-style homes, hospitality settings, and other spaces where smaller prints can feel lost.",
+        },
+      ]}
+      premiumTitle="Statement pieces with a more considered finish"
+      premiumIntro={
+        <>
+          OpenEire Studios approaches large wall art as physical artwork for
+          real interiors, not oversized filler. The emphasis stays on curation,
+          composition, and how a piece feels once it owns the room.
+        </>
+      }
+      premiumPoints={[
+        <>
+          Premium aerial and landscape imagery chosen for presence rather than
+          trend-driven wall decor.
+        </>,
+        <>
+          Made-to-order physical prints that feel art-led in larger interiors,
+          not like generic stock imagery scaled up for convenience.
+        </>,
+        <>
+          For the broader premium overview, continue to{" "}
+          <Link
+            to="/us/fine-art-prints"
+            className="text-accent hover:text-white"
+          >
+            United States fine art prints
+          </Link>{" "}
+          or go straight into{" "}
+          <Link to="/gallery/physical" className="text-accent hover:text-white">
+            the print gallery
+          </Link>
+          .
+        </>,
+      ]}
+      relevanceTitle="Buying large wall art in the United States"
+      relevanceParagraphs={[
+        <>
+          Large wall art from OpenEire Studios is available to buyers in the
+          United States as made-to-order physical pieces.
+        </>,
+        <>
+          Larger prints follow the same straightforward buying flow, with
+          shipping handled at checkout.
+        </>,
+      ]}
+      relevanceBullets={[
+        "Available to buyers in the United States",
+        "Large-format wall art for interiors",
+        "Shipping is calculated at checkout",
+      ]}
+      relevanceNote={
+        <>
+          For the broader collector-led overview, visit the{" "}
+          <Link
+            to="/us/fine-art-prints"
+            className="text-accent hover:text-white"
+          >
+            United States fine art prints page
+          </Link>
+          .
+        </>
+      }
+      ctaTitle="Need a print with more presence?"
+      ctaText={
+        <>
+          Browse the{" "}
+          <Link to="/gallery/physical" className="text-accent hover:text-white">
+            print gallery
+          </Link>
+          , compare the collector-led{" "}
+          <Link
+            to="/us/fine-art-prints"
+            className="text-accent hover:text-white"
+          >
+            fine art overview
+          </Link>
+          , or explore the more placement-specific{" "}
+          <Link
+            to="/us/wall-art-for-living-room"
+            className="text-accent hover:text-white"
+          >
+            living room page
+          </Link>{" "}
+          and{" "}
+          <Link
+            to="/us/wall-art-for-office"
+            className="text-accent hover:text-white"
+          >
+            office page
+          </Link>
+          .
+        </>
+      }
+      ctas={[
+        { label: "Browse Prints", to: "/gallery/physical" },
+        {
+          label: "Contact the Studio",
+          to: "/contact",
+          variant: "secondary",
+        },
+        {
+          label: "Fine Art Overview",
+          to: "/us/fine-art-prints",
+          variant: "tertiary",
+        },
+      ]}
+    />
+  );
+};
+
+export default USLargeWallArtPage;

--- a/openeire/src/pages/USWallArtForLivingRoomPage.tsx
+++ b/openeire/src/pages/USWallArtForLivingRoomPage.tsx
@@ -1,0 +1,183 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import { FaCouch, FaRegMoon, FaVectorSquare } from "react-icons/fa";
+import USPrintLandingPage from "../components/USPrintLandingPage";
+
+const USWallArtForLivingRoomPage: React.FC = () => {
+  return (
+    <USPrintLandingPage
+      title="Living Room Wall Art USA | Interior Prints | OpenÉire Studios"
+      description="Discover premium wall art for living rooms in the United States, with curated prints chosen for balance, atmosphere, and a strong but measured presence in the room."
+      canonicalPath="/us/wall-art-for-living-room"
+      breadcrumbLabel="US Wall Art for Living Room"
+      eyebrow="Living room wall art for the United States"
+      heading="Wall Art for Living Rooms in the United States"
+      intro={
+        <>
+          Discover wall art designed for living room spaces, where placement,
+          balance, and atmosphere matter. These pieces are selected to hold
+          visual weight without overwhelming the room.
+        </>
+      }
+      heroPrimaryCta={{
+        label: "Browse Living Room Prints",
+        to: "/gallery/physical",
+      }}
+      heroSecondaryCta={{
+        label: "Contact the Studio",
+        to: "/contact",
+        variant: "secondary",
+      }}
+      heroNote={
+        <>
+          If you are comparing broader scenic pieces, the{" "}
+          <Link
+            to="/us/landscape-wall-art"
+            className="text-accent hover:text-white"
+          >
+            landscape wall art page
+          </Link>{" "}
+          and{" "}
+          <Link
+            to="/us/large-wall-art"
+            className="text-accent hover:text-white"
+          >
+            large wall art page
+          </Link>{" "}
+          offer a useful next step.
+        </>
+      }
+      angleTitle="Why living room wall art needs balance"
+      angleIntro={
+        <>
+          Living rooms ask more of a piece than simple decoration. The artwork
+          has to create atmosphere, sit comfortably with furniture and light,
+          and hold the room without becoming visually heavy.
+        </>
+      }
+      angleCards={[
+        {
+          icon: <FaCouch />,
+          title: "Designed for placement",
+          text: "The focus here is on prints that feel considered above sofas, consoles, and other main living room sightlines.",
+        },
+        {
+          icon: <FaRegMoon />,
+          title: "Atmosphere over noise",
+          text: "These pieces are selected to add mood and depth without making the room feel crowded or overly busy.",
+        },
+        {
+          icon: <FaVectorSquare />,
+          title: "Visual weight with restraint",
+          text: "The aim is presence, but with enough calm and structure to support the room rather than dominate it.",
+        },
+      ]}
+      premiumTitle="Curated prints for rooms people actually live in"
+      premiumIntro={
+        <>
+          OpenEire Studios treats living room wall art as part of the interior
+          composition. The collection is made for buyers who want a more refined
+          answer than generic decor or trend-led poster sets.
+        </>
+      }
+      premiumPoints={[
+        <>
+          Premium physical prints chosen for their ability to bring atmosphere
+          and compositional calm into a living space.
+        </>,
+        <>
+          Made-to-order artwork with a stronger editorial and collector-led feel
+          than mass-market home decor.
+        </>,
+        <>
+          For a broader premium view, explore{" "}
+          <Link
+            to="/us/fine-art-prints"
+            className="text-accent hover:text-white"
+          >
+            United States fine art prints
+          </Link>{" "}
+          or continue into{" "}
+          <Link
+            to="/us/landscape-wall-art"
+            className="text-accent hover:text-white"
+          >
+            landscape wall art
+          </Link>{" "}
+          if scenery and mood are the priority.
+        </>,
+      ]}
+      relevanceTitle="Wall art for living spaces in the United States"
+      relevanceParagraphs={[
+        <>
+          Living room wall art from OpenEire Studios is available to buyers in
+          the United States as made-to-order physical prints.
+        </>,
+        <>
+          Orders move through checkout, keeping the process clear and
+          consistent.
+        </>,
+      ]}
+      relevanceBullets={[
+        "Available to buyers in the United States",
+        "Designed for living room placement",
+        "Shipping is calculated at checkout",
+      ]}
+      relevanceNote={
+        <>
+          To browse available pieces directly, open{" "}
+          <Link to="/gallery/physical" className="text-accent hover:text-white">
+            the print gallery
+          </Link>
+          .
+        </>
+      }
+      ctaTitle="Looking for the right living room piece?"
+      ctaText={
+        <>
+          Start with{" "}
+          <Link to="/gallery/physical" className="text-accent hover:text-white">
+            the print gallery
+          </Link>
+          , compare the more collector-led{" "}
+          <Link
+            to="/us/fine-art-prints"
+            className="text-accent hover:text-white"
+          >
+            fine art overview
+          </Link>
+          , or continue into{" "}
+          <Link
+            to="/us/large-wall-art"
+            className="text-accent hover:text-white"
+          >
+            large wall art
+          </Link>{" "}
+          and{" "}
+          <Link
+            to="/us/landscape-wall-art"
+            className="text-accent hover:text-white"
+          >
+            landscape wall art
+          </Link>{" "}
+          to compare scale and mood.
+        </>
+      }
+      ctas={[
+        { label: "Browse Prints", to: "/gallery/physical" },
+        {
+          label: "Fine Art Overview",
+          to: "/us/fine-art-prints",
+          variant: "secondary",
+        },
+        {
+          label: "Contact the Studio",
+          to: "/contact",
+          variant: "tertiary",
+        },
+      ]}
+    />
+  );
+};
+
+export default USWallArtForLivingRoomPage;

--- a/openeire/src/pages/USWallArtForOfficePage.tsx
+++ b/openeire/src/pages/USWallArtForOfficePage.tsx
@@ -1,0 +1,176 @@
+import React from "react";
+import { Link } from "react-router-dom";
+import { FaBriefcase, FaRegBuilding, FaThLarge } from "react-icons/fa";
+import USPrintLandingPage from "../components/USPrintLandingPage";
+
+const USWallArtForOfficePage: React.FC = () => {
+  return (
+    <USPrintLandingPage
+      title="Office Wall Art USA | Professional Interior Prints | OpenÉire Studios"
+      description="Explore premium office wall art for the United States, with refined aerial and landscape prints chosen for workspaces, studios, and professional interiors."
+      canonicalPath="/us/wall-art-for-office"
+      breadcrumbLabel="US Wall Art for Office"
+      eyebrow="Office wall art for the United States"
+      heading="Wall Art for Offices and Workspaces in the United States"
+      intro={
+        <>
+          Explore wall art suited for professional environments, including
+          offices, studios, and hospitality spaces. These prints are selected
+          for clarity, structure, and a refined visual tone.
+        </>
+      }
+      heroPrimaryCta={{
+        label: "Browse Office Prints",
+        to: "/gallery/physical",
+      }}
+      heroSecondaryCta={{
+        label: "View Fine Art Overview",
+        to: "/us/fine-art-prints",
+        variant: "secondary",
+      }}
+      heroNote={
+        <>
+          If you need help narrowing the collection for a workspace, use{" "}
+          <Link to="/contact" className="text-accent hover:text-white">
+            contact page
+          </Link>{" "}
+          for a direct studio enquiry, or compare the more medium-led{" "}
+          <Link
+            to="/us/aerial-photography-prints"
+            className="text-accent hover:text-white"
+          >
+            aerial photography page
+          </Link>
+          .
+        </>
+      }
+      angleTitle="Why office wall art needs a cleaner visual language"
+      angleIntro={
+        <>
+          Workspaces benefit from artwork with structure and restraint. The goal
+          is to add character, depth, and a more considered atmosphere without
+          distracting from the room’s professional function.
+        </>
+      }
+      angleCards={[
+        {
+          icon: <FaBriefcase />,
+          title: "Appropriate for professional settings",
+          text: "The collection is suited to offices, studios, meeting spaces, and client-facing environments that need a more polished visual tone.",
+        },
+        {
+          icon: <FaThLarge />,
+          title: "Clear structure and composition",
+          text: "Aerial and landscape imagery with stronger geometry can bring order and visual rhythm to a workspace wall.",
+        },
+        {
+          icon: <FaRegBuilding />,
+          title: "Works across commercial interiors",
+          text: "The tone stays refined enough for hospitality, studio, and office environments where the artwork needs to feel deliberate.",
+        },
+      ]}
+      premiumTitle="Professional interiors still deserve real artwork"
+      premiumIntro={
+        <>
+          OpenEire Studios positions office wall art as a design decision, not
+          an afterthought. The collection is curated for environments that want
+          visual distinction without tipping into generic decor.
+        </>
+      }
+      premiumPoints={[
+        <>
+          Premium physical prints selected for clarity, structure, and a more
+          composed presence in workspaces.
+        </>,
+        <>
+          Made-to-order artwork that feels more considered than generic office
+          filler or commodity stock decor.
+        </>,
+        <>
+          A direct route into{" "}
+          <Link
+            to="/us/aerial-photography-prints"
+            className="text-accent hover:text-white"
+          >
+            aerial photography prints
+          </Link>{" "}
+          when perspective matters most, and into{" "}
+          <Link
+            to="/us/fine-art-prints"
+            className="text-accent hover:text-white"
+          >
+            United States fine art prints
+          </Link>{" "}
+          for the broader premium overview.
+        </>,
+      ]}
+      relevanceTitle="Wall art for offices and workspaces in the United States"
+      relevanceParagraphs={[
+        <>
+          Office wall art from OpenEire Studios is available to buyers in the
+          United States through the same print ordering flow used across the
+          collection.
+        </>,
+        <>
+          Orders are made to order, which keeps the process grounded in the
+          existing print workflow rather than promising a separate commercial
+          fulfillment model.
+        </>,
+      ]}
+      relevanceBullets={[
+        "Available to buyers in the United States",
+        "Suitable for offices and professional environments",
+        "Shipping is calculated at checkout",
+      ]}
+      relevanceNote={
+        <>
+          For a broader premium overview before you browse, visit{" "}
+          <Link
+            to="/us/fine-art-prints"
+            className="text-accent hover:text-white"
+          >
+            the United States fine art prints page
+          </Link>
+          .
+        </>
+      }
+      ctaTitle="Need artwork for a more professional setting?"
+      ctaText={
+        <>
+          Browse{" "}
+          <Link to="/gallery/physical" className="text-accent hover:text-white">
+            the print gallery
+          </Link>
+          , compare the more perspective-led{" "}
+          <Link
+            to="/us/aerial-photography-prints"
+            className="text-accent hover:text-white"
+          >
+            aerial photography page
+          </Link>
+          , or use{" "}
+          <Link to="/contact" className="text-accent hover:text-white">
+            contact page
+          </Link>{" "}
+          if you want help choosing a print for an office, studio, or
+          hospitality interior.
+        </>
+      }
+      ctas={[
+        { label: "Browse Prints", to: "/gallery/physical" },
+        {
+          label: "Contact the Studio",
+          to: "/contact",
+          variant: "secondary",
+        },
+        {
+          label: "Fine Art Overview",
+          to: "/us/fine-art-prints",
+          variant: "tertiary",
+        },
+      ]}
+    />
+  );
+};
+
+export default USWallArtForOfficePage;

--- a/openeire/src/pages/USWallArtPrintsPage.tsx
+++ b/openeire/src/pages/USWallArtPrintsPage.tsx
@@ -10,7 +10,7 @@ import {
 
 const USWallArtPrintsPage: React.FC = () => {
   const shippingNote = FREE_SHIPPING_PROMO_ENABLED
-    ? `Shipping is calculated at checkout. Current free-shipping messaging applies to eligible ${FREE_SHIPPING_COUNTRY_LABEL} orders over EUR ${FREE_SHIPPING_THRESHOLD.toFixed(2)}, while United States orders follow the same print workflow.`
+    ? `Shipping is calculated at checkout. Current free-shipping messaging applies to eligible ${FREE_SHIPPING_COUNTRY_LABEL} orders over EUR ${FREE_SHIPPING_THRESHOLD.toFixed(2)}, while United States orders are handled through the same made-to-order print flow.`
     : "Shipping is calculated at checkout for each made-to-order print.";
 
   return (
@@ -24,10 +24,9 @@ const USWallArtPrintsPage: React.FC = () => {
       intro={
         <>
           Browse a curated collection of wall art prints designed for homes,
-          offices, and interior projects across the United States. This page
-          acts as the entry point into the OpenEire Studios print collection,
-          covering a range of styles including aerial, landscape, and statement
-          pieces.
+          offices, and interior projects across the United States. The
+          collection brings together aerial, landscape, and statement pieces
+          chosen for atmosphere, presence, and real-world display.
         </>
       }
       heroPrimaryCta={{
@@ -52,9 +51,9 @@ const USWallArtPrintsPage: React.FC = () => {
       angleTitle="Wall art that works in real spaces"
       angleIntro={
         <>
-          This page is centered on placement and interior use: statement wall
-          art for living rooms, offices, hospitality settings, and refined
-          spaces that need a focal piece rather than generic decoration.
+          Built around placement and interior use, this collection suits living
+          rooms, offices, hospitality settings, and refined spaces that need a
+          focal piece rather than generic decoration.
         </>
       }
       angleCards={[
@@ -92,25 +91,25 @@ const USWallArtPrintsPage: React.FC = () => {
           interiors.
         </>,
         <>
-          A clean path from this broader wall-art page into{" "}
+          If you want a more collector-led direction, continue to{" "}
           <Link
             to="/us/fine-art-prints"
             className="text-accent hover:text-white"
           >
             United States fine art prints
-          </Link>{" "}
-          when the buyer intent becomes more collector-led.
+          </Link>
+          .
         </>,
       ]}
       relevanceTitle="For United States buyers"
       relevanceParagraphs={[
         <>
           Wall art prints from OpenEire Studios are available to buyers in the
-          United States through the existing print order flow.
+          United States as made-to-order physical pieces.
         </>,
         <>
-          Orders are produced to order, with shipping handled through checkout
-          rather than through a separate manual quote by default.
+          Orders move through checkout, so shipping and order handling stay
+          clear and consistent without needing a separate quote by default.
         </>,
       ]}
       relevanceBullets={[
@@ -134,12 +133,12 @@ const USWallArtPrintsPage: React.FC = () => {
         {
           question: "Do you ship wall art prints to the United States?",
           answer:
-            "Yes. United States orders follow the existing print workflow, with shipping handled through checkout.",
+            "Yes. United States orders are available through the current print flow, with shipping handled at checkout.",
         },
         {
           question: "Are these suitable for interiors and offices?",
           answer:
-            "Yes. The collection is positioned for homes, offices, and curated spaces that need more considered wall art.",
+            "Yes. The collection is designed for homes, offices, and curated spaces that need more considered wall art.",
         },
       ]}
       ctaTitle="Ready to place the right piece?"


### PR DESCRIPTION
## Summary

Adds three new US-targeted print landing pages to expand the existing SEO cluster:

- `/us/large-wall-art`
- `/us/wall-art-for-living-room`
- `/us/wall-art-for-office`

These pages reuse the current US landing-page structure and SEO pattern while keeping each page distinct in buyer intent, copy angle, and internal-linking role.

## Why

This extends the US print funnel without duplicating the existing `/us/fine-art-prints`, `/us/wall-art-prints`, `/us/aerial-photography-prints`, and `/us/landscape-wall-art` pages.

The goal is to capture higher-intent searches around:
- large statement wall art
- living room wall art placement
- office/workspace wall art

while preserving the premium OpenEire Studios positioning and avoiding thin or near-duplicate landing pages.

## Screenshots / Demo

- [x] Not needed
- [ ] Added (attach screenshots / short Loom link)

## Changes

- Backend:
  - None
- Frontend:
  - Added `/us/large-wall-art` with scale-led, statement-piece positioning
  - Added `/us/wall-art-for-living-room` with placement, balance, and atmosphere-led copy
  - Added `/us/wall-art-for-office` with professional, structured, workspace-appropriate positioning
  - Wired all 3 routes into the main router
  - Reused the existing `USPrintLandingPage` component pattern for consistency
  - Added page-specific SEO metadata and canonical paths through the current `SEOHead` flow
  - Added breadcrumb schema via the existing shared page pattern
  - Added contextual internal links to `/gallery/physical`, `/us/fine-art-prints`, and related US landing pages
- Infra/Config:
  - None

## Testing

- [ ] Django tests pass locally
- [x] React build passes locally
- [ ] Manual smoke test done

### Manual smoke test checklist (quick)

- [ ] No console errors
- [ ] Forms submit correctly (success + validation errors)
- [ ] API errors handled (loading/error states)
- [ ] Mobile layout checked
- [ ] Auth/permissions verified (if relevant)

## Risk & Rollback

Risk level: Low

Rollback plan:

- [x] Revert PR
- [ ] Feature flag off
- [ ] Hotfix path described:

## Notes for Reviewer (Codex/Copilot)

Focus review on:

- [ ] Security (auth, permissions, file uploads, CSRF/CORS)
- [ ] Performance (N+1 queries, heavy renders, unnecessary requests)
- [x] Maintainability (naming, structure, duplicated logic)

Additional review context:
- Each page is intentionally differentiated by search intent and user mindset:
  - `large-wall-art` = scale and presence
  - `wall-art-for-living-room` = placement and atmosphere
  - `wall-art-for-office` = professional suitability and structure
- Shipping language stays intentionally minimal and truthful: shipping is calculated at checkout.
- No new print-size, framing, or delivery-time claims were introduced.