### PR TITLE
Streamline private gallery gate without weakening security

### DIFF
--- a/openeire/src/components/AuthForm.tsx
+++ b/openeire/src/components/AuthForm.tsx
@@ -1,7 +1,7 @@
-﻿import React, { useState } from "react";
-import { registerUser } from "../services/api";
+import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import toast from "react-hot-toast";
+import { registerUser } from "../services/api";
 import { getRegistrationToastErrorMessage } from "../utils/toast";
 
 interface FormData {
@@ -13,7 +13,15 @@ interface FormData {
   confirmPassword: string;
 }
 
-const AuthForm: React.FC = () => {
+interface AuthFormProps {
+  initialEmail?: string;
+  redirectPath?: string;
+}
+
+const AuthForm: React.FC<AuthFormProps> = ({
+  initialEmail = "",
+  redirectPath,
+}) => {
   const [formData, setFormData] = useState<FormData>({
     first_name: "",
     last_name: "",
@@ -24,6 +32,14 @@ const AuthForm: React.FC = () => {
   });
   const [loading, setLoading] = useState<boolean>(false);
   const navigate = useNavigate();
+
+  useEffect(() => {
+    if (!initialEmail) return;
+    setFormData((current) => {
+      if (current.email === initialEmail) return current;
+      return { ...current, email: initialEmail };
+    });
+  }, [initialEmail]);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setFormData({ ...formData, [e.target.name]: e.target.value });
@@ -48,7 +64,13 @@ const AuthForm: React.FC = () => {
         password: formData.password,
       });
       toast.success("Registration successful! Please check your email.");
-      navigate("/verify-pending");
+      navigate("/verify-pending", {
+        state: {
+          email: formData.email,
+          fromGalleryGate: redirectPath === "/gallery-gate",
+          from: redirectPath ? { pathname: redirectPath } : undefined,
+        },
+      });
     } catch (err: any) {
       console.error("Registration error:", err);
       toast.error(getRegistrationToastErrorMessage(err));
@@ -64,7 +86,7 @@ const AuthForm: React.FC = () => {
 
   return (
     <form className="space-y-5" onSubmit={handleSubmit}>
-      <div className="flex flex-col sm:flex-row gap-4">
+      <div className="flex flex-col gap-4 sm:flex-row">
         <div className="w-full">
           <label htmlFor="first_name" className={labelClass}>
             First Name
@@ -163,7 +185,7 @@ const AuthForm: React.FC = () => {
 
       <button
         type="submit"
-        className="w-full py-3 bg-brand-500 text-paper font-bold rounded-lg hover:bg-brand-700 transition-colors shadow-lg disabled:opacity-50 disabled:cursor-not-allowed"
+        className="w-full rounded-lg bg-brand-500 py-3 font-bold text-paper shadow-lg transition-colors hover:bg-brand-700 disabled:cursor-not-allowed disabled:opacity-50"
         disabled={loading}
       >
         {loading ? "Creating Account..." : "Create Account"}
@@ -173,5 +195,3 @@ const AuthForm: React.FC = () => {
 };
 
 export default AuthForm;
-
-

--- a/openeire/src/components/GalleryGuard.tsx
+++ b/openeire/src/components/GalleryGuard.tsx
@@ -1,29 +1,28 @@
-﻿import React from "react";
-import { Navigate, Outlet } from "react-router-dom";
+import React from "react";
+import { Navigate, Outlet, useLocation } from "react-router-dom";
+import { useAuth } from "../context/AuthContext";
 
 const GalleryGuard = () => {
-  // 1. Check local storage for the ticket
-  const storedSession = localStorage.getItem("gallery_access");
+  const { isAuthenticated, user } = useAuth();
+  const location = useLocation();
 
-  if (!storedSession) {
-    // No ticket? Go to the Gate.
-    return <Navigate to="/gallery-gate" replace />;
+  if (!isAuthenticated) {
+    return <Navigate to="/gallery-gate" state={{ from: location }} replace />;
   }
 
-  // 2. Check expiration (Optional but recommended)
-  const { expiresAt } = JSON.parse(storedSession);
-  const now = new Date();
-  const expiration = new Date(expiresAt);
-
-  if (now > expiration) {
-    // Ticket expired? Clear it and kick them out.
-    localStorage.removeItem("gallery_access");
-    return <Navigate to="/gallery-gate" replace />;
+  if (!user) {
+    return (
+      <div className="flex min-h-[50vh] items-center justify-center text-sm font-medium uppercase tracking-[0.2em] text-gray-500">
+        Checking access...
+      </div>
+    );
   }
 
-  // 3. Valid ticket? Let them in.
+  if (!user.can_access_gallery) {
+    return <Navigate to="/gallery-gate" state={{ from: location }} replace />;
+  }
+
   return <Outlet />;
 };
 
 export default GalleryGuard;
-

--- a/openeire/src/context/AuthContext.tsx
+++ b/openeire/src/context/AuthContext.tsx
@@ -7,6 +7,10 @@
   useCallback,
 } from "react";
 import { loginUser, api } from "../services/api";
+import {
+  clearPendingGalleryCode,
+  clearPendingGalleryRedirect,
+} from "../utils/galleryAccessFlow";
 
 interface User {
   username: string;
@@ -15,7 +19,7 @@ interface User {
   first_name?: string;
   last_name?: string;
   country?: string;
-  // Add other fields you expect
+  can_access_gallery?: boolean;
 }
 
 interface AuthState {
@@ -68,6 +72,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
       localStorage.removeItem("accessToken");
       localStorage.removeItem("refreshToken");
     }
+    localStorage.removeItem("gallery_access");
 
     const storedToken = getSessionAccessToken();
 
@@ -88,6 +93,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     sessionStorage.setItem("refreshToken", response.refresh);
     localStorage.removeItem("accessToken");
     localStorage.removeItem("refreshToken");
+    localStorage.removeItem("gallery_access");
 
     setAccessToken(response.access);
     await refreshUser(); // Load user data immediately
@@ -102,6 +108,7 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
     sessionStorage.setItem("refreshToken", data.refresh);
     localStorage.removeItem("accessToken");
     localStorage.removeItem("refreshToken");
+    localStorage.removeItem("gallery_access");
     setAccessToken(data.access);
 
     if (data.user) {
@@ -114,8 +121,11 @@ export const AuthProvider = ({ children }: { children: ReactNode }) => {
   const logout = () => {
     localStorage.removeItem("accessToken");
     localStorage.removeItem("refreshToken");
+    localStorage.removeItem("gallery_access");
     sessionStorage.removeItem("accessToken");
     sessionStorage.removeItem("refreshToken");
+    clearPendingGalleryCode();
+    clearPendingGalleryRedirect();
     setAccessToken(null);
     setUser(null);
   };

--- a/openeire/src/pages/GalleryGatePage.tsx
+++ b/openeire/src/pages/GalleryGatePage.tsx
@@ -1,65 +1,407 @@
-﻿import React, { useState } from "react";
-import { useNavigate, useLocation, Link } from "react-router-dom";
+import React, { useEffect, useMemo, useState } from "react";
+import { Link, useLocation, useNavigate } from "react-router-dom";
 import toast from "react-hot-toast";
+import SEOHead from "../components/SEOHead";
+import { useAuth } from "../context/AuthContext";
+import { requestGalleryAccess, verifyGalleryAccess } from "../services/api";
 import {
   getGalleryAccessRequestToastErrorMessage,
   getGalleryAccessVerifyToastErrorMessage,
 } from "../utils/toast";
-import { requestGalleryAccess, verifyGalleryAccess } from "../services/api";
-import SEOHead from "../components/SEOHead";
+import {
+  clearGalleryAccessIntent,
+  getPendingGalleryCode,
+  getPendingGalleryRedirect,
+  getRequestedGalleryEmail,
+  setPendingGalleryCode,
+  setPendingGalleryRedirect,
+  setRequestedGalleryEmail,
+} from "../utils/galleryAccessFlow";
+
+type GateState = "A" | "B" | "C" | "D" | "E";
+
+const normalizeEmail = (value: string): string => value.trim().toLowerCase();
 
 const GalleryGatePage = () => {
-  const [email, setEmail] = useState("");
-  const [code, setCode] = useState("");
-  const [isLoading, setIsLoading] = useState(false);
   const navigate = useNavigate();
   const location = useLocation();
+  const { isAuthenticated, refreshUser, user } = useAuth();
 
-  const handleRequestAccess = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setIsLoading(true);
+  const [requestEmail, setRequestEmail] = useState("");
+  const [requestedEmail, setRequestedEmailState] = useState("");
+  const [code, setCode] = useState("");
+  const [isRequestingCode, setIsRequestingCode] = useState(false);
+  const [isVerifyingCode, setIsVerifyingCode] = useState(false);
+
+  const pendingRedirect =
+    getPendingGalleryRedirect() ||
+    ((location.state as { from?: { pathname?: string } } | undefined)?.from
+      ?.pathname ?? "/gallery/digital");
+  const accountEmail = normalizeEmail(user?.email ?? "");
+  const hasGalleryAccess = Boolean(user?.can_access_gallery);
+  const emailsMatch =
+    Boolean(requestedEmail) && Boolean(accountEmail) && requestedEmail === accountEmail;
+
+  useEffect(() => {
+    localStorage.removeItem("gallery_access");
+    setCode(getPendingGalleryCode());
+    const storedRequestedEmail = getRequestedGalleryEmail();
+    setRequestedEmailState(storedRequestedEmail);
+    if (storedRequestedEmail) {
+      setRequestEmail(storedRequestedEmail);
+      return;
+    }
+    if (accountEmail) {
+      setRequestEmail(accountEmail);
+    }
+  }, [accountEmail]);
+
+  const gateState: GateState = useMemo(() => {
+    if (hasGalleryAccess) return "E";
+    if (!isAuthenticated && !requestedEmail) return "A";
+    if (!isAuthenticated && requestedEmail) return "B";
+    if (isAuthenticated && requestedEmail && !emailsMatch) return "D";
+    return "C";
+  }, [emailsMatch, hasGalleryAccess, isAuthenticated, requestedEmail]);
+
+  const handleRequestAccess = async (emailOverride?: string) => {
+    const emailToUse = normalizeEmail(emailOverride ?? requestEmail);
+    if (!emailToUse) {
+      toast.error("Enter the email address you want to use for private gallery access.");
+      return;
+    }
+
+    setIsRequestingCode(true);
     try {
-      await requestGalleryAccess(email);
-      toast.success("Access code sent! Please check your email.");
-      setEmail("");
+      await requestGalleryAccess(emailToUse);
+      setRequestedGalleryEmail(emailToUse);
+      setRequestedEmailState(emailToUse);
+      setRequestEmail(emailToUse);
+      setPendingGalleryRedirect(pendingRedirect);
+      toast.success("Access code sent. Check your inbox for the next step.");
+      if (gateState === "D") {
+        toast.success("We’ve sent a fresh code for the signed-in account.");
+      }
     } catch (error: any) {
       toast.error(getGalleryAccessRequestToastErrorMessage(error));
     } finally {
-      setIsLoading(false);
+      setIsRequestingCode(false);
     }
+  };
+
+  const handleStartOver = () => {
+    clearGalleryAccessIntent();
+    setRequestedEmailState("");
+    setCode("");
+    setRequestEmail(accountEmail || "");
+    toast.success("You can request access with a different email now.");
   };
 
   const handleVerifyCode = async (e: React.FormEvent) => {
     e.preventDefault();
-    setIsLoading(true);
+    const normalizedCode = code.trim().toUpperCase();
+    if (!normalizedCode) {
+      toast.error("Enter the access code from your email.");
+      return;
+    }
+
+    if (!isAuthenticated) {
+      setPendingGalleryCode(normalizedCode);
+      setPendingGalleryRedirect(pendingRedirect);
+      toast("Sign in with the same email you used to request access.");
+      navigate("/login", {
+        state: {
+          from: { pathname: "/gallery-gate" },
+          prefillEmail: requestedEmail || undefined,
+          fromGalleryGate: true,
+        },
+      });
+      return;
+    }
+
+    if (gateState === "D") {
+      toast.error("This signed-in email does not match the email where your code was sent.");
+      return;
+    }
+
+    setIsVerifyingCode(true);
     try {
-      const data = await verifyGalleryAccess(code);
+      const data = await verifyGalleryAccess(normalizedCode);
       if (data.valid) {
-        const sessionData = {
-          code: code.toUpperCase(),
-          expiresAt: data.expires_at,
-        };
-        localStorage.setItem("gallery_access", JSON.stringify(sessionData));
-        toast.success("Access Granted. Welcome.");
-        const from =
-          (location.state as any)?.from?.pathname || "/gallery/digital";
-        navigate(from, { replace: true });
+        await refreshUser();
+        clearGalleryAccessIntent();
+        toast.success("Private gallery unlocked.");
+        navigate(pendingRedirect, { replace: true });
       }
     } catch (error: any) {
       toast.error(getGalleryAccessVerifyToastErrorMessage(error));
     } finally {
-      setIsLoading(false);
+      setIsVerifyingCode(false);
     }
+  };
+
+  const signInLinkState = {
+    from: { pathname: "/gallery-gate" },
+    prefillEmail: requestedEmail || requestEmail || undefined,
+    fromGalleryGate: true,
+  };
+
+  const registerLinkState = {
+    from: { pathname: "/gallery-gate" },
+    prefillEmail: requestedEmail || requestEmail || undefined,
+    fromGalleryGate: true,
+  };
+
+  const renderPrimaryPanel = () => {
+    if (gateState === "E") {
+      return (
+        <div className="space-y-5">
+          <div className="rounded-xl border border-emerald-200 bg-emerald-50 p-5">
+            <p className="text-sm font-semibold uppercase tracking-[0.18em] text-emerald-700">
+              Access Ready
+            </p>
+            <h2 className="mt-2 text-2xl font-serif font-bold text-brand-900">
+              Your private gallery is unlocked
+            </h2>
+            <p className="mt-3 text-sm leading-relaxed text-gray-600">
+              This account already has access to the private digital collection.
+            </p>
+          </div>
+          <button
+            onClick={() => navigate("/gallery/digital")}
+            className="w-full rounded-lg bg-brand-900 py-4 font-bold text-white shadow-lg transition-all hover:bg-brand-800 hover:shadow-xl"
+          >
+            Continue to Gallery
+          </button>
+        </div>
+      );
+    }
+
+    if (gateState === "D") {
+      return (
+        <div className="space-y-5">
+          <div className="rounded-xl border border-amber-200 bg-amber-50 p-5">
+            <p className="text-sm font-semibold uppercase tracking-[0.18em] text-amber-700">
+              Email Check
+            </p>
+            <h2 className="mt-2 text-2xl font-serif font-bold text-brand-900">
+              Sign in with the same email
+            </h2>
+            <p className="mt-3 text-sm leading-relaxed text-gray-600">
+              Your code was requested for{" "}
+              <span className="font-semibold text-brand-900">{requestedEmail}</span>,
+              but you are currently signed in as{" "}
+              <span className="font-semibold text-brand-900">{accountEmail}</span>.
+            </p>
+          </div>
+
+          <button
+            onClick={() => handleRequestAccess(accountEmail)}
+            disabled={isRequestingCode}
+            className="w-full rounded-lg bg-brand-900 py-4 font-bold text-white shadow-lg transition-all hover:bg-brand-800 hover:shadow-xl disabled:cursor-not-allowed disabled:opacity-70"
+          >
+            {isRequestingCode
+              ? "Sending Fresh Code..."
+              : "Request a New Code for This Account"}
+          </button>
+
+          <Link
+            to="/logout"
+            className="block w-full rounded-lg border border-brand-200 px-6 py-4 text-center text-sm font-bold text-brand-700 transition-colors hover:bg-brand-50 hover:text-brand-900"
+          >
+            Switch Account
+          </Link>
+        </div>
+      );
+    }
+
+    if (gateState === "B") {
+      return (
+        <div className="space-y-5">
+          <div className="rounded-xl border border-brand-200 bg-brand-50/70 p-5">
+            <p className="text-sm font-semibold uppercase tracking-[0.18em] text-brand-700">
+              Continue Your Access Request
+            </p>
+            <h2 className="mt-2 text-2xl font-serif font-bold text-brand-900">
+              Use the same email to keep going
+            </h2>
+            <p className="mt-3 text-sm leading-relaxed text-gray-600">
+              You’re continuing a gallery access request for{" "}
+              <span className="font-semibold text-brand-900">{requestedEmail}</span>.
+              Sign in or create your account with this same email, then return
+              here to unlock the gallery. If you need another code, you can send
+              a fresh one below.
+            </p>
+          </div>
+
+          <div className="grid gap-3 sm:grid-cols-2">
+            <Link
+              to="/login"
+              state={signInLinkState}
+              className="rounded-lg bg-brand-900 px-6 py-4 text-center text-sm font-bold text-white shadow-lg transition-all hover:bg-brand-800"
+            >
+              Sign In
+            </Link>
+            <Link
+              to="/register"
+              state={registerLinkState}
+              className="rounded-lg border border-brand-200 px-6 py-4 text-center text-sm font-bold text-brand-700 transition-colors hover:bg-brand-50 hover:text-brand-900"
+            >
+              Create Account
+            </Link>
+          </div>
+
+          <button
+            onClick={() => handleRequestAccess(requestedEmail)}
+            disabled={isRequestingCode}
+            className="w-full rounded-lg border border-brand-200 px-6 py-4 text-sm font-bold text-brand-700 transition-colors hover:bg-brand-50 hover:text-brand-900 disabled:cursor-not-allowed disabled:opacity-70"
+          >
+            {isRequestingCode ? "Sending Fresh Code..." : "Send a Fresh Code"}
+          </button>
+
+          <button
+            onClick={handleStartOver}
+            type="button"
+            className="w-full text-sm font-semibold text-gray-500 underline-offset-4 transition-colors hover:text-brand-900 hover:underline"
+          >
+            Use a different email
+          </button>
+        </div>
+      );
+    }
+
+    if (gateState === "C") {
+      return (
+        <div className="space-y-6">
+          <div className="rounded-xl border border-brand-200 bg-brand-50/70 p-5">
+            <p className="text-sm font-semibold uppercase tracking-[0.18em] text-brand-700">
+              Final Step
+            </p>
+            <h2 className="mt-2 text-2xl font-serif font-bold text-brand-900">
+              Enter your access code
+            </h2>
+            <p className="mt-3 text-sm leading-relaxed text-gray-600">
+              {requestedEmail
+                ? `Use the code sent to ${requestedEmail} to unlock the private digital gallery.`
+                : `Request a code for ${accountEmail} and then enter it here to unlock the private digital gallery.`}
+            </p>
+          </div>
+
+          <button
+            onClick={() => handleRequestAccess(requestedEmail || accountEmail)}
+            disabled={isRequestingCode}
+            className="w-full rounded-lg border border-brand-200 px-6 py-4 text-sm font-bold text-brand-700 transition-colors hover:bg-brand-50 hover:text-brand-900 disabled:cursor-not-allowed disabled:opacity-70"
+          >
+            {isRequestingCode
+              ? "Sending Fresh Code..."
+              : requestedEmail
+                ? "Send a Fresh Code"
+                : "Request Access Code"}
+          </button>
+
+          {!requestedEmail && (
+            <p className="text-center text-sm text-gray-500">
+              We’ll send the code to <span className="font-semibold text-brand-900">{accountEmail}</span>.
+            </p>
+          )}
+
+          {requestedEmail && (
+            <button
+              onClick={handleStartOver}
+              type="button"
+              className="w-full text-sm font-semibold text-gray-500 underline-offset-4 transition-colors hover:text-brand-900 hover:underline"
+            >
+              Use a different email
+            </button>
+          )}
+
+          <form onSubmit={handleVerifyCode} className="space-y-5">
+            <input
+              type="text"
+              placeholder="A1B2-C3D4"
+              value={code}
+              onChange={(e) => setCode(e.target.value)}
+              className="w-full rounded-lg border border-gray-200 bg-gray-50 p-4 text-center font-mono text-base uppercase tracking-[0.2em] text-brand-900 outline-none transition-all placeholder-gray-300 focus:border-transparent focus:ring-2 focus:ring-accent sm:text-lg sm:tracking-[0.3em]"
+              maxLength={9}
+            />
+            <button
+              type="submit"
+              disabled={isVerifyingCode}
+              className="w-full rounded-lg bg-brand-900 py-4 font-bold text-white shadow-lg transition-all hover:bg-brand-800 hover:shadow-xl disabled:cursor-not-allowed disabled:opacity-70"
+            >
+              {isVerifyingCode ? "Verifying..." : "Verify Code"}
+            </button>
+          </form>
+        </div>
+      );
+    }
+
+    return (
+      <div className="space-y-6">
+        <div className="rounded-xl border border-brand-200 bg-brand-50/70 p-5">
+          <p className="text-sm font-semibold uppercase tracking-[0.18em] text-brand-700">
+            Private Access
+          </p>
+          <h2 className="mt-2 text-2xl font-serif font-bold text-brand-900">
+            Request your access code
+          </h2>
+          <p className="mt-3 text-sm leading-relaxed text-gray-600">
+            Use the email you plan to use for your account. You’ll sign in or
+            create that account next, then enter your emailed code to unlock the gallery.
+          </p>
+        </div>
+
+        <form
+          onSubmit={(e) => {
+            e.preventDefault();
+            void handleRequestAccess();
+          }}
+          className="space-y-4"
+        >
+          <input
+            type="email"
+            placeholder="creators@studio.com"
+            value={requestEmail}
+            onChange={(e) => setRequestEmail(e.target.value)}
+            className="w-full rounded-lg border border-gray-200 bg-gray-50 p-4 text-sm text-brand-900 outline-none focus:ring-2 focus:ring-accent"
+          />
+          <button
+            type="submit"
+            disabled={isRequestingCode}
+            className="w-full rounded-lg bg-brand-900 py-4 font-bold text-white shadow-lg transition-all hover:bg-brand-800 hover:shadow-xl disabled:cursor-not-allowed disabled:opacity-70"
+          >
+            {isRequestingCode ? "Sending Code..." : "Request Access Code"}
+          </button>
+        </form>
+
+        <div className="grid gap-3 sm:grid-cols-2">
+          <Link
+            to="/login"
+            state={signInLinkState}
+            className="rounded-lg border border-brand-200 px-6 py-4 text-center text-sm font-bold text-brand-700 transition-colors hover:bg-brand-50 hover:text-brand-900"
+          >
+            Sign In
+          </Link>
+          <Link
+            to="/register"
+            state={registerLinkState}
+            className="rounded-lg border border-brand-200 px-6 py-4 text-center text-sm font-bold text-brand-700 transition-colors hover:bg-brand-50 hover:text-brand-900"
+          >
+            Create Account
+          </Link>
+        </div>
+      </div>
+    );
   };
 
   return (
     <div
-      className="relative flex min-h-screen items-center justify-center overflow-x-hidden bg-brand-900 px-4 py-10 mobile-page-offset sm:py-12"
+      className="mobile-page-offset relative flex min-h-screen items-center justify-center overflow-x-hidden bg-brand-900 px-4 py-10 sm:py-12"
       style={{ boxSizing: "border-box" }}
     >
       <SEOHead
         title="Private Collection Access"
-        description="Request access or enter your code to unlock the private OpenÉire Studios digital collection."
+        description="Request access, sign in with the same email, and unlock the private OpenEire Studios digital collection."
         canonicalPath="/gallery-gate"
         noindex
       />
@@ -97,11 +439,16 @@ const GalleryGatePage = () => {
             </span>
           </h1>
 
-          <p className="mx-auto max-w-md text-base leading-relaxed text-brand-100 opacity-80 sm:text-lg md:mx-0">
-            Our digital stock footage vault is reserved for verified creators.
-            Request access if you need a pass, or enter your code if you
-            already have one.
-          </p>
+          <div className="space-y-3 text-brand-100/85">
+            <p className="text-base leading-relaxed sm:text-lg">
+              Unlock our private digital gallery in three simple steps.
+            </p>
+            <ol className="space-y-3 text-sm leading-relaxed sm:text-base">
+              <li>1. Request your access code.</li>
+              <li>2. Sign in or create an account with the same email.</li>
+              <li>3. Enter the code to unlock the gallery.</li>
+            </ol>
+          </div>
 
           <div className="mx-auto h-1 w-24 rounded bg-accent opacity-80 md:mx-0"></div>
 
@@ -116,94 +463,14 @@ const GalleryGatePage = () => {
         </div>
 
         <div className="w-full max-w-full rounded-2xl border border-white/10 bg-white p-6 shadow-2xl transition-all hover:scale-[1.01] sm:p-8 lg:p-10">
-          <div className="mb-10 border-b border-gray-100 pb-10">
-            <h2 className="mb-3 flex items-center gap-3 text-xl font-bold font-sans text-brand-900">
-              <span className="flex h-8 w-8 items-center justify-center rounded-full bg-gray-100 text-sm text-gray-500">
-                01
-              </span>
-              Request Access
-            </h2>
-            <p className="mb-5 text-sm text-gray-500 font-sans leading-relaxed sm:ml-11">
-              Don&apos;t have a code? We&apos;ll email you a 30-day guest pass
-              immediately.
-            </p>
-            <p className="mb-5 text-xs text-gray-400 font-sans leading-relaxed sm:ml-11">
-              By requesting access, you agree to receive this gallery-pass email
-              and any follow-up access-related messages for the private
-              collection.
-            </p>
-            <form
-              onSubmit={handleRequestAccess}
-              className="flex flex-col gap-3 sm:ml-11 sm:flex-row"
-            >
-              <input
-                type="email"
-                placeholder="creators@studio.com"
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                className="w-full flex-1 rounded-lg border border-gray-200 bg-gray-50 p-3 text-sm outline-none focus:ring-1 focus:ring-accent"
-              />
-              <button
-                type="submit"
-                disabled={isLoading}
-                className="w-full rounded-lg border border-brand-200 px-6 py-3 text-sm font-bold text-brand-700 transition-colors hover:bg-brand-50 hover:text-brand-900 sm:w-auto"
-              >
-                Send
-              </button>
-            </form>
-          </div>
-
-          <div>
-            <h2 className="mb-6 flex items-center gap-3 text-xl font-bold font-sans text-brand-900">
-              <span className="flex h-8 w-8 items-center justify-center rounded-full bg-brand-100 text-sm text-brand-700">
-                02
-              </span>
-              Enter Access Code
-            </h2>
-            <form onSubmit={handleVerifyCode} className="space-y-5">
-              <input
-                type="text"
-                placeholder="A1B2-C3D4"
-                value={code}
-                onChange={(e) => setCode(e.target.value)}
-                className="w-full rounded-lg border border-gray-200 bg-gray-50 p-4 text-center font-mono text-base uppercase tracking-[0.2em] text-brand-900 outline-none transition-all placeholder-gray-300 focus:border-transparent focus:ring-2 focus:ring-accent sm:text-lg sm:tracking-[0.3em]"
-                maxLength={9}
-              />
-              <button
-                type="submit"
-                disabled={isLoading}
-                className="w-full rounded-lg bg-brand-900 py-4 font-bold text-white shadow-lg transition-all hover:bg-brand-800 hover:shadow-xl disabled:cursor-not-allowed disabled:opacity-70"
-              >
-                {isLoading ? (
-                  <span className="flex items-center justify-center gap-2">
-                    <svg
-                      className="h-5 w-5 animate-spin text-white"
-                      xmlns="http://www.w3.org/2000/svg"
-                      fill="none"
-                      viewBox="0 0 24 24"
-                    >
-                      <circle
-                        className="opacity-25"
-                        cx="12"
-                        cy="12"
-                        r="10"
-                        stroke="currentColor"
-                        strokeWidth="4"
-                      ></circle>
-                      <path
-                        className="opacity-75"
-                        fill="currentColor"
-                        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
-                      ></path>
-                    </svg>
-                    Verifying...
-                  </span>
-                ) : (
-                  "Unlock Vault"
-                )}
-              </button>
-            </form>
-          </div>
+          {requestedEmail && gateState !== "E" && (
+            <div className="mb-6 rounded-xl border border-brand-100 bg-brand-50 px-4 py-3 text-sm text-brand-900">
+              Using{" "}
+              <span className="font-semibold">{requestedEmail}</span>{" "}
+              for gallery access
+            </div>
+          )}
+          {renderPrimaryPanel()}
         </div>
       </div>
     </div>
@@ -211,5 +478,3 @@ const GalleryGatePage = () => {
 };
 
 export default GalleryGatePage;
-
-

--- a/openeire/src/pages/GalleryGatePage.tsx
+++ b/openeire/src/pages/GalleryGatePage.tsx
@@ -18,7 +18,12 @@ import {
   setRequestedGalleryEmail,
 } from "../utils/galleryAccessFlow";
 
-type GateState = "A" | "B" | "C" | "D" | "E";
+type GateState =
+  | "loggedOutStart"
+  | "loggedOutRequested"
+  | "readyToVerify"
+  | "emailMismatch"
+  | "alreadyApproved";
 
 const normalizeEmail = (value: string): string => value.trim().toLowerCase();
 
@@ -33,14 +38,17 @@ const GalleryGatePage = () => {
   const [isRequestingCode, setIsRequestingCode] = useState(false);
   const [isVerifyingCode, setIsVerifyingCode] = useState(false);
 
+  const locationRedirect =
+    (location.state as { from?: { pathname?: string } } | undefined)?.from
+      ?.pathname ?? "";
   const pendingRedirect =
-    getPendingGalleryRedirect() ||
-    ((location.state as { from?: { pathname?: string } } | undefined)?.from
-      ?.pathname ?? "/gallery/digital");
+    locationRedirect || getPendingGalleryRedirect() || "/gallery/digital";
   const accountEmail = normalizeEmail(user?.email ?? "");
   const hasGalleryAccess = Boolean(user?.can_access_gallery);
   const emailsMatch =
-    Boolean(requestedEmail) && Boolean(accountEmail) && requestedEmail === accountEmail;
+    Boolean(requestedEmail) &&
+    Boolean(accountEmail) &&
+    requestedEmail === accountEmail;
 
   useEffect(() => {
     localStorage.removeItem("gallery_access");
@@ -56,18 +64,28 @@ const GalleryGatePage = () => {
     }
   }, [accountEmail]);
 
+  useEffect(() => {
+    if (locationRedirect) {
+      setPendingGalleryRedirect(locationRedirect);
+    }
+  }, [locationRedirect]);
+
   const gateState: GateState = useMemo(() => {
-    if (hasGalleryAccess) return "E";
-    if (!isAuthenticated && !requestedEmail) return "A";
-    if (!isAuthenticated && requestedEmail) return "B";
-    if (isAuthenticated && requestedEmail && !emailsMatch) return "D";
-    return "C";
+    if (hasGalleryAccess) return "alreadyApproved";
+    if (!isAuthenticated && !requestedEmail) return "loggedOutStart";
+    if (!isAuthenticated && requestedEmail) return "loggedOutRequested";
+    if (isAuthenticated && requestedEmail && !emailsMatch) {
+      return "emailMismatch";
+    }
+    return "readyToVerify";
   }, [emailsMatch, hasGalleryAccess, isAuthenticated, requestedEmail]);
 
   const handleRequestAccess = async (emailOverride?: string) => {
     const emailToUse = normalizeEmail(emailOverride ?? requestEmail);
     if (!emailToUse) {
-      toast.error("Enter the email address you want to use for private gallery access.");
+      toast.error(
+        "Enter the email address you want to use for private gallery access.",
+      );
       return;
     }
 
@@ -79,8 +97,8 @@ const GalleryGatePage = () => {
       setRequestEmail(emailToUse);
       setPendingGalleryRedirect(pendingRedirect);
       toast.success("Access code sent. Check your inbox for the next step.");
-      if (gateState === "D") {
-        toast.success("We’ve sent a fresh code for the signed-in account.");
+      if (gateState === "emailMismatch") {
+        toast.success("We've sent a fresh code for the signed-in account.");
       }
     } catch (error: any) {
       toast.error(getGalleryAccessRequestToastErrorMessage(error));
@@ -119,8 +137,10 @@ const GalleryGatePage = () => {
       return;
     }
 
-    if (gateState === "D") {
-      toast.error("This signed-in email does not match the email where your code was sent.");
+    if (gateState === "emailMismatch") {
+      toast.error(
+        "This signed-in email does not match the email where your code was sent.",
+      );
       return;
     }
 
@@ -153,7 +173,7 @@ const GalleryGatePage = () => {
   };
 
   const renderPrimaryPanel = () => {
-    if (gateState === "E") {
+    if (gateState === "alreadyApproved") {
       return (
         <div className="space-y-5">
           <div className="rounded-xl border border-emerald-200 bg-emerald-50 p-5">
@@ -177,7 +197,7 @@ const GalleryGatePage = () => {
       );
     }
 
-    if (gateState === "D") {
+    if (gateState === "emailMismatch") {
       return (
         <div className="space-y-5">
           <div className="rounded-xl border border-amber-200 bg-amber-50 p-5">
@@ -189,9 +209,14 @@ const GalleryGatePage = () => {
             </h2>
             <p className="mt-3 text-sm leading-relaxed text-gray-600">
               Your code was requested for{" "}
-              <span className="font-semibold text-brand-900">{requestedEmail}</span>,
-              but you are currently signed in as{" "}
-              <span className="font-semibold text-brand-900">{accountEmail}</span>.
+              <span className="font-semibold text-brand-900">
+                {requestedEmail}
+              </span>
+              , but you are currently signed in as{" "}
+              <span className="font-semibold text-brand-900">
+                {accountEmail}
+              </span>
+              .
             </p>
           </div>
 
@@ -215,7 +240,7 @@ const GalleryGatePage = () => {
       );
     }
 
-    if (gateState === "B") {
+    if (gateState === "loggedOutRequested") {
       return (
         <div className="space-y-5">
           <div className="rounded-xl border border-brand-200 bg-brand-50/70 p-5">
@@ -226,11 +251,13 @@ const GalleryGatePage = () => {
               Use the same email to keep going
             </h2>
             <p className="mt-3 text-sm leading-relaxed text-gray-600">
-              You’re continuing a gallery access request for{" "}
-              <span className="font-semibold text-brand-900">{requestedEmail}</span>.
-              Sign in or create your account with this same email, then return
-              here to unlock the gallery. If you need another code, you can send
-              a fresh one below.
+              You're continuing a gallery access request for{" "}
+              <span className="font-semibold text-brand-900">
+                {requestedEmail}
+              </span>
+              . Sign in or create your account with this same email, then
+              return here to unlock the gallery. If you need another code, you
+              can send a fresh one below.
             </p>
           </div>
 
@@ -270,7 +297,7 @@ const GalleryGatePage = () => {
       );
     }
 
-    if (gateState === "C") {
+    if (gateState === "readyToVerify") {
       return (
         <div className="space-y-6">
           <div className="rounded-xl border border-brand-200 bg-brand-50/70 p-5">
@@ -301,7 +328,11 @@ const GalleryGatePage = () => {
 
           {!requestedEmail && (
             <p className="text-center text-sm text-gray-500">
-              We’ll send the code to <span className="font-semibold text-brand-900">{accountEmail}</span>.
+              We'll send the code to{" "}
+              <span className="font-semibold text-brand-900">
+                {accountEmail}
+              </span>
+              .
             </p>
           )}
 
@@ -346,8 +377,9 @@ const GalleryGatePage = () => {
             Request your access code
           </h2>
           <p className="mt-3 text-sm leading-relaxed text-gray-600">
-            Use the email you plan to use for your account. You’ll sign in or
-            create that account next, then enter your emailed code to unlock the gallery.
+            Use the email you plan to use for your account. You'll sign in or
+            create that account next, then enter your emailed code to unlock
+            the gallery.
           </p>
         </div>
 
@@ -401,7 +433,7 @@ const GalleryGatePage = () => {
     >
       <SEOHead
         title="Private Collection Access"
-        description="Request access, sign in with the same email, and unlock the private OpenEire Studios digital collection."
+        description="Request access, sign in with the same email, and unlock the private Open\u00C9ire Studios digital collection."
         canonicalPath="/gallery-gate"
         noindex
       />
@@ -463,11 +495,10 @@ const GalleryGatePage = () => {
         </div>
 
         <div className="w-full max-w-full rounded-2xl border border-white/10 bg-white p-6 shadow-2xl transition-all hover:scale-[1.01] sm:p-8 lg:p-10">
-          {requestedEmail && gateState !== "E" && (
+          {requestedEmail && gateState !== "alreadyApproved" && (
             <div className="mb-6 rounded-xl border border-brand-100 bg-brand-50 px-4 py-3 text-sm text-brand-900">
-              Using{" "}
-              <span className="font-semibold">{requestedEmail}</span>{" "}
-              for gallery access
+              Using <span className="font-semibold">{requestedEmail}</span> for
+              gallery access
             </div>
           )}
           {renderPrimaryPanel()}

--- a/openeire/src/pages/LoginPage.tsx
+++ b/openeire/src/pages/LoginPage.tsx
@@ -1,11 +1,23 @@
-﻿import { Link, useLocation, useNavigate } from "react-router-dom";
-import React, { useState } from "react";
+import React, { useEffect, useMemo, useState } from "react";
+import { Link, useLocation, useNavigate } from "react-router-dom";
+import toast from "react-hot-toast";
 import { useAuth } from "../context/AuthContext";
 import { resendVerificationEmail } from "../services/api";
-import toast from "react-hot-toast";
 import SocialLogin from "../components/SocialLogin";
 import SEOHead from "../components/SEOHead";
-import { getLoginToastErrorMessage, getResendVerificationToastErrorMessage } from "../utils/toast";
+import {
+  getLoginToastErrorMessage,
+  getResendVerificationToastErrorMessage,
+} from "../utils/toast";
+import { getRequestedGalleryEmail } from "../utils/galleryAccessFlow";
+
+type LoginLocationState =
+  | {
+      from?: { pathname?: string };
+      prefillEmail?: string;
+      fromGalleryGate?: boolean;
+    }
+  | undefined;
 
 const LoginPage: React.FC = () => {
   const [email, setEmail] = useState("");
@@ -15,12 +27,20 @@ const LoginPage: React.FC = () => {
   const { login } = useAuth();
   const navigate = useNavigate();
   const location = useLocation();
+  const locationState = location.state as LoginLocationState;
+  const galleryIntentEmail = useMemo(
+    () => locationState?.prefillEmail || getRequestedGalleryEmail(),
+    [locationState?.prefillEmail],
+  );
   const redirectPath =
-    (
-      location.state as
-        | { from?: { pathname?: string } }
-        | undefined
-    )?.from?.pathname || "/profile";
+    locationState?.from?.pathname ||
+    (galleryIntentEmail ? "/gallery-gate" : "/profile");
+  const isGalleryIntent = redirectPath === "/gallery-gate";
+
+  useEffect(() => {
+    if (!galleryIntentEmail) return;
+    setEmail((current) => current || galleryIntentEmail);
+  }, [galleryIntentEmail]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -50,29 +70,41 @@ const LoginPage: React.FC = () => {
     }
   };
 
-  // Styles
   const inputClass =
-    "w-full bg-black border border-white/20 rounded-lg p-3 text-white focus:border-brand-500 focus:ring-1 focus:ring-brand-500 outline-none transition-all";
+    "w-full rounded-lg border border-white/20 bg-black p-3 text-white outline-none transition-all focus:border-brand-500 focus:ring-1 focus:ring-brand-500";
   const labelClass =
-    "block text-xs font-bold text-gray-500 uppercase tracking-widest mb-2";
+    "mb-2 block text-xs font-bold uppercase tracking-widest text-gray-500";
 
   return (
-    <div className="min-h-screen bg-black flex flex-col justify-center items-center p-4 pt-20 mobile-page-offset">
+    <div className="mobile-page-offset flex min-h-screen flex-col items-center justify-center bg-black p-4 pt-20">
       <SEOHead
         title="Log In"
         description="Sign in to access your OpenÉire Studios account, downloads, and order history."
         canonicalPath="/login"
         noindex
       />
-      <div className="w-full max-w-md bg-gray-900 border border-white/10 rounded-2xl shadow-2xl p-8 animate-fade-in-up">
-        <div className="text-center mb-8">
-          <h1 className="text-3xl font-serif font-bold text-white mb-2">
+      <div className="w-full max-w-md rounded-2xl border border-white/10 bg-gray-900 p-8 shadow-2xl animate-fade-in-up">
+        <div className="mb-8 text-center">
+          <h1 className="mb-2 text-3xl font-serif font-bold text-white">
             Welcome Back
           </h1>
-          <p className="text-gray-400 text-sm">
-            Sign in to access your gallery and orders.
+          <p className="text-sm text-gray-400">
+            {isGalleryIntent
+              ? "Sign in with the same email you used to request your gallery code."
+              : "Sign in to access your gallery and orders."}
           </p>
         </div>
+
+        {isGalleryIntent && (
+          <div className="mb-6 rounded-xl border border-accent/20 bg-accent/5 p-4 text-sm leading-relaxed text-brand-100">
+            <p className="font-semibold text-white">Unlock your private gallery</p>
+            <p className="mt-2">
+              Use the same email where you received your access code. Once
+              you&apos;re signed in, we&apos;ll take you back to the gallery gate
+              to enter it.
+            </p>
+          </div>
+        )}
 
         <form className="space-y-6" onSubmit={handleSubmit}>
           <div>
@@ -90,11 +122,8 @@ const LoginPage: React.FC = () => {
             />
           </div>
           <div>
-            <div className="flex justify-between items-center mb-2">
-              <label
-                htmlFor="password"
-                className="block text-xs font-bold text-gray-500 uppercase tracking-widest"
-              >
+            <div className="mb-2 flex items-center justify-between">
+              <label htmlFor="password" className={labelClass}>
                 Password
               </label>
               <Link
@@ -118,7 +147,7 @@ const LoginPage: React.FC = () => {
           <button
             type="submit"
             disabled={loading}
-            className="w-full py-3 px-4 bg-brand-500 text-paper font-bold rounded-lg hover:bg-brand-700 transition-all transform active:scale-[0.98] disabled:opacity-50 disabled:cursor-not-allowed shadow-lg"
+            className="w-full rounded-lg bg-brand-500 px-4 py-3 font-bold text-paper shadow-lg transition-all active:scale-[0.98] hover:bg-brand-700 disabled:cursor-not-allowed disabled:opacity-50"
           >
             {loading ? "Signing in..." : "Log In"}
           </button>
@@ -126,19 +155,24 @@ const LoginPage: React.FC = () => {
 
         <SocialLogin redirectPath={redirectPath} />
 
-        <div className="text-center text-sm text-gray-500 mt-8 pt-6 border-t border-white/10">
+        <div className="mt-8 border-t border-white/10 pt-6 text-center text-sm text-gray-500">
           <p className="mb-2">
-            Don't have an account?{" "}
+            Don&apos;t have an account?{" "}
             <Link
               to="/register"
-              className="text-white font-bold hover:text-brand-500 transition-colors"
+              state={{
+                from: { pathname: redirectPath },
+                prefillEmail: email || galleryIntentEmail || undefined,
+                fromGalleryGate: isGalleryIntent,
+              }}
+              className="font-bold text-white transition-colors hover:text-brand-500"
             >
               Sign up
             </Link>
           </p>
           <button
             onClick={handleResendVerification}
-            className="text-xs text-gray-600 hover:text-gray-400 underline"
+            className="text-xs text-gray-600 underline hover:text-gray-400"
           >
             Resend Verification Email
           </button>
@@ -149,6 +183,3 @@ const LoginPage: React.FC = () => {
 };
 
 export default LoginPage;
-
-
-

--- a/openeire/src/pages/RegisterPage.tsx
+++ b/openeire/src/pages/RegisterPage.tsx
@@ -1,35 +1,74 @@
-﻿import AuthForm from "../components/AuthForm";
+import { Link, useLocation } from "react-router-dom";
+import AuthForm from "../components/AuthForm";
 import SocialLogin from "../components/SocialLogin";
-import { Link } from "react-router-dom";
 import SEOHead from "../components/SEOHead";
+import { getRequestedGalleryEmail } from "../utils/galleryAccessFlow";
+
+type RegisterLocationState =
+  | {
+      from?: { pathname?: string };
+      prefillEmail?: string;
+      fromGalleryGate?: boolean;
+    }
+  | undefined;
 
 const RegisterPage = () => {
+  const location = useLocation();
+  const locationState = location.state as RegisterLocationState;
+  const galleryIntentEmail =
+    locationState?.prefillEmail || getRequestedGalleryEmail();
+  const redirectPath =
+    locationState?.from?.pathname ||
+    (galleryIntentEmail ? "/gallery-gate" : "/profile");
+  const isGalleryIntent = redirectPath === "/gallery-gate";
+
   return (
-    <div className="min-h-screen bg-black flex flex-col justify-center items-center p-4 pt-20 mobile-page-offset">
+    <div className="mobile-page-offset flex min-h-screen flex-col items-center justify-center bg-black p-4 pt-20">
       <SEOHead
         title="Create Account"
         description="Create an OpenÉire Studios account to manage orders, downloads, and gallery access."
         canonicalPath="/register"
         noindex
       />
-      <div className="w-full max-w-md bg-gray-900 border border-white/10 rounded-2xl shadow-2xl p-8 animate-fade-in-up">
-        <div className="text-center mb-8">
-          <h1 className="text-3xl font-serif font-bold text-white mb-2">
+      <div className="w-full max-w-md rounded-2xl border border-white/10 bg-gray-900 p-8 shadow-2xl animate-fade-in-up">
+        <div className="mb-8 text-center">
+          <h1 className="mb-2 text-3xl font-serif font-bold text-white">
             Create Account
           </h1>
-          <p className="text-gray-400 text-sm">
-            Join Open{"\u00C9"}ire Studios to access exclusive content.
+          <p className="text-sm text-gray-400">
+            {isGalleryIntent
+              ? "Create your account with the same email you used to request gallery access."
+              : 'Join Open\u00C9ire Studios to access exclusive content.'}
           </p>
         </div>
 
-        <AuthForm />
-        <SocialLogin />
+        {isGalleryIntent && (
+          <div className="mb-6 rounded-xl border border-accent/20 bg-accent/5 p-4 text-sm leading-relaxed text-brand-100">
+            <p className="font-semibold text-white">Private gallery access</p>
+            <p className="mt-2">
+              Use the same email where your access code was delivered. After
+              you verify your account email, you can sign in and unlock the
+              gallery.
+            </p>
+          </div>
+        )}
 
-        <div className="text-center text-sm text-gray-500 mt-6 pt-6 border-t border-white/10">
+        <AuthForm
+          initialEmail={galleryIntentEmail}
+          redirectPath={redirectPath}
+        />
+        <SocialLogin redirectPath={redirectPath} />
+
+        <div className="mt-6 border-t border-white/10 pt-6 text-center text-sm text-gray-500">
           Already have an account?{" "}
           <Link
             to="/login"
-            className="text-white font-bold hover:text-accent transition-colors"
+            state={{
+              from: { pathname: redirectPath },
+              prefillEmail: galleryIntentEmail || undefined,
+              fromGalleryGate: isGalleryIntent,
+            }}
+            className="font-bold text-white transition-colors hover:text-accent"
           >
             Log in
           </Link>
@@ -40,4 +79,3 @@ const RegisterPage = () => {
 };
 
 export default RegisterPage;
-

--- a/openeire/src/pages/VerificationPendingPage.tsx
+++ b/openeire/src/pages/VerificationPendingPage.tsx
@@ -1,45 +1,88 @@
-﻿import React from "react";
+import React from "react";
+import { Link, useLocation } from "react-router-dom";
 import { FaEnvelopeOpenText } from "react-icons/fa";
 import SEOHead from "../components/SEOHead";
 
+type VerificationPendingState =
+  | {
+      email?: string;
+      fromGalleryGate?: boolean;
+      from?: { pathname?: string };
+    }
+  | undefined;
+
 const VerificationPendingPage: React.FC = () => {
+  const location = useLocation();
+  const state = location.state as VerificationPendingState;
+  const isGalleryIntent = Boolean(state?.fromGalleryGate);
+  const email = state?.email;
+
   return (
-    <div className="min-h-screen bg-black flex justify-center items-center p-4 mobile-page-offset">
+    <div className="mobile-page-offset flex min-h-screen items-center justify-center bg-black p-4">
       <SEOHead
         title="Verify Your Email"
         description="Check your inbox to verify your OpenÉire Studios account."
         canonicalPath="/verify-pending"
         noindex
       />
-      <div className="w-full max-w-md bg-gray-900 border border-white/10 rounded-2xl shadow-2xl p-8 text-center animate-fade-in-up">
-        {/* Animated Icon */}
-        <div className="w-20 h-20 bg-accent/10 rounded-full flex items-center justify-center mx-auto mb-6 relative group">
-          <div className="absolute inset-0 bg-accent/20 rounded-full animate-ping opacity-20"></div>
-          <FaEnvelopeOpenText className="text-4xl text-accent relative z-10" />
+      <div className="w-full max-w-md rounded-2xl border border-white/10 bg-gray-900 p-8 text-center shadow-2xl animate-fade-in-up">
+        <div className="group relative mx-auto mb-6 flex h-20 w-20 items-center justify-center rounded-full bg-accent/10">
+          <div className="absolute inset-0 rounded-full bg-accent/20 opacity-20 animate-ping"></div>
+          <FaEnvelopeOpenText className="relative z-10 text-4xl text-accent" />
         </div>
 
-        <h1 className="text-3xl font-serif font-bold text-white mb-4">
+        <h1 className="mb-4 text-3xl font-serif font-bold text-white">
           Verify Your Email
         </h1>
 
-        <p className="text-gray-400 mb-6 leading-relaxed">
-          Thank you for registering. We have sent a secure verification link to
-          your email address. Please click the link to activate your account.
+        <p className="mb-6 leading-relaxed text-gray-400">
+          {isGalleryIntent
+            ? "We’ve sent a secure verification link so you can finish setting up your account and unlock the private gallery."
+            : "Thank you for registering. We have sent a secure verification link to your email address. Please click the link to activate your account."}
         </p>
 
-        <div className="bg-black/40 border border-white/5 rounded-lg p-4 text-xs text-gray-500">
+        {email && (
+          <div className="mb-6 rounded-xl border border-white/10 bg-black/30 p-4 text-sm text-brand-100">
+            Sent to <span className="font-semibold text-white">{email}</span>
+          </div>
+        )}
+
+        {isGalleryIntent && (
+          <div className="mb-6 rounded-xl border border-accent/20 bg-accent/5 p-4 text-sm leading-relaxed text-brand-100">
+            After verifying, sign in with this same email and we&apos;ll take
+            you back to the gallery gate to enter your access code.
+          </div>
+        )}
+
+        <div className="rounded-lg border border-white/5 bg-black/40 p-4 text-xs text-gray-500">
           <p>
-            Didn't receive an email? Check your spam folder or{" "}
-            <button className="text-accent hover:underline font-bold">
+            Didn&apos;t receive an email? Check your spam folder or{" "}
+            <button className="font-bold text-accent hover:underline">
               contact support
             </button>
             .
           </p>
         </div>
+
+        {isGalleryIntent && (
+          <div className="mt-6 text-sm text-gray-400">
+            Already verified?{" "}
+            <Link
+              to="/login"
+              state={{
+                from: { pathname: "/gallery-gate" },
+                prefillEmail: email,
+                fromGalleryGate: true,
+              }}
+              className="font-semibold text-white hover:text-accent"
+            >
+              Sign in and continue
+            </Link>
+          </div>
+        )}
       </div>
     </div>
   );
 };
 
 export default VerificationPendingPage;
-

--- a/openeire/src/pages/VerificationPendingPage.tsx
+++ b/openeire/src/pages/VerificationPendingPage.tsx
@@ -21,7 +21,7 @@ const VerificationPendingPage: React.FC = () => {
     <div className="mobile-page-offset flex min-h-screen items-center justify-center bg-black p-4">
       <SEOHead
         title="Verify Your Email"
-        description="Check your inbox to verify your OpenÉire Studios account."
+        description="Check your inbox to verify your Open\u00C9ire Studios account."
         canonicalPath="/verify-pending"
         noindex
       />
@@ -37,7 +37,7 @@ const VerificationPendingPage: React.FC = () => {
 
         <p className="mb-6 leading-relaxed text-gray-400">
           {isGalleryIntent
-            ? "We’ve sent a secure verification link so you can finish setting up your account and unlock the private gallery."
+            ? "We've sent a secure verification link so you can finish setting up your account and unlock the private gallery."
             : "Thank you for registering. We have sent a secure verification link to your email address. Please click the link to activate your account."}
         </p>
 
@@ -57,9 +57,9 @@ const VerificationPendingPage: React.FC = () => {
         <div className="rounded-lg border border-white/5 bg-black/40 p-4 text-xs text-gray-500">
           <p>
             Didn&apos;t receive an email? Check your spam folder or{" "}
-            <button className="font-bold text-accent hover:underline">
+            <Link to="/contact" className="font-bold text-accent hover:underline">
               contact support
-            </button>
+            </Link>
             .
           </p>
         </div>

--- a/openeire/src/pages/VerificationStatusPage.tsx
+++ b/openeire/src/pages/VerificationStatusPage.tsx
@@ -1,5 +1,5 @@
-﻿import React, { useEffect, useState } from "react";
-import { useParams, Link } from "react-router-dom";
+import React, { useEffect, useMemo, useState } from "react";
+import { Link, useParams } from "react-router-dom";
 import { verifyEmail } from "../services/api";
 import {
   FaSpinner,
@@ -8,6 +8,7 @@ import {
   FaArrowRight,
 } from "react-icons/fa";
 import SEOHead from "../components/SEOHead";
+import { getRequestedGalleryEmail } from "../utils/galleryAccessFlow";
 
 type Status = "verifying" | "success" | "error";
 
@@ -15,6 +16,8 @@ const VerificationStatusPage: React.FC = () => {
   const [status, setStatus] = useState<Status>("verifying");
   const [message, setMessage] = useState<string>("Verifying your account...");
   const { token } = useParams<{ token: string }>();
+  const requestedGalleryEmail = useMemo(() => getRequestedGalleryEmail(), []);
+  const isGalleryIntent = Boolean(requestedGalleryEmail);
 
   useEffect(() => {
     if (!token) {
@@ -40,63 +43,77 @@ const VerificationStatusPage: React.FC = () => {
   }, [token]);
 
   return (
-    <div className="min-h-screen bg-black flex justify-center items-center p-4 mobile-page-offset">
+    <div className="mobile-page-offset flex min-h-screen items-center justify-center bg-black p-4">
       <SEOHead
         title="Email Verification"
         description="Confirm your OpenÉire Studios email verification link."
         canonicalPath="/verify-email/confirm"
         noindex
       />
-      <div className="w-full max-w-md bg-gray-900 border border-white/10 rounded-2xl shadow-2xl p-10 text-center animate-fade-in-up">
-        {/* 1. LOADING STATE */}
+      <div className="w-full max-w-md rounded-2xl border border-white/10 bg-gray-900 p-10 text-center shadow-2xl animate-fade-in-up">
         {status === "verifying" && (
           <div className="flex flex-col items-center">
-            <FaSpinner className="text-4xl text-accent animate-spin mb-6" />
-            <h1 className="text-2xl font-serif font-bold text-white mb-2">
+            <FaSpinner className="mb-6 animate-spin text-4xl text-accent" />
+            <h1 className="mb-2 text-2xl font-serif font-bold text-white">
               Verifying...
             </h1>
-            <p className="text-gray-400 text-sm">
+            <p className="text-sm text-gray-400">
               Please wait while we secure your account.
             </p>
           </div>
         )}
 
-        {/* 2. SUCCESS STATE */}
         {status === "success" && (
           <div className="flex flex-col items-center">
-            <div className="w-16 h-16 bg-green-500/10 rounded-full flex items-center justify-center mb-6 border border-green-500/20">
+            <div className="mb-6 flex h-16 w-16 items-center justify-center rounded-full border border-green-500/20 bg-green-500/10">
               <FaCheckCircle className="text-4xl text-green-500" />
             </div>
-            <h1 className="text-3xl font-serif font-bold text-white mb-2">
+            <h1 className="mb-2 text-3xl font-serif font-bold text-white">
               Verified
             </h1>
-            <p className="text-gray-400 mb-8">{message}</p>
+            <p className="mb-6 text-gray-400">{message}</p>
+
+            {isGalleryIntent && (
+              <div className="mb-8 w-full rounded-xl border border-accent/20 bg-accent/5 p-4 text-sm leading-relaxed text-brand-100">
+                Your account is ready. Sign in with{" "}
+                <span className="font-semibold text-white">
+                  {requestedGalleryEmail}
+                </span>{" "}
+                and we&apos;ll take you back to the gallery gate to enter your
+                access code.
+              </div>
+            )}
 
             <Link
               to="/login"
-              className="w-full py-3 bg-brand-500 text-paper font-bold rounded-lg hover:bg-brand-700 transition-all transform active:scale-95 shadow-lg flex items-center justify-center gap-2"
+              state={{
+                from: { pathname: isGalleryIntent ? "/gallery-gate" : "/profile" },
+                prefillEmail: requestedGalleryEmail || undefined,
+                fromGalleryGate: isGalleryIntent,
+              }}
+              className="flex w-full items-center justify-center gap-2 rounded-lg bg-brand-500 py-3 font-bold text-paper shadow-lg transition-all hover:bg-brand-700 active:scale-95"
             >
-              Go to Login <FaArrowRight className="text-sm" />
+              {isGalleryIntent ? "Sign In to Continue" : "Go to Login"}{" "}
+              <FaArrowRight className="text-sm" />
             </Link>
           </div>
         )}
 
-        {/* 3. ERROR STATE */}
         {status === "error" && (
           <div className="flex flex-col items-center">
-            <div className="w-16 h-16 bg-red-500/10 rounded-full flex items-center justify-center mb-6 border border-red-500/20">
+            <div className="mb-6 flex h-16 w-16 items-center justify-center rounded-full border border-red-500/20 bg-red-500/10">
               <FaTimesCircle className="text-4xl text-red-500" />
             </div>
-            <h1 className="text-2xl font-serif font-bold text-white mb-2">
+            <h1 className="mb-2 text-2xl font-serif font-bold text-white">
               Verification Failed
             </h1>
-            <p className="text-red-400/80 mb-8 text-sm bg-red-500/5 p-3 rounded-lg border border-red-500/10 w-full">
+            <p className="mb-8 w-full rounded-lg border border-red-500/10 bg-red-500/5 p-3 text-sm text-red-400/80">
               {message}
             </p>
 
             <Link
               to="/contact"
-              className="text-gray-400 hover:text-white underline text-sm"
+              className="text-sm text-gray-400 underline hover:text-white"
             >
               Contact Support
             </Link>
@@ -108,4 +125,3 @@ const VerificationStatusPage: React.FC = () => {
 };
 
 export default VerificationStatusPage;
-

--- a/openeire/src/services/api.ts
+++ b/openeire/src/services/api.ts
@@ -24,7 +24,7 @@ const getRequestPath = (url?: string): string => {
   return normalizeApiPath(url);
 };
 
-const isGalleryAccessScopedPath = (requestPath: string): boolean =>
+export const isGalleryAccessScopedPath = (requestPath: string): boolean =>
   requestPath.startsWith("photos/") ||
   requestPath.startsWith("videos/") ||
   requestPath.startsWith("gallery/");

--- a/openeire/src/services/api.ts
+++ b/openeire/src/services/api.ts
@@ -24,41 +24,10 @@ const getRequestPath = (url?: string): string => {
   return normalizeApiPath(url);
 };
 
-export const isGalleryAccessScopedPath = (requestPath: string): boolean =>
+const isGalleryAccessScopedPath = (requestPath: string): boolean =>
   requestPath.startsWith("photos/") ||
   requestPath.startsWith("videos/") ||
   requestPath.startsWith("gallery/");
-
-const isAbsoluteUrl = (url: string): boolean =>
-  url.startsWith("http://") || url.startsWith("https://");
-
-export const isSameApiOriginRequest = (
-  url?: string,
-  baseUrl?: string,
-): boolean => {
-  if (!url || !isAbsoluteUrl(url)) {
-    return true;
-  }
-
-  if (!baseUrl) {
-    return false;
-  }
-
-  try {
-    const requestOrigin = new URL(url).origin;
-    const apiOrigin = new URL(baseUrl).origin;
-    return requestOrigin === apiOrigin;
-  } catch {
-    return false;
-  }
-};
-
-export const shouldAttachGalleryAccessToken = (
-  url?: string,
-  baseUrl?: string,
-): boolean =>
-  isGalleryAccessScopedPath(getRequestPath(url)) &&
-  isSameApiOriginRequest(url, baseUrl);
 
 const shouldSkipForbiddenRouteRedirect = (requestPath: string): boolean =>
   isGalleryAccessScopedPath(requestPath);
@@ -70,29 +39,9 @@ const shouldHandleGlobalErrorRoute = (method?: string): boolean =>
 // This handles BOTH User Authentication and Gallery Access
 api.interceptors.request.use(
   (config) => {
-    // 1. Handle User Auth (Login)
     const token = sessionStorage.getItem("accessToken");
     if (token) {
       config.headers.Authorization = `Bearer ${token}`;
-    }
-
-    // 2. Handle Gallery Guest Pass (Only for scoped digital-gallery endpoints)
-    const gallerySession = localStorage.getItem("gallery_access");
-    const apiBaseUrl =
-      typeof config.baseURL === "string" ? config.baseURL : api.defaults.baseURL;
-    if (
-      gallerySession &&
-      shouldAttachGalleryAccessToken(config.url, apiBaseUrl)
-    ) {
-      try {
-        const { code } = JSON.parse(gallerySession);
-        if (code) {
-          // This header tells the backend: "I have the password for the vault"
-          config.headers["X-Gallery-Access-Token"] = code;
-        }
-      } catch (e) {
-        console.error("Error parsing gallery access token", e);
-      }
     }
 
     return config;
@@ -113,7 +62,6 @@ api.interceptors.response.use(
 
       const statusCode = error.response?.status;
       const requestPath = getRequestPath(error.config?.url);
-
       if (
         statusCode === 403 &&
         !shouldSkipForbiddenRouteRedirect(requestPath)

--- a/openeire/src/utils/galleryAccessFlow.ts
+++ b/openeire/src/utils/galleryAccessFlow.ts
@@ -1,0 +1,61 @@
+const REQUESTED_EMAIL_KEY = "galleryRequestedEmail";
+const PENDING_CODE_KEY = "pendingGalleryAccessCode";
+const REDIRECT_KEY = "pendingGalleryRedirect";
+
+const normalizeEmail = (value?: string | null): string => {
+  return (value ?? "").trim().toLowerCase();
+};
+
+export const getRequestedGalleryEmail = (): string => {
+  return normalizeEmail(sessionStorage.getItem(REQUESTED_EMAIL_KEY));
+};
+
+export const setRequestedGalleryEmail = (email: string): void => {
+  const normalized = normalizeEmail(email);
+  if (!normalized) return;
+  sessionStorage.setItem(REQUESTED_EMAIL_KEY, normalized);
+};
+
+export const clearRequestedGalleryEmail = (): void => {
+  sessionStorage.removeItem(REQUESTED_EMAIL_KEY);
+};
+
+export const getPendingGalleryCode = (): string => {
+  return (sessionStorage.getItem(PENDING_CODE_KEY) ?? "").trim().toUpperCase();
+};
+
+export const setPendingGalleryCode = (code: string): void => {
+  const normalized = code.trim().toUpperCase();
+  if (!normalized) return;
+  sessionStorage.setItem(PENDING_CODE_KEY, normalized);
+};
+
+export const clearPendingGalleryCode = (): void => {
+  sessionStorage.removeItem(PENDING_CODE_KEY);
+};
+
+export const getPendingGalleryRedirect = (): string => {
+  const value = sessionStorage.getItem(REDIRECT_KEY) ?? "";
+  return value.startsWith("/") ? value : "";
+};
+
+export const setPendingGalleryRedirect = (path: string): void => {
+  if (!path.startsWith("/")) return;
+  sessionStorage.setItem(REDIRECT_KEY, path);
+};
+
+export const clearPendingGalleryRedirect = (): void => {
+  sessionStorage.removeItem(REDIRECT_KEY);
+};
+
+export const clearGalleryAccessIntent = (): void => {
+  clearRequestedGalleryEmail();
+  clearPendingGalleryCode();
+  clearPendingGalleryRedirect();
+};
+
+export const getGalleryAccessIntent = () => ({
+  requestedEmail: getRequestedGalleryEmail(),
+  pendingCode: getPendingGalleryCode(),
+  redirectPath: getPendingGalleryRedirect(),
+});

--- a/openeire/tests/galleryAccessScope.test.ts
+++ b/openeire/tests/galleryAccessScope.test.ts
@@ -1,8 +1,5 @@
 import { describe, expect, it } from "vitest";
-import {
-  isGalleryAccessScopedPath,
-  shouldAttachGalleryAccessToken,
-} from "../src/services/api";
+import { isGalleryAccessScopedPath } from "../src/services/api";
 
 describe("isGalleryAccessScopedPath", () => {
   it("returns true for protected gallery content endpoints", () => {
@@ -16,25 +13,5 @@ describe("isGalleryAccessScopedPath", () => {
     expect(isGalleryAccessScopedPath("checkout/order-history/")).toBe(false);
     expect(isGalleryAccessScopedPath("gallery-request/")).toBe(false);
     expect(isGalleryAccessScopedPath("gallery-verify/")).toBe(false);
-  });
-
-  it("attaches token only for same-origin scoped requests", () => {
-    const baseUrl = "http://127.0.0.1:8000/api/";
-
-    expect(shouldAttachGalleryAccessToken("gallery/", baseUrl)).toBe(true);
-    expect(shouldAttachGalleryAccessToken("photos/123/", baseUrl)).toBe(true);
-    expect(shouldAttachGalleryAccessToken("videos/456/", baseUrl)).toBe(true);
-
-    expect(
-      shouldAttachGalleryAccessToken(
-        "http://127.0.0.1:8000/api/videos/456/",
-        baseUrl,
-      ),
-    ).toBe(true);
-
-    expect(
-      shouldAttachGalleryAccessToken("https://example.com/api/videos/456/", baseUrl),
-    ).toBe(false);
-    expect(shouldAttachGalleryAccessToken("auth/profile/", baseUrl)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

This PR improves the private digital gallery gate UX while keeping the new account-scoped backend security model intact. It removes the old browser-wide trust path, adds a clearer state-driven gallery gate flow, preserves user intent through login/register, and reduces drop-off with better email prefill, resend, mismatch, and recovery paths.

## Why

After tightening gallery security, the flow became correct but could feel confusing and high-friction. Users could request a code without clearly understanding that they still needed to sign in or create an account with the same email, and some states left them without an obvious recovery path.

## Screenshots / Demo

- [x] Not needed
- [ ] Added (attach screenshots / short Loom link)

## Changes

- Backend:
  - None
- Frontend:
  - Removed browser-scoped `gallery_access` trust from API request headers
  - Updated `GalleryGuard` to rely on authenticated backend-backed `can_access_gallery`
  - Added `galleryAccessFlow` session helpers to preserve gallery intent, requested email, pending code, and return path for UX only
  - Reworked `GalleryGatePage` into a clearer state machine for logged-out, logged-in, mismatch, verify, and already-approved states
  - Added gallery-aware login/register prefills and return flow back to the gate
  - Updated verification pending/status pages so gallery users stay in the unlock journey after account creation
  - Fixed a bug where login/register could overwrite the originally requested gallery email
  - Added resend/reset actions so users are not trapped if they lose the code or used the wrong email/account
  - Cleared obsolete gallery client state safely on logout and auth refresh
- Infra/Config:
  - None

## Testing

- [ ] Django tests pass locally
- [x] React build passes locally
- [x] Manual smoke test done

Verification completed:
- `npm run build`
- Manual gallery flow testing for:
  - logged-out request flow
  - sign-in and register email prefill
  - return-to-gate behavior after auth
  - wrong-account mismatch handling
  - resend and reset actions
  - logout clearing stale gallery intent

### Manual smoke test checklist (quick)

- [x] No console errors
- [x] Forms submit correctly (success + validation errors)
- [x] API errors handled (loading/error states)
- [x] Mobile layout checked
- [x] Auth/permissions verified (if relevant)

## Risk & Rollback

Risk level: Medium

Rollback plan:

- [x] Revert PR
- [ ] Feature flag off
- [x] Hotfix path described: revert the gallery gate/auth-context/API changes to restore the prior frontend flow while leaving backend account-scoped enforcement untouched

## Notes for Reviewer (Codex/Copilot)

Focus review on:

- [x] Security (auth, permissions, file uploads, CSRF/CORS)
- [ ] Performance (N+1 queries, heavy renders, unnecessary requests)
- [x] Maintainability (naming, structure, duplicated logic)
