### PR TITLE
Harden checkout config and align account/profile form flows

### DIFF
--- a/openeire/src/components/BackToTop.tsx
+++ b/openeire/src/components/BackToTop.tsx
@@ -28,7 +28,7 @@ const BackToTop: React.FC = () => {
       {isVisible && (
         <button
           onClick={scrollToTop}
-          className="fixed bottom-24 left-4 p-3 rounded-full bg-green-600 text-white shadow-lg hover:bg-green-700 transition-all duration-300 z-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500"
+          className="fixed bottom-24 right-4 p-3 rounded-full bg-green-600 text-white shadow-lg hover:bg-green-700 transition-all duration-300 z-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-green-500"
           aria-label="Back to top"
         >
           <svg

--- a/openeire/src/components/ChangeEmailForm.tsx
+++ b/openeire/src/components/ChangeEmailForm.tsx
@@ -7,7 +7,7 @@ import { FaCheckCircle } from "react-icons/fa";
 const ChangeEmailForm: React.FC = () => {
   const [formData, setFormData] = useState({
     new_email: "",
-    password: "",
+    current_password: "",
   });
   const [status, setStatus] = useState<"idle" | "loading" | "success">("idle");
 
@@ -26,7 +26,7 @@ const ChangeEmailForm: React.FC = () => {
       await changeEmail(formData);
       setStatus("success");
       toast.success("Verification email sent!");
-      setFormData({ new_email: "", password: "" });
+      setFormData({ new_email: "", current_password: "" });
     } catch (err: any) {
       console.error(err);
       setStatus("idle");
@@ -85,7 +85,7 @@ const ChangeEmailForm: React.FC = () => {
         </div>
 
         <div>
-          <label htmlFor="password" className={labelClass}>
+          <label htmlFor="current_password" className={labelClass}>
             Current Password{" "}
             <span className="text-[10px] text-gray-600 normal-case ml-1">
               (Required)
@@ -93,10 +93,10 @@ const ChangeEmailForm: React.FC = () => {
           </label>
           <input
             type="password"
-            name="password"
-            id="password"
+            name="current_password"
+            id="current_password"
             required
-            value={formData.password}
+            value={formData.current_password}
             onChange={handleChange}
             className={inputClass}
           />

--- a/openeire/src/components/CheckoutForm.tsx
+++ b/openeire/src/components/CheckoutForm.tsx
@@ -49,6 +49,7 @@ interface CheckoutFormProps {
   accountEmail?: string | null;
   successContext: CheckoutSuccessContext;
   isStripeContextAvailable?: boolean;
+  paymentUnavailableMessage?: string | null;
 }
 
 interface CheckoutPaymentSectionProps {
@@ -225,6 +226,7 @@ const CheckoutForm: React.FC<CheckoutFormProps> = ({
   accountEmail,
   successContext,
   isStripeContextAvailable = false,
+  paymentUnavailableMessage = null,
 }) => {
   const { hasPhysicalItems } = useCart();
   const formRef = useRef<HTMLFormElement | null>(null);
@@ -252,7 +254,7 @@ const CheckoutForm: React.FC<CheckoutFormProps> = ({
       );
       if (hasExistingInput) return;
 
-      let initialCountry = initialData.default_country || "";
+      let initialCountry = initialData.country || "";
 
       if (
         hasPhysicalItems &&
@@ -539,7 +541,13 @@ const CheckoutForm: React.FC<CheckoutFormProps> = ({
         </div>
       )}
 
-      {isStripeContextAvailable ? (
+      {paymentUnavailableMessage ? (
+        <div className="bg-gray-900 border border-amber-500/20 rounded-2xl p-6 md:p-8">
+          <div className="rounded-xl border border-amber-500/20 bg-amber-500/10 p-4 text-sm font-bold text-amber-200">
+            {paymentUnavailableMessage}
+          </div>
+        </div>
+      ) : isStripeContextAvailable ? (
         <CheckoutPaymentSection
           hasPhysicalItems={hasPhysicalItems}
           shippingDetails={shippingDetails}

--- a/openeire/src/components/EditProfileForm.tsx
+++ b/openeire/src/components/EditProfileForm.tsx
@@ -18,7 +18,7 @@ const EditProfileForm: React.FC<EditProfileFormProps> = ({ initialData }) => {
   const [countries, setCountries] = useState<Country[]>([]);
   const [formData, setFormData] = useState({
     ...initialData,
-    default_country: initialData.default_country || "",
+    country: initialData.country || "",
   });
   const [loading, setLoading] = useState(false);
 
@@ -41,7 +41,7 @@ const EditProfileForm: React.FC<EditProfileFormProps> = ({ initialData }) => {
     // Clean data for Django
     const payload = {
       ...formData,
-      country: formData.default_country || null,
+      country: formData.country || null,
       phone_number: formData.default_phone_number || null,
     };
 
@@ -183,8 +183,8 @@ const EditProfileForm: React.FC<EditProfileFormProps> = ({ initialData }) => {
             <div>
               <label className={labelClass}>Country</label>
               <select
-                name="default_country"
-                value={formData.default_country || ""}
+                name="country"
+                value={formData.country || ""}
                 onChange={handleChange}
                 className={`${inputClass} appearance-none cursor-pointer`}
               >

--- a/openeire/src/context/CartContext.tsx
+++ b/openeire/src/context/CartContext.tsx
@@ -73,7 +73,7 @@ interface CartContextType {
   itemCount: number;
   cartTotal: number;
   clearCart: () => void;
-  hasPhysicalItems?: boolean;
+  hasPhysicalItems: boolean;
 }
 
 const CartContext = createContext<CartContextType | undefined>(undefined);

--- a/openeire/src/pages/ArtPrintsFAQPage.tsx
+++ b/openeire/src/pages/ArtPrintsFAQPage.tsx
@@ -15,13 +15,13 @@ const ArtPrintsFAQPage: React.FC = () => {
   const printFaqs: FAQEntry[] = [
     {
       question: "Do you ship fine art prints to the United States?",
-      answerLead: "Yes, prints are available to buyers in the United States.",
+      answerLead: "Yes, we ship prints to the United States.",
       answerParagraphs: [
-        "Orders still follow the current print workflow, with shipping handled through checkout rather than through a separate manual quote by default.",
+        "You can order directly through the site, and shipping is calculated at checkout based on your location and the print.",
       ],
       bridge: (
         <>
-          For the broader United States print context, visit the{" "}
+          For more details, see the{" "}
           <Link
             to="/us/fine-art-prints"
             className="text-accent hover:text-white"
@@ -32,14 +32,15 @@ const ArtPrintsFAQPage: React.FC = () => {
         </>
       ),
       schemaAnswer:
-        "Yes, prints are available to buyers in the United States. Orders still follow the current print workflow, with shipping handled through checkout rather than through a separate manual quote by default. For the broader United States print context, visit /us/fine-art-prints.",
+        "Yes, prints are available in the United States. Orders can be placed directly through the site, with shipping calculated at checkout.",
     },
+
     {
       question: "What kind of prints do you sell?",
       answerLead:
-        "OpenEire Studios sells premium fine art prints based on aerial photography.",
+        "We sell premium wall art prints created from original aerial & ground photography.",
       answerParagraphs: [
-        "The collection is positioned as physical wall art for collectors, interiors, and gifting rather than generic poster merchandise.",
+        "Each piece is designed to feel like a finished artwork rather than a generic poster, with a focus on composition, atmosphere, and perspective.",
       ],
       bridge: (
         <>
@@ -47,7 +48,7 @@ const ArtPrintsFAQPage: React.FC = () => {
           <Link to="/art-prints" className="text-accent hover:text-white">
             art prints page
           </Link>{" "}
-          or open the{" "}
+          or browse the{" "}
           <Link to="/gallery/physical" className="text-accent hover:text-white">
             print gallery
           </Link>
@@ -55,18 +56,18 @@ const ArtPrintsFAQPage: React.FC = () => {
         </>
       ),
       schemaAnswer:
-        "OpenEire Studios sells premium fine art prints based on aerial photography. The collection is positioned as physical wall art for collectors, interiors, and gifting rather than generic poster merchandise. Start with /art-prints or open the print gallery.",
+        "OpenEire Studios sells premium wall art prints created from original aerial photography, designed as finished artworks rather than generic posters.",
     },
+
     {
       question: "Are these original aerial photography prints?",
-      answerLead:
-        "Yes. The print collection is built around original aerial photography curated by OpenEire Studios.",
+      answerLead: "Yes — every print comes from original aerial photography.",
       answerParagraphs: [
-        "That is part of what separates the collection from more generic wall art marketplaces.",
+        "The collection is built from work captured and curated by OpenEire Studios, not sourced from stock libraries.",
       ],
       bridge: (
         <>
-          If you want the collection overview, go to the{" "}
+          You can explore the full collection on the{" "}
           <Link to="/art-prints" className="text-accent hover:text-white">
             art prints page
           </Link>
@@ -74,18 +75,18 @@ const ArtPrintsFAQPage: React.FC = () => {
         </>
       ),
       schemaAnswer:
-        "Yes. The print collection is built around original aerial photography curated by OpenEire Studios. That is part of what separates the collection from more generic wall art marketplaces. If you want the collection overview, go to /art-prints.",
+        "Yes. All prints are based on original aerial photography created and curated by OpenEire Studios.",
     },
+
     {
       question: "Are prints suitable for gifting?",
-      answerLead:
-        "Yes. The collection is designed to work well as a more distinctive gift choice.",
+      answerLead: "Yes, they work very well as a gift.",
       answerParagraphs: [
-        "The overall positioning is premium and interior-led, which makes the prints better suited to thoughtful gifting than off-the-shelf decor.",
+        "Because the prints are more distinctive and design-led, they tend to feel more considered than standard wall decor.",
       ],
       bridge: (
         <>
-          If you need help choosing a piece, use the{" "}
+          If you're unsure what to choose, use the{" "}
           <Link to="/contact" className="text-accent hover:text-white">
             contact page
           </Link>
@@ -93,14 +94,14 @@ const ArtPrintsFAQPage: React.FC = () => {
         </>
       ),
       schemaAnswer:
-        "Yes. The collection is designed to work well as a more distinctive gift choice. The overall positioning is premium and interior-led, which makes the prints better suited to thoughtful gifting than off-the-shelf decor. If you need help choosing a piece, use /contact.",
+        "Yes. These prints are well suited for gifting because they offer a more distinctive and design-led alternative to standard wall decor.",
     },
+
     {
       question: "What sizes or formats are available?",
-      answerLead:
-        "Available sizes and formats depend on the specific print listing.",
+      answerLead: "Sizes and formats vary depending on the individual print.",
       answerParagraphs: [
-        "This FAQ page does not invent fixed dimensions because product pages remain the source of truth for the options attached to each piece.",
+        "Each product page shows the exact options available for that piece, including dimensions and format.",
       ],
       bridge: (
         <>
@@ -108,41 +109,41 @@ const ArtPrintsFAQPage: React.FC = () => {
           <Link to="/gallery/physical" className="text-accent hover:text-white">
             print gallery
           </Link>{" "}
-          for the current print options.
+          to see current options.
         </>
       ),
       schemaAnswer:
-        "Available sizes and formats depend on the specific print listing. This FAQ page does not invent fixed dimensions because product pages remain the source of truth for the options attached to each piece. Browse /gallery/physical for the current print options.",
+        "Sizes and formats vary by print. Each product page shows the available options for that specific piece.",
     },
+
     {
       question: "Are prints framed?",
-      answerLead:
-        "Framing should be treated as product-specific rather than assumed across the whole collection.",
+      answerLead: "Framing depends on the specific print you choose.",
       answerParagraphs: [
-        "Where framing or presentation details matter, the listing itself or a direct enquiry is the safest source of truth.",
+        "Some prints may be available with framing options, while others are supplied unframed.",
       ],
       bridge: (
         <>
-          If you need certainty before ordering, ask through the{" "}
+          Check the product listing or{" "}
           <Link to="/contact" className="text-accent hover:text-white">
-            contact page
-          </Link>
-          .
+            get in touch
+          </Link>{" "}
+          if you need to confirm before ordering.
         </>
       ),
       schemaAnswer:
-        "Framing should be treated as product-specific rather than assumed across the whole collection. Where framing or presentation details matter, the listing itself or a direct enquiry is the safest source of truth. If you need certainty before ordering, ask through /contact.",
+        "Framing depends on the individual print. Check the product listing or contact the studio for confirmation.",
     },
+
     {
       question: "Are these limited edition?",
-      answerLead:
-        "Do not assume every print is a limited edition unless the specific product says so.",
+      answerLead: "Some prints may be limited, but not all are.",
       answerParagraphs: [
-        "The collection is premium, but edition status should come from the individual print details rather than a blanket site-wide claim.",
+        "If a print is a limited edition, it will be clearly stated on the product page.",
       ],
       bridge: (
         <>
-          The best next step is to inspect the listing in the{" "}
+          The best way to check is directly in the{" "}
           <Link to="/gallery/physical" className="text-accent hover:text-white">
             print gallery
           </Link>
@@ -150,33 +151,34 @@ const ArtPrintsFAQPage: React.FC = () => {
         </>
       ),
       schemaAnswer:
-        "Do not assume every print is a limited edition unless the specific product says so. The collection is premium, but edition status should come from the individual print details rather than a blanket site-wide claim. The best next step is to inspect the listing in the print gallery.",
+        "Some prints may be limited edition. This is specified on the individual product page where applicable.",
     },
+
     {
       question: "How is shipping handled for print orders?",
-      answerLead: "Shipping is handled through the current checkout flow.",
+      answerLead: "Shipping is handled during checkout.",
       answerParagraphs: [shippingAnswer],
       bridge: (
         <>
-          For a more specific print enquiry, continue to the{" "}
+          If you have a specific question, use the{" "}
           <Link to="/contact" className="text-accent hover:text-white">
             contact page
           </Link>
           .
         </>
       ),
-      schemaAnswer: `Shipping is handled through the current checkout flow. ${shippingAnswer} For a more specific print enquiry, continue to /contact.`,
+      schemaAnswer: `Shipping is handled during checkout. ${shippingAnswer}`,
     },
+
     {
       question: "When is shipping calculated for print orders?",
-      answerLead:
-        "Shipping is calculated during checkout rather than shown as a fixed site-wide price in advance.",
+      answerLead: "Shipping is calculated at checkout.",
       answerParagraphs: [
-        "That keeps the order flow tied to the actual print options and delivery details attached to the piece you are buying.",
+        "The final cost depends on the print, size, and delivery location.",
       ],
       bridge: (
         <>
-          If you want to browse available pieces first, open the{" "}
+          You can browse prints first in the{" "}
           <Link to="/gallery/physical" className="text-accent hover:text-white">
             print gallery
           </Link>
@@ -184,25 +186,24 @@ const ArtPrintsFAQPage: React.FC = () => {
         </>
       ),
       schemaAnswer:
-        "Shipping is calculated during checkout rather than shown as a fixed site-wide price in advance. That keeps the order flow tied to the actual print options and delivery details attached to the piece you are buying. If you want to browse available pieces first, open /gallery/physical.",
+        "Shipping is calculated at checkout based on the print, size, and delivery location.",
     },
+
     {
       question: `Do you offer free shipping in ${FREE_SHIPPING_COUNTRY_LABEL}?`,
       answerLead: FREE_SHIPPING_PROMO_ENABLED
-        ? `Yes. Eligible ${FREE_SHIPPING_COUNTRY_LABEL} print orders over EUR ${FREE_SHIPPING_THRESHOLD.toFixed(
+        ? `Yes. Orders over EUR ${FREE_SHIPPING_THRESHOLD.toFixed(
             2,
-          )} qualify for free shipping under the current offer.`
-        : `There is no active free-shipping promotion for ${FREE_SHIPPING_COUNTRY_LABEL} at the moment.`,
+          )} qualify for free shipping in ${FREE_SHIPPING_COUNTRY_LABEL}.`
+        : `There is no active free shipping offer at the moment.`,
       answerParagraphs: FREE_SHIPPING_PROMO_ENABLED
-        ? [
-            "The current threshold is handled through the existing checkout flow, so the order details still remain the source of truth at purchase time.",
-          ]
+        ? ["The discount is applied automatically during checkout."]
         : [
-            "Shipping is still handled through checkout, where the current delivery cost is confirmed during the order flow.",
+            "Shipping costs are shown during checkout before you complete your order.",
           ],
       bridge: (
         <>
-          For the current print-buying flow, start with the{" "}
+          You can start browsing on the{" "}
           <Link to="/art-prints" className="text-accent hover:text-white">
             art prints page
           </Link>
@@ -210,43 +211,21 @@ const ArtPrintsFAQPage: React.FC = () => {
         </>
       ),
       schemaAnswer: FREE_SHIPPING_PROMO_ENABLED
-        ? `Yes. Eligible ${FREE_SHIPPING_COUNTRY_LABEL} print orders over EUR ${FREE_SHIPPING_THRESHOLD.toFixed(
+        ? `Orders over EUR ${FREE_SHIPPING_THRESHOLD.toFixed(
             2,
-          )} qualify for free shipping under the current offer. The current threshold is handled through the existing checkout flow, so the order details still remain the source of truth at purchase time. For the current print-buying flow, start with /art-prints.`
-        : `There is no active free-shipping promotion for ${FREE_SHIPPING_COUNTRY_LABEL} at the moment. Shipping is still handled through checkout, where the current delivery cost is confirmed during the order flow. For the current print-buying flow, start with /art-prints.`,
+          )} qualify for free shipping in ${FREE_SHIPPING_COUNTRY_LABEL}.`
+        : `There is no active free shipping promotion at the moment.`,
     },
-    {
-      question: "Do you ship art prints internationally?",
-      answerLead:
-        "Yes, international buyers can order prints where the current checkout and fulfilment flow supports delivery.",
-      answerParagraphs: [
-        "The site keeps shipping tied to the actual checkout process rather than making blanket promises that may vary by destination.",
-      ],
-      bridge: (
-        <>
-          If you are buying from the United States, visit the{" "}
-          <Link
-            to="/us/fine-art-prints"
-            className="text-accent hover:text-white"
-          >
-            United States fine art prints page
-          </Link>
-          .
-        </>
-      ),
-      schemaAnswer:
-        "Yes, international buyers can order prints where the current checkout and fulfilment flow supports delivery. The site keeps shipping tied to the actual checkout process rather than making blanket promises that may vary by destination. If you are buying from the United States, visit /us/fine-art-prints.",
-    },
+
     {
       question: "How long does print fulfilment usually take?",
-      answerLead:
-        "Fulfilment timing depends on the specific order rather than being treated as a fixed promise across the whole collection.",
+      answerLead: "Fulfilment time depends on the print and delivery location.",
       answerParagraphs: [
-        "Because prints are produced through the current print workflow, the safest expectation-setting comes from the order flow itself or a direct enquiry where timing matters.",
+        "Most orders are produced and shipped within a few working days, with delivery times depending on the shipping method.",
       ],
       bridge: (
         <>
-          If timing is important before you order, use the{" "}
+          If timing matters, use the{" "}
           <Link to="/contact" className="text-accent hover:text-white">
             contact page
           </Link>
@@ -254,26 +233,27 @@ const ArtPrintsFAQPage: React.FC = () => {
         </>
       ),
       schemaAnswer:
-        "Fulfilment timing depends on the specific order rather than being treated as a fixed promise across the whole collection. Because prints are produced through the current print workflow, the safest expectation-setting comes from the order flow itself or a direct enquiry where timing matters. If timing is important before you order, use /contact.",
+        "Fulfilment time depends on the print and delivery location. Most orders are produced within a few working days.",
     },
+
     {
       question: "What should I do if I need help before ordering?",
       answerLead:
-        "Use the contact page if you want help choosing a print or clarifying ordering details before checkout.",
+        "You can contact the studio directly before placing an order.",
       answerParagraphs: [
-        "That is the best route when the decision depends on the piece itself, presentation questions, or delivery confidence before purchase.",
+        "This is the best option if you need help choosing a piece or want clarity on sizing, framing, or delivery.",
       ],
       bridge: (
         <>
-          Go straight to the{" "}
+          Go to the{" "}
           <Link to="/contact" className="text-accent hover:text-white">
             contact page
           </Link>{" "}
-          if you want a direct conversation.
+          to get in touch.
         </>
       ),
       schemaAnswer:
-        "Use the contact page if you want help choosing a print or clarifying ordering details before checkout. That is the best route when the decision depends on the piece itself, presentation questions, or delivery confidence before purchase. Go straight to /contact if you want a direct conversation.",
+        "Use the contact page if you need help choosing a print or clarifying details before ordering.",
     },
   ];
 

--- a/openeire/src/pages/CheckoutPage.tsx
+++ b/openeire/src/pages/CheckoutPage.tsx
@@ -22,7 +22,11 @@ import { EMPTY_SHIPPING_DETAILS, ShippingDetails } from "../types/checkout";
 import { buildAnalyticsItemFromCartItem } from "../lib/ecommerceAnalytics";
 import SEOHead from "../components/SEOHead";
 
-const stripePromise = loadStripe(import.meta.env.VITE_STRIPE_PUBLIC_KEY);
+const stripePublicKey = import.meta.env.VITE_STRIPE_PUBLIC_KEY?.trim() ?? "";
+const isStripeConfigured = stripePublicKey.length > 0;
+const stripePromise = isStripeConfigured ? loadStripe(stripePublicKey) : null;
+const STRIPE_CONFIGURATION_ERROR =
+  "Checkout is temporarily unavailable because payment configuration is incomplete. Please try again later.";
 
 const flattenApiErrors = (value: unknown, path = ""): string[] => {
   if (typeof value === "string") {
@@ -261,6 +265,14 @@ const CheckoutPage: React.FC = () => {
         if (isCancelled || requestId !== latestIntentRequestId.current) return;
         resetCheckoutIntentState();
         setCheckoutError(null);
+        setIsUpdatingIntent(false);
+        return;
+      }
+
+      if (!isStripeConfigured) {
+        if (isCancelled || requestId !== latestIntentRequestId.current) return;
+        resetCheckoutIntentState();
+        setCheckoutError(STRIPE_CONFIGURATION_ERROR);
         setIsUpdatingIntent(false);
         return;
       }
@@ -508,6 +520,9 @@ const CheckoutPage: React.FC = () => {
                 accountEmail={profileData?.email ?? null}
                 successContext={checkoutSuccessContext}
                 isStripeContextAvailable={false}
+                paymentUnavailableMessage={
+                  isStripeConfigured ? null : STRIPE_CONFIGURATION_ERROR
+                }
               />
             )}
             {checkoutError && (

--- a/openeire/src/pages/CheckoutPage.tsx
+++ b/openeire/src/pages/CheckoutPage.tsx
@@ -272,7 +272,7 @@ const CheckoutPage: React.FC = () => {
       if (!isStripeConfigured) {
         if (isCancelled || requestId !== latestIntentRequestId.current) return;
         resetCheckoutIntentState();
-        setCheckoutError(STRIPE_CONFIGURATION_ERROR);
+        setCheckoutError(null);
         setIsUpdatingIntent(false);
         return;
       }

--- a/openeire/src/pages/ContactPage.tsx
+++ b/openeire/src/pages/ContactPage.tsx
@@ -214,6 +214,7 @@ const ContactPage = () => {
                       <select
                         name="subject"
                         id="subject"
+                        required
                         value={formData.subject}
                         onChange={handleChange}
                         className={`${inputClass} appearance-none cursor-pointer`}

--- a/openeire/src/services/api.ts
+++ b/openeire/src/services/api.ts
@@ -89,7 +89,7 @@ export interface UserProfile {
   default_town: string | null;
   default_county: string | null;
   default_postcode: string | null;
-  default_country: string | null;
+  country: string | null;
 }
 
 export interface UserProfileUpdateData {
@@ -103,7 +103,7 @@ export interface UserProfileUpdateData {
   default_town?: string | null;
   default_county?: string | null;
   default_postcode?: string | null;
-  default_country?: string | null;
+  country?: string | null;
 }
 
 interface RegisterData {
@@ -235,7 +235,7 @@ export interface OrderHistory {
 
 interface ChangeEmailData {
   new_email: string;
-  password: string;
+  current_password: string;
 }
 
 interface VerifyEmailResponse {
@@ -737,7 +737,7 @@ export const sendContactMessage = async (contactData: ContactData) => {
 };
 
 export const changeEmail = async (data: ChangeEmailData) => {
-  const response = await api.post('auth/email/change', data);
+  const response = await api.put("auth/email/change/", data);
   return response.data;
 };
 

--- a/openeire/src/types/analytics.d.ts
+++ b/openeire/src/types/analytics.d.ts
@@ -8,6 +8,7 @@ declare global {
 
   interface ImportMetaEnv {
     readonly VITE_GA_MEASUREMENT_ID?: string;
+    readonly VITE_STRIPE_PUBLIC_KEY?: string;
   }
 }
 

--- a/openeire/src/utils/toast.ts
+++ b/openeire/src/utils/toast.ts
@@ -259,7 +259,7 @@ export const getPasswordChangeToastErrorMessage = (error: unknown): string =>
 export const getEmailChangeToastErrorMessage = (error: unknown): string =>
   getToastErrorMessage(error, {
     fallback: "Could not update your email right now. Please try again.",
-    fieldPriority: ["new_email", "password", "detail", "non_field_errors"],
+    fieldPriority: ["new_email", "current_password", "detail", "non_field_errors"],
     statusMessages: {
       401: "Please confirm your current password and try again.",
       429: "Too many email change attempts. Please wait a moment and try again.",
@@ -279,7 +279,7 @@ export const getProfileUpdateToastErrorMessage = (error: unknown): string =>
       "default_town",
       "default_county",
       "default_postcode",
-      "default_country",
+      "country",
       "detail",
       "non_field_errors",
     ],


### PR DESCRIPTION
## Summary

This PR hardens the frontend around checkout/payment configuration and aligns several account/profile flows with the current backend contract.

## What changed

- Added an explicit Stripe publishable key guard on checkout
- Prevented Stripe Elements from rendering when `VITE_STRIPE_PUBLIC_KEY` is missing
- Added a clear checkout-unavailable message instead of allowing a cryptic runtime failure
- Updated the change-email form/client to use `PUT auth/email/change/`
- Switched the change-email payload to `current_password`
- Replaced remaining frontend `default_country` usage in the active profile/checkout flow with `country`
- Fixed physical checkout country prefill to use the backend canonical field
- Required a contact subject before contact form submission
- Tightened `hasPhysicalItems` typing in cart context
- Updated toast field mappings to match backend validation field names
- Moved the BackToTop button from left to right
- Refreshed Art Prints FAQ copy/content

## Why

These changes close launch-critical frontend risks:
- checkout should fail clearly if Stripe is misconfigured
- change-email should match the backend method/payload
- profile country should prefill correctly in checkout
- contact form should not allow an empty subject to reach the API

## Files of note

- `openeire/src/pages/CheckoutPage.tsx`
- `openeire/src/components/CheckoutForm.tsx`
- `openeire/src/components/ChangeEmailForm.tsx`
- `openeire/src/components/EditProfileForm.tsx`
- `openeire/src/services/api.ts`
- `openeire/src/utils/toast.ts`

## Verification

- Frontend build passes with the Stripe guard changes
- Checkout now shows a clear unavailable state when Stripe config is missing
- Change-email contract is aligned with the backend
- Checkout/profile country flow now uses `country`

## Notes

This PR also includes small unrelated frontend content/UI changes:
- BackToTop position adjustment
- Art Prints FAQ copy refresh
