### PR TITLE
Make GA4 consent-aware with Iubenda-safe retry behavior

### DIFF
--- a/openeire/src/App.tsx
+++ b/openeire/src/App.tsx
@@ -18,7 +18,12 @@ import ServerErrorPage from "./pages/ServerErrorPage";
 import { BreadcrumbProvider } from "./context/BreadcrumbContext";
 import { Toaster } from "react-hot-toast";
 import { subscribeToErrorRoute } from "./utils/errorRouting";
-import { bootstrapIubendaConsentDatabase } from "./utils/iubendaConsent";
+import {
+  bootstrapIubendaConsentDatabase,
+  registerIubendaConsentGrantedCallback,
+  shouldDeferGAUntilIubendaConsent,
+} from "./utils/iubendaConsent";
+import { initGA } from "./lib/analytics";
 
 // ================= LAZY IMPORTS =================
 // These are split into separate JS chunks by Vite and downloaded only when needed.
@@ -89,6 +94,18 @@ function App() {
 
   useEffect(() => {
     bootstrapIubendaConsentDatabase();
+  }, []);
+
+  useEffect(() => {
+    const unsubscribe = registerIubendaConsentGrantedCallback(() => {
+      void initGA();
+    });
+
+    if (!shouldDeferGAUntilIubendaConsent()) {
+      void initGA();
+    }
+
+    return unsubscribe;
   }, []);
 
   useEffect(() => {

--- a/openeire/src/App.tsx
+++ b/openeire/src/App.tsx
@@ -97,11 +97,14 @@ function App() {
   }, []);
 
   useEffect(() => {
-    const unsubscribe = registerIubendaConsentGrantedCallback(() => {
-      void initGA();
-    });
+    const shouldDefer = shouldDeferGAUntilIubendaConsent();
+    const unsubscribe = shouldDefer
+      ? registerIubendaConsentGrantedCallback(() => {
+          void initGA();
+        })
+      : () => undefined;
 
-    if (!shouldDeferGAUntilIubendaConsent()) {
+    if (!shouldDefer) {
       void initGA();
     }
 

--- a/openeire/src/lib/analytics.ts
+++ b/openeire/src/lib/analytics.ts
@@ -39,7 +39,11 @@ const loadGtagScript = (measurementId: string): Promise<void> => {
 
   if (!gaScriptPromise) {
     gaScriptPromise = new Promise<void>((resolve, reject) => {
-      const script = existingScript ?? document.createElement("script");
+      if (existingScript) {
+        existingScript.remove();
+      }
+
+      const script = document.createElement("script");
 
       script.id = GA_SCRIPT_ID;
       script.async = true;
@@ -52,13 +56,12 @@ const loadGtagScript = (measurementId: string): Promise<void> => {
         resolve();
       };
       script.onerror = () => {
-        console.error("Failed to load Google Analytics script:", script.src);
+        script.dataset.loaded = "error";
+        console.warn("Failed to load Google Analytics script:", script.src);
         reject(new Error(`Failed to load Google Analytics script: ${script.src}`));
       };
 
-      if (!existingScript) {
-        document.head.appendChild(script);
-      }
+      document.head.appendChild(script);
     }).catch((error) => {
       gaScriptPromise = null;
       throw error;
@@ -87,10 +90,13 @@ export const initGA = (): Promise<void> => {
       });
       gaInitialized = true;
     })
-.catch((error) => {
-  console.error("GA initialisation failed:", error);
-  gaInitialized = false;
-})
+    .catch((error) => {
+      console.warn(
+        "GA initialisation deferred after script load failure; it will retry on later navigation or events.",
+        error,
+      );
+      gaInitialized = false;
+    })
     .finally(() => {
       gaInitPromise = null;
     });
@@ -102,6 +108,7 @@ export const trackPageView = (path: string, title?: string): void => {
   const measurementId = getMeasurementId();
   if (!measurementId || typeof window === "undefined") return;
 
+  void initGA();
   ensureGtagStub();
 
   const pageTitle = title ?? document.title;
@@ -118,6 +125,7 @@ export const trackEvent = (
   const measurementId = getMeasurementId();
   if (!measurementId || typeof window === "undefined") return;
 
+  void initGA();
   ensureGtagStub();
   window.gtag?.("event", name, params);
 };

--- a/openeire/src/lib/analytics.ts
+++ b/openeire/src/lib/analytics.ts
@@ -1,4 +1,6 @@
-﻿const GA_SCRIPT_ID = "openeire-ga-script";
+import { isAnalyticsConsentGranted } from "../utils/iubendaConsent";
+
+const GA_SCRIPT_ID = "openeire-ga-script";
 
 let gaInitialized = false;
 let gaInitPromise: Promise<void> | null = null;
@@ -107,6 +109,7 @@ export const initGA = (): Promise<void> => {
 export const trackPageView = (path: string, title?: string): void => {
   const measurementId = getMeasurementId();
   if (!measurementId || typeof window === "undefined") return;
+  if (!isAnalyticsConsentGranted()) return;
 
   void initGA();
   ensureGtagStub();
@@ -124,9 +127,9 @@ export const trackEvent = (
 ): void => {
   const measurementId = getMeasurementId();
   if (!measurementId || typeof window === "undefined") return;
+  if (!isAnalyticsConsentGranted()) return;
 
   void initGA();
   ensureGtagStub();
   window.gtag?.("event", name, params);
 };
-

--- a/openeire/src/main.tsx
+++ b/openeire/src/main.tsx
@@ -7,7 +7,6 @@ import { AuthProvider } from "./context/AuthContext";
 import { CartProvider } from "./context/CartContext";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import AppErrorBoundary from "./components/AppErrorBoundary";
-import { initGA } from "./lib/analytics";
 const CHUNK_RELOAD_STORAGE_KEY = "openeire:chunk-reload-attempted";
 
 const queryClient = new QueryClient();
@@ -35,8 +34,6 @@ if (window.sessionStorage.getItem(CHUNK_RELOAD_STORAGE_KEY) === "1") {
     { once: true },
   );
 }
-
-void initGA();
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>

--- a/openeire/src/utils/iubendaConsent.ts
+++ b/openeire/src/utils/iubendaConsent.ts
@@ -55,6 +55,25 @@ const consentGrantedListeners = new Set<IubendaConsentGrantedCallback>();
 const CONSENT_SCRIPT_SRC = "https://cdn.iubenda.com/cons/iubenda_cons.js";
 const DEFAULT_LEGAL_NOTICE_IDENTIFIERS = ["privacy_policy", "cookie_policy"];
 const IUBENDA_CALLBACK_BRIDGE_MARKER = "__openeireCallbackBridgeInstalled";
+const ANALYTICS_CONSENT_KEYS = new Set([
+  "analytics",
+  "analytics_storage",
+  "measurement",
+  "measurements",
+  "performance",
+  "statistics",
+  "statistical",
+]);
+const CONSENT_CONTAINER_KEYS = [
+  "consents",
+  "preferences",
+  "purposes",
+  "purposeConsents",
+  "categories",
+  "services",
+] as const;
+let analyticsConsentGranted = false;
+let callbackBridgeRetryId: number | null = null;
 
 const ensureConsentInstructionQueue = () => {
   window._iub = window._iub || {};
@@ -83,22 +102,132 @@ const composeCallback = (
   };
 };
 
+const markAnalyticsConsentGranted = () => {
+  analyticsConsentGranted = true;
+};
+
 const notifyConsentGranted = () => {
+  markAnalyticsConsentGranted();
   for (const callback of consentGrantedListeners) {
     callback();
   }
 };
 
-const hasStoredIubendaConsent = (): boolean => {
-  if (typeof document === "undefined") return false;
+const getIubendaConsentCookieValues = (): string[] => {
+  if (typeof document === "undefined") return [];
 
   return document.cookie
     .split(";")
     .map((cookie) => cookie.trim())
-    .some(
+    .filter(
       (cookie) =>
         cookie.startsWith("_iub_cs-") || cookie.startsWith("_iub_cs-s"),
-    );
+    )
+    .map((cookie) => cookie.split("=").slice(1).join("="))
+    .filter((value) => value.length > 0);
+};
+
+const safeJsonParse = (value: string): unknown | null => {
+  try {
+    return JSON.parse(value) as unknown;
+  } catch {
+    return null;
+  }
+};
+
+const decodeConsentCookieValue = (rawValue: string): unknown | null => {
+  const candidates = [rawValue];
+
+  try {
+    candidates.push(decodeURIComponent(rawValue));
+  } catch {
+    // Ignore malformed cookie values.
+  }
+
+  for (const candidate of candidates) {
+    const parsed = safeJsonParse(candidate);
+    if (parsed !== null) {
+      return parsed;
+    }
+  }
+
+  return null;
+};
+
+const extractAnalyticsConsentFromValue = (value: unknown): boolean | null => {
+  if (typeof value === "boolean") {
+    return value;
+  }
+
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const nested = extractAnalyticsConsentFromValue(item);
+      if (nested !== null) {
+        return nested;
+      }
+    }
+    return null;
+  }
+
+  if (!value || typeof value !== "object") {
+    return null;
+  }
+
+  const record = value as Record<string, unknown>;
+
+  for (const [key, nestedValue] of Object.entries(record)) {
+    const normalizedKey = key.trim().toLowerCase();
+    if (ANALYTICS_CONSENT_KEYS.has(normalizedKey)) {
+      const nested = extractAnalyticsConsentFromValue(nestedValue);
+      if (nested !== null) {
+        return nested;
+      }
+    }
+  }
+
+  for (const containerKey of CONSENT_CONTAINER_KEYS) {
+    if (!(containerKey in record)) continue;
+    const nested = extractAnalyticsConsentFromValue(record[containerKey]);
+    if (nested !== null) {
+      return nested;
+    }
+  }
+
+  if ("consent" in record) {
+    const nested = extractAnalyticsConsentFromValue(record.consent);
+    if (nested !== null) {
+      return nested;
+    }
+  }
+
+  return null;
+};
+
+const hasStoredIubendaAnalyticsConsent = (): boolean => {
+  if (analyticsConsentGranted) {
+    return true;
+  }
+
+  const cookieValues = getIubendaConsentCookieValues();
+  if (cookieValues.length === 0) {
+    return false;
+  }
+
+  return cookieValues.some((cookieValue) => {
+    const parsed = decodeConsentCookieValue(cookieValue);
+    return extractAnalyticsConsentFromValue(parsed) === true;
+  });
+};
+
+const extractConsentGrantedFromCallbackArgs = (args: unknown[]): boolean => {
+  for (const arg of args) {
+    const nested = extractAnalyticsConsentFromValue(arg);
+    if (nested === true) {
+      return true;
+    }
+  }
+
+  return hasStoredIubendaAnalyticsConsent();
 };
 
 const attachIubendaCookieCallbacks = () => {
@@ -116,16 +245,20 @@ const attachIubendaCookieCallbacks = () => {
     return true;
   }
 
-  callbacks.onReady = composeCallback(callbacks.onReady, (consent) => {
-    if (consent === true) {
+  callbacks.onReady = composeCallback(callbacks.onReady, (...args) => {
+    if (extractConsentGrantedFromCallbackArgs(args)) {
       notifyConsentGranted();
     }
   });
-  callbacks.onConsentGiven = composeCallback(callbacks.onConsentGiven, () => {
-    notifyConsentGranted();
+  callbacks.onConsentGiven = composeCallback(callbacks.onConsentGiven, (...args) => {
+    if (extractConsentGrantedFromCallbackArgs(args)) {
+      notifyConsentGranted();
+    }
   });
-  callbacks.onConsentRead = composeCallback(callbacks.onConsentRead, () => {
-    notifyConsentGranted();
+  callbacks.onConsentRead = composeCallback(callbacks.onConsentRead, (...args) => {
+    if (extractConsentGrantedFromCallbackArgs(args)) {
+      notifyConsentGranted();
+    }
   });
   (callbacks as Record<string, unknown>)[IUBENDA_CALLBACK_BRIDGE_MARKER] = true;
   cookieConfiguration.callback = callbacks;
@@ -133,12 +266,49 @@ const attachIubendaCookieCallbacks = () => {
   return true;
 };
 
+const ensureIubendaCookieCallbacksAttached = () => {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  if (attachIubendaCookieCallbacks()) {
+    if (callbackBridgeRetryId !== null) {
+      window.clearInterval(callbackBridgeRetryId);
+      callbackBridgeRetryId = null;
+    }
+    return;
+  }
+
+  if (callbackBridgeRetryId !== null) {
+    return;
+  }
+
+  callbackBridgeRetryId = window.setInterval(() => {
+    if (!attachIubendaCookieCallbacks()) {
+      return;
+    }
+
+    if (callbackBridgeRetryId !== null) {
+      window.clearInterval(callbackBridgeRetryId);
+      callbackBridgeRetryId = null;
+    }
+  }, 250);
+};
+
 export const shouldDeferGAUntilIubendaConsent = (): boolean => {
   if (typeof window === "undefined") {
     return false;
   }
 
-  return Boolean(window._iub?.csConfiguration) && !hasStoredIubendaConsent();
+  return IUBENDA_CONSENT_DATABASE_ENABLED && !hasStoredIubendaAnalyticsConsent();
+};
+
+export const isAnalyticsConsentGranted = (): boolean => {
+  if (typeof window === "undefined") {
+    return false;
+  }
+
+  return !shouldDeferGAUntilIubendaConsent();
 };
 
 export const registerIubendaConsentGrantedCallback = (
@@ -149,9 +319,9 @@ export const registerIubendaConsentGrantedCallback = (
   }
 
   consentGrantedListeners.add(callback);
-  attachIubendaCookieCallbacks();
+  ensureIubendaCookieCallbacksAttached();
 
-  if (hasStoredIubendaConsent()) {
+  if (hasStoredIubendaAnalyticsConsent()) {
     callback();
   }
 
@@ -185,7 +355,7 @@ export const bootstrapIubendaConsentDatabase = () => {
   script.type = "text/javascript";
   document.head.appendChild(script);
 
-  attachIubendaCookieCallbacks();
+  ensureIubendaCookieCallbacksAttached();
 };
 
 export const registerIubendaConsentForm = (config: IubendaConsentFormConfig) => {

--- a/openeire/src/utils/iubendaConsent.ts
+++ b/openeire/src/utils/iubendaConsent.ts
@@ -27,17 +27,34 @@ interface RegisteredFormEntry {
   config: IubendaConsentFormConfig;
 }
 
+type IubendaConsentGrantedCallback = () => void;
+
+type IubendaCookieCallback = (...args: unknown[]) => void;
+
+interface IubendaCookieCallbacks {
+  onReady?: IubendaCookieCallback;
+  onConsentGiven?: IubendaCookieCallback;
+  onConsentRead?: IubendaCookieCallback;
+}
+
+interface IubendaCookieConfiguration {
+  callback?: IubendaCookieCallbacks;
+}
+
 declare global {
   interface Window {
     _iub?: {
       cons_instructions?: Array<[string, Record<string, unknown>, Record<string, unknown>?]>;
+      csConfiguration?: IubendaCookieConfiguration;
     };
   }
 }
 
 const registeredForms = new Map<string, RegisteredFormEntry>();
+const consentGrantedListeners = new Set<IubendaConsentGrantedCallback>();
 const CONSENT_SCRIPT_SRC = "https://cdn.iubenda.com/cons/iubenda_cons.js";
 const DEFAULT_LEGAL_NOTICE_IDENTIFIERS = ["privacy_policy", "cookie_policy"];
+const IUBENDA_CALLBACK_BRIDGE_MARKER = "__openeireCallbackBridgeInstalled";
 
 const ensureConsentInstructionQueue = () => {
   window._iub = window._iub || {};
@@ -55,6 +72,93 @@ const buildFieldMap = (subject: SubjectFieldMap, preferences?: PreferenceFieldMa
 
 const getLegalNotices = (legalNoticeIdentifiers: string[]) =>
   legalNoticeIdentifiers.map((identifier) => ({ identifier }));
+
+const composeCallback = (
+  originalCallback: IubendaCookieCallback | undefined,
+  nextCallback: IubendaCookieCallback,
+): IubendaCookieCallback => {
+  return (...args: unknown[]) => {
+    originalCallback?.(...args);
+    nextCallback(...args);
+  };
+};
+
+const notifyConsentGranted = () => {
+  for (const callback of consentGrantedListeners) {
+    callback();
+  }
+};
+
+const hasStoredIubendaConsent = (): boolean => {
+  if (typeof document === "undefined") return false;
+
+  return document.cookie
+    .split(";")
+    .map((cookie) => cookie.trim())
+    .some(
+      (cookie) =>
+        cookie.startsWith("_iub_cs-") || cookie.startsWith("_iub_cs-s"),
+    );
+};
+
+const attachIubendaCookieCallbacks = () => {
+  if (typeof window === "undefined") {
+    return false;
+  }
+
+  const cookieConfiguration = window._iub?.csConfiguration;
+  if (!cookieConfiguration) {
+    return false;
+  }
+
+  const callbacks = cookieConfiguration.callback ?? {};
+  if ((callbacks as Record<string, unknown>)[IUBENDA_CALLBACK_BRIDGE_MARKER]) {
+    return true;
+  }
+
+  callbacks.onReady = composeCallback(callbacks.onReady, (consent) => {
+    if (consent === true) {
+      notifyConsentGranted();
+    }
+  });
+  callbacks.onConsentGiven = composeCallback(callbacks.onConsentGiven, () => {
+    notifyConsentGranted();
+  });
+  callbacks.onConsentRead = composeCallback(callbacks.onConsentRead, () => {
+    notifyConsentGranted();
+  });
+  (callbacks as Record<string, unknown>)[IUBENDA_CALLBACK_BRIDGE_MARKER] = true;
+  cookieConfiguration.callback = callbacks;
+
+  return true;
+};
+
+export const shouldDeferGAUntilIubendaConsent = (): boolean => {
+  if (typeof window === "undefined") {
+    return false;
+  }
+
+  return Boolean(window._iub?.csConfiguration) && !hasStoredIubendaConsent();
+};
+
+export const registerIubendaConsentGrantedCallback = (
+  callback: IubendaConsentGrantedCallback,
+) => {
+  if (typeof window === "undefined") {
+    return () => undefined;
+  }
+
+  consentGrantedListeners.add(callback);
+  attachIubendaCookieCallbacks();
+
+  if (hasStoredIubendaConsent()) {
+    callback();
+  }
+
+  return () => {
+    consentGrantedListeners.delete(callback);
+  };
+};
 
 export const bootstrapIubendaConsentDatabase = () => {
   if (!IUBENDA_CONSENT_DATABASE_ENABLED || !IUBENDA_CONSENT_PUBLIC_API_KEY || typeof window === "undefined") {
@@ -80,6 +184,8 @@ export const bootstrapIubendaConsentDatabase = () => {
   script.async = true;
   script.type = "text/javascript";
   document.head.appendChild(script);
+
+  attachIubendaCookieCallbacks();
 };
 
 export const registerIubendaConsentForm = (config: IubendaConsentFormConfig) => {


### PR DESCRIPTION
## Summary

This PR hardens the GA4 startup flow on the live site by making it consent-aware when Iubenda is active, while keeping both integrations separate and vendor-safe.

## Problem

GA4 was being initialized immediately from `main.tsx`.

On the live site, that created two practical issues:

- if the initial `gtag.js` request failed, the session could get stuck on a failed script node
- when Iubenda cookie consent is active, GA could try to initialize before consent is available

This showed up as frontend console errors like:

- `Failed to load Google Analytics script: https://www.googletagmanager.com/gtag/js?id=...`
- `GA initialisation failed`

## What changed

### Consent-aware startup
- moved initial GA bootstrap out of `main.tsx`
- startup now happens from `App.tsx`
- if Iubenda consent is not in play, GA initializes normally
- if Iubenda consent is active and no consent is stored yet, GA waits
- once Iubenda reports consent, GA initializes immediately
- if consent was already stored, GA initializes on page load

### Safe bridge to Iubenda
- added a small bridge in `src/utils/iubendaConsent.ts`
- the bridge:
  - detects existing Iubenda consent cookies
  - composes with existing `csConfiguration.callback` handlers
  - listens to `onReady`, `onConsentGiven`, and `onConsentRead`
- it does **not** replace or take over Iubenda’s own logic

### Retry-safe GA loading
- retained the earlier GA loader hardening so failed script loads can retry cleanly later instead of reusing a dead script tag

## Files changed

- `src/App.tsx`
- `src/main.tsx`
- `src/utils/iubendaConsent.ts`
- `src/lib/analytics.ts`

## Why this approach

This keeps responsibilities clean:

- Iubenda remains the consent source of truth
- GA remains responsible for analytics bootstrapping
- the app only coordinates timing between them

That makes the change low-risk and avoids custom behavior that could break either vendor integration.

## Verification

### Build
- `npm run build`
- result: passed

### Manual checks to run in staging/live
- load the site in a clean browser with no ad blocker
- verify GA does not initialize before consent when Iubenda cookie consent is active
- accept consent and confirm `gtag.js` loads immediately
- confirm GA4 Realtime receives a page view
- reload after consent and confirm GA loads on first page load
- verify existing Iubenda consent form/database behavior is unchanged

## Notes

This PR is intentionally narrow:
- no redesign
- no vendor script replacement
- no custom consent model
- only safer startup timing and recovery behavior
