### PR TITLE
Strengthen launch SEO and fix mobile toast overlap

### DIFF
--- a/openeire/src/App.tsx
+++ b/openeire/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, Suspense, lazy } from "react";
+import React, { useEffect, Suspense, lazy, useState } from "react";
 import { Routes, Route, useNavigate } from "react-router-dom";
 
 // ================= SYNC IMPORTS =================
@@ -91,6 +91,20 @@ const StaffVideoUploadsPage = lazy(() => import("./pages/StaffVideoUploadsPage")
 
 function App() {
   const navigate = useNavigate();
+  const [hasCompactViewport, setHasCompactViewport] = useState(false);
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia("(max-width: 768px)");
+    const syncViewport = () => {
+      setHasCompactViewport(mediaQuery.matches);
+    };
+
+    syncViewport();
+    mediaQuery.addEventListener("change", syncViewport);
+    return () => {
+      mediaQuery.removeEventListener("change", syncViewport);
+    };
+  }, []);
 
   useEffect(() => {
     bootstrapIubendaConsentDatabase();
@@ -126,7 +140,11 @@ function App() {
         <Navbar />
         <Breadcrumbs />
         <main className="flex-grow">
-          <Toaster position="bottom-center" toastOptions={{ duration: 3000 }} />
+          <Toaster
+            position="bottom-center"
+            containerStyle={hasCompactViewport ? { bottom: 96 } : undefined}
+            toastOptions={{ duration: 3000 }}
+          />
 
           {/* ================= SUSPENSE BOUNDARY ================= */}
           {/* While Vite downloads a lazy-loaded page, this fallback UI is shown */}

--- a/openeire/src/App.tsx
+++ b/openeire/src/App.tsx
@@ -94,15 +94,29 @@ function App() {
   const [hasCompactViewport, setHasCompactViewport] = useState(false);
 
   useEffect(() => {
+    if (
+      typeof window === "undefined" ||
+      typeof window.matchMedia !== "function"
+    ) {
+      return;
+    }
+
     const mediaQuery = window.matchMedia("(max-width: 768px)");
     const syncViewport = () => {
       setHasCompactViewport(mediaQuery.matches);
     };
 
     syncViewport();
-    mediaQuery.addEventListener("change", syncViewport);
+    if (typeof mediaQuery.addEventListener === "function") {
+      mediaQuery.addEventListener("change", syncViewport);
+      return () => {
+        mediaQuery.removeEventListener("change", syncViewport);
+      };
+    }
+
+    mediaQuery.addListener(syncViewport);
     return () => {
-      mediaQuery.removeEventListener("change", syncViewport);
+      mediaQuery.removeListener(syncViewport);
     };
   }, []);
 

--- a/openeire/src/components/SEOHead.tsx
+++ b/openeire/src/components/SEOHead.tsx
@@ -1,6 +1,7 @@
 ﻿import React from "react";
 import { Helmet } from "react-helmet";
 import {
+  DEFAULT_SOCIAL_IMAGE_PATH,
   SITE_TITLE,
   buildAbsoluteSiteUrl,
   getCurrentCanonicalUrl,
@@ -34,6 +35,7 @@ const SEOHead: React.FC<SEOHeadProps> = ({
 }) => {
   const resolvedTitle = appendSiteTitle ? `${title} | ${SITE_TITLE}` : title;
   const pageUrl = url ? buildAbsoluteSiteUrl(url) : getCurrentPageUrl();
+  const resolvedImage = buildAbsoluteSiteUrl(image || DEFAULT_SOCIAL_IMAGE_PATH);
   const resolvedCanonicalUrl = canonicalUrl
     ? buildAbsoluteSiteUrl(canonicalUrl)
     : canonicalPath
@@ -44,20 +46,23 @@ const SEOHead: React.FC<SEOHeadProps> = ({
     <Helmet>
       <title>{resolvedTitle}</title>
       <meta name="description" content={description} />
-      <meta name="robots" content={noindex ? "noindex, follow" : "index, follow"} />
+      <meta
+        name="robots"
+        content={noindex ? "noindex, follow" : "index, follow, max-image-preview:large"}
+      />
 
       <meta property="og:type" content={type} />
       <meta property="og:site_name" content={SITE_TITLE} />
       <meta property="og:url" content={pageUrl} />
       <meta property="og:title" content={resolvedTitle} />
       <meta property="og:description" content={description} />
-      {image ? <meta property="og:image" content={image} /> : null}
+      <meta property="og:image" content={resolvedImage} />
 
-      <meta name="twitter:card" content={image ? "summary_large_image" : "summary"} />
+      <meta name="twitter:card" content="summary_large_image" />
       <meta name="twitter:url" content={pageUrl} />
       <meta name="twitter:title" content={resolvedTitle} />
       <meta name="twitter:description" content={description} />
-      {image ? <meta name="twitter:image" content={image} /> : null}
+      <meta name="twitter:image" content={resolvedImage} />
 
       <link rel="canonical" href={resolvedCanonicalUrl} />
 

--- a/openeire/src/config/site.ts
+++ b/openeire/src/config/site.ts
@@ -1,4 +1,9 @@
-export const SITE_TITLE = "OpenÉire Studios";
+export const SITE_TITLE = "Open\u00c9ire Studios";
+export const SITE_TITLE_ASCII = "OpenEire Studios";
+export const SITE_DESCRIPTION =
+  "Premium aerial photography, fine art prints, commercial licensing, and curated visual assets from Ireland.";
+export const SITE_CONTACT_EMAIL = "studio@openeire.ie";
+export const DEFAULT_SOCIAL_IMAGE_PATH = "/hero-poster.jpg";
 
 export const getSiteOrigin = (): string => {
   const configured = import.meta.env.VITE_SITE_URL?.trim().replace(/\/+$/, "");

--- a/openeire/src/lib/seoSchema.ts
+++ b/openeire/src/lib/seoSchema.ts
@@ -144,7 +144,10 @@ export const buildProductSchema = (input: ProductSchemaInput): StructuredData =>
   }
 
   if (input.image) {
-    schema.image = normalizeImages(input.image);
+    const normalizedImages = normalizeImages(input.image);
+    if (normalizedImages) {
+      schema.image = normalizedImages;
+    }
   }
 
   if (typeof input.price === "number" && Number.isFinite(input.price)) {
@@ -181,7 +184,10 @@ export const buildVisualArtworkSchema = (
   }
 
   if (input.image) {
-    schema.image = normalizeImages(input.image);
+    const normalizedImages = normalizeImages(input.image);
+    if (normalizedImages) {
+      schema.image = normalizedImages;
+    }
   }
 
   return schema;

--- a/openeire/src/lib/seoSchema.ts
+++ b/openeire/src/lib/seoSchema.ts
@@ -21,7 +21,7 @@ type ProductSchemaInput = {
   name: string;
   description: string;
   url: string;
-  image?: string;
+  image?: string | string[];
   brandName: string;
   sku?: string;
   price?: number;
@@ -33,7 +33,7 @@ type VisualArtworkSchemaInput = {
   name: string;
   description: string;
   url: string;
-  image?: string;
+  image?: string | string[];
   creatorName: string;
   artform?: string;
 };
@@ -43,32 +43,54 @@ type FAQItemInput = {
   answer: string;
 };
 
-const normalizeImages = (image?: string): string[] | undefined => {
+const normalizeImages = (
+  image?: string | string[],
+): string[] | undefined => {
   if (!image) return undefined;
-  return [image];
+  const images = Array.isArray(image) ? image : [image];
+  const cleaned = images.filter(Boolean);
+  return cleaned.length ? cleaned : undefined;
 };
 
 export const buildOrganizationSchema = (input: {
+  type?: "Organization" | "OnlineStore";
   name: string;
+  alternateName?: string;
   url: string;
   logo?: string;
   description?: string;
+  contactEmail?: string;
+  sameAs?: string[];
 }): StructuredData => ({
   "@context": "https://schema.org",
-  "@type": "Organization",
+  "@type": input.type ?? "Organization",
   name: input.name,
+  ...(input.alternateName ? { alternateName: input.alternateName } : {}),
   url: input.url,
   ...(input.logo ? { logo: input.logo } : {}),
   ...(input.description ? { description: input.description } : {}),
+  ...(input.contactEmail
+    ? {
+        contactPoint: [
+          {
+            "@type": "ContactPoint",
+            email: input.contactEmail,
+          },
+        ],
+      }
+    : {}),
+  ...(input.sameAs?.length ? { sameAs: input.sameAs } : {}),
 });
 
 export const buildWebsiteSchema = (input: {
   name: string;
+  alternateName?: string;
   url: string;
 }): StructuredData => ({
   "@context": "https://schema.org",
   "@type": "WebSite",
   name: input.name,
+  ...(input.alternateName ? { alternateName: input.alternateName } : {}),
   url: input.url,
 });
 

--- a/openeire/src/pages/AboutPage.tsx
+++ b/openeire/src/pages/AboutPage.tsx
@@ -2,24 +2,49 @@ import React from "react";
 import { Link } from "react-router-dom";
 import { FaCamera, FaPlane, FaMapMarkedAlt, FaAward } from "react-icons/fa";
 import SEOHead from "../components/SEOHead";
-import { buildAbsoluteSiteUrl } from "../config/site";
-import { buildBreadcrumbSchema } from "../lib/seoSchema";
+import logoImage from "../assets/simple-logo-black.png";
+import {
+  SITE_CONTACT_EMAIL,
+  SITE_DESCRIPTION,
+  SITE_TITLE,
+  SITE_TITLE_ASCII,
+  buildAbsoluteSiteUrl,
+} from "../config/site";
+import {
+  buildBreadcrumbSchema,
+  buildOrganizationSchema,
+  buildWebsiteSchema,
+} from "../lib/seoSchema";
 
 const AboutPage: React.FC = () => {
   return (
     <div className="bg-black min-h-screen text-white mobile-page-offset">
       <SEOHead
-        title="About OpenÉire Studios | Drone Photography & Fine Art Prints"
+        title="About Open\u00c9ire Studios | Drone Photography & Fine Art Prints"
         description="Meet OpenÉire Studios, an Ireland-based studio creating aerial stock footage, drone photography, and fine art prints."
         canonicalPath="/about"
-        schema={buildBreadcrumbSchema([
-          { name: "Home", url: buildAbsoluteSiteUrl("/") },
-          { name: "About", url: buildAbsoluteSiteUrl("/about") },
-        ])}
+        image="/doubtful_sound.webp"
+        schema={[
+          buildBreadcrumbSchema([
+            { name: "Home", url: buildAbsoluteSiteUrl("/") },
+            { name: "About", url: buildAbsoluteSiteUrl("/about") },
+          ]),
+          buildOrganizationSchema({
+            name: SITE_TITLE,
+            alternateName: SITE_TITLE_ASCII,
+            url: buildAbsoluteSiteUrl("/"),
+            logo: buildAbsoluteSiteUrl(logoImage),
+            description: SITE_DESCRIPTION,
+            contactEmail: SITE_CONTACT_EMAIL,
+          }),
+          buildWebsiteSchema({
+            name: SITE_TITLE,
+            alternateName: SITE_TITLE_ASCII,
+            url: buildAbsoluteSiteUrl("/"),
+          }),
+        ]}
       />
-      {/* 1. HERO SECTION (Parallax feel) */}
       <div className="relative h-[70vh] w-full overflow-hidden flex items-center justify-center">
-        {/* Background Image */}
         <div
           className="absolute inset-0 bg-cover bg-center opacity-60 scale-105 animate-slow-zoom"
           style={{
@@ -36,15 +61,15 @@ const AboutPage: React.FC = () => {
             Capturing the <br /> Spirit of the Wild
           </h1>
           <p className="text-gray-300 text-lg md:text-xl font-light max-w-2xl mx-auto leading-relaxed animate-fade-in-up delay-200">
-            OpenÉire Studios is an Ireland-based aerial photography and stock footage studio dedicated to the raw, unspoken beauty of the Irish landscape and beyond.
+            OpenÉire Studios is an Ireland-based aerial photography and stock
+            footage studio dedicated to the raw, unspoken beauty of the Irish
+            landscape and beyond.
           </p>
         </div>
       </div>
 
-      {/* 2. THE STORY */}
       <div className="container mx-auto px-4 lg:px-8 py-24">
         <div className="grid grid-cols-1 md:grid-cols-2 gap-16 items-center">
-          {/* Left: Text */}
           <div className="space-y-8">
             <h2 className="text-3xl md:text-4xl font-serif font-bold text-white">
               More than just pixels. <br />
@@ -71,7 +96,6 @@ const AboutPage: React.FC = () => {
             </div>
           </div>
 
-          {/* Right: Image Grid */}
           <div className="grid grid-cols-2 gap-4 relative">
             <img
               src="/macro_flower.webp?auto=format&fit=crop&q=80&w=800"
@@ -84,13 +108,11 @@ const AboutPage: React.FC = () => {
               alt="Mountain Hike"
             />
 
-            {/* Decorative Element */}
             <div className="absolute -z-10 top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 w-[120%] h-[120%] bg-accent/5 blur-3xl rounded-full"></div>
           </div>
         </div>
       </div>
 
-      {/* 3. STATS / TRUST BANNER */}
       <div className="border-y border-white/10 bg-gray-900/30 backdrop-blur-sm">
         <div className="container mx-auto px-4 py-16">
           <div className="grid grid-cols-2 md:grid-cols-4 gap-8 text-center">
@@ -126,7 +148,6 @@ const AboutPage: React.FC = () => {
         </div>
       </div>
 
-      {/* 4. THE PROCESS */}
       <div className="container mx-auto px-4 py-24">
         <div className="text-center mb-16">
           <h2 className="text-3xl md:text-5xl font-serif font-bold mb-6">
@@ -139,7 +160,6 @@ const AboutPage: React.FC = () => {
         </div>
 
         <div className="grid grid-cols-1 md:grid-cols-3 gap-8">
-          {/* Step 1 */}
           <div className="bg-gray-900 border border-white/10 p-8 rounded-2xl relative overflow-hidden group hover:-translate-y-2 transition-transform duration-300">
             <div className="absolute top-0 right-0 p-8 text-6xl font-serif font-bold text-white/5 group-hover:text-white/10 transition-colors">
               01
@@ -153,7 +173,6 @@ const AboutPage: React.FC = () => {
             </p>
           </div>
 
-          {/* Step 2 */}
           <div className="bg-gray-900 border border-white/10 p-8 rounded-2xl relative overflow-hidden group hover:-translate-y-2 transition-transform duration-300">
             <div className="absolute top-0 right-0 p-8 text-6xl font-serif font-bold text-white/5 group-hover:text-white/10 transition-colors">
               02
@@ -168,7 +187,6 @@ const AboutPage: React.FC = () => {
             </p>
           </div>
 
-          {/* Step 3 */}
           <div className="bg-gray-900 border border-white/10 p-8 rounded-2xl relative overflow-hidden group hover:-translate-y-2 transition-transform duration-300">
             <div className="absolute top-0 right-0 p-8 text-6xl font-serif font-bold text-white/5 group-hover:text-white/10 transition-colors">
               03
@@ -184,7 +202,6 @@ const AboutPage: React.FC = () => {
         </div>
       </div>
 
-      {/* 5. CTA SECTION */}
       <div className="relative h-[50vh] flex items-center justify-center overflow-hidden">
         <img
           src="pacific_ocean.webp?auto=format&fit=crop&q=80&w=1200"

--- a/openeire/src/pages/ArtPrintsFAQPage.tsx
+++ b/openeire/src/pages/ArtPrintsFAQPage.tsx
@@ -56,14 +56,14 @@ const ArtPrintsFAQPage: React.FC = () => {
         </>
       ),
       schemaAnswer:
-        "OpenEire Studios sells premium wall art prints created from original aerial photography, designed as finished artworks rather than generic posters.",
+        "OpenÉire Studios sells premium wall art prints created from original aerial photography, designed as finished artworks rather than generic posters.",
     },
 
     {
       question: "Are these original aerial photography prints?",
       answerLead: "Yes — every print comes from original aerial photography.",
       answerParagraphs: [
-        "The collection is built from work captured and curated by OpenEire Studios, not sourced from stock libraries.",
+        "The collection is built from work captured and curated by OpenÉire Studios, not sourced from stock libraries.",
       ],
       bridge: (
         <>
@@ -75,7 +75,7 @@ const ArtPrintsFAQPage: React.FC = () => {
         </>
       ),
       schemaAnswer:
-        "Yes. All prints are based on original aerial photography created and curated by OpenEire Studios.",
+        "Yes. All prints are based on original aerial photography created and curated by OpenÉire Studios.",
     },
 
     {

--- a/openeire/src/pages/FAQIndexPage.tsx
+++ b/openeire/src/pages/FAQIndexPage.tsx
@@ -36,8 +36,8 @@ const FAQIndexPage: React.FC = () => {
   return (
     <div className="bg-black min-h-screen text-white pb-20">
       <SEOHead
-        title="FAQ | OpenEire Studios"
-        description="Browse buyer FAQs about drone footage licensing, drone footage usage, and fine art prints from OpenEire Studios."
+        title="FAQ | OpenÉire Studios"
+        description="Browse buyer FAQs about drone footage licensing, drone footage usage, and fine art prints from OpenÉire Studios."
         canonicalPath="/faq"
         appendSiteTitle={false}
         schema={buildBreadcrumbSchema([

--- a/openeire/src/pages/FootageLandingPage.tsx
+++ b/openeire/src/pages/FootageLandingPage.tsx
@@ -151,7 +151,7 @@ const FootageLandingPage: React.FC = () => {
   return (
     <div className="bg-black min-h-screen text-white pb-20">
       <SEOHead
-        title="Drone Footage Ireland | Licensed Aerial Footage | OpenEire Studios"
+        title="Drone Footage Ireland | Licensed Aerial Footage | OpenÉire Studios"
         description="Browse licensed drone footage from Ireland for commercial, editorial, and creative use. Premium aerial video with clear licensing options."
         canonicalPath="/footage"
         schema={[
@@ -311,7 +311,7 @@ const FootageLandingPage: React.FC = () => {
           <div className="space-y-6 lg:col-span-7">
             <h2 className={SECTION_TITLE_CLASS}>Why choose OpenEire footage</h2>
             <p className="text-gray-400 leading-relaxed">
-              OpenEire Studios positions aerial footage as premium source
+              OpenÉire Studios positions aerial footage as premium source
               material for serious use. The goal here is not to overwhelm you
               with legal detail before you have even found the right shot. It is
               to help you find footage that feels location-specific, cinematic,

--- a/openeire/src/pages/FootageLandingPage.tsx
+++ b/openeire/src/pages/FootageLandingPage.tsx
@@ -309,7 +309,7 @@ const FootageLandingPage: React.FC = () => {
       <section className="container mx-auto px-4 lg:px-8 pt-8 md:pt-20">
         <div className="grid gap-8 lg:grid-cols-12 lg:items-start">
           <div className="space-y-6 lg:col-span-7">
-            <h2 className={SECTION_TITLE_CLASS}>Why choose OpenEire footage</h2>
+            <h2 className={SECTION_TITLE_CLASS}>Why choose OpenÉire footage</h2>
             <p className="text-gray-400 leading-relaxed">
               OpenÉire Studios positions aerial footage as premium source
               material for serious use. The goal here is not to overwhelm you

--- a/openeire/src/pages/HomePage.tsx
+++ b/openeire/src/pages/HomePage.tsx
@@ -5,8 +5,14 @@ import DeferredSection from "../components/ui/DeferredSection";
 import HeroSection from "../components/HeroSection";
 import SEOHead from "../components/SEOHead";
 import ServicesSection from "../components/ServicesSection";
-import logoImage from "../assets/full-logo-white.png";
-import { buildAbsoluteSiteUrl } from "../config/site";
+import logoImage from "../assets/simple-logo-black.png";
+import {
+  SITE_CONTACT_EMAIL,
+  SITE_DESCRIPTION,
+  SITE_TITLE,
+  SITE_TITLE_ASCII,
+  buildAbsoluteSiteUrl,
+} from "../config/site";
 import {
   buildOrganizationSchema,
   buildWebsiteSchema,
@@ -23,16 +29,19 @@ const HomePage: React.FC = () => {
         title="Fine Art Prints & Commercial Licensing in Ireland"
         description="Discover premium fine art prints from Ireland, commercial drone footage licensing, and curated aerial visuals from OpenÉire Studios."
         canonicalPath="/"
+        image="/hero-poster.jpg"
         schema={[
           buildOrganizationSchema({
-            name: "OpenÉire Studios",
+            name: SITE_TITLE,
+            alternateName: SITE_TITLE_ASCII,
             url: buildAbsoluteSiteUrl("/"),
             logo: buildAbsoluteSiteUrl(logoImage),
-            description:
-              "OpenÉire Studios creates fine art prints, commercial licensing assets, and aerial visuals from Ireland.",
+            description: SITE_DESCRIPTION,
+            contactEmail: SITE_CONTACT_EMAIL,
           }),
           buildWebsiteSchema({
-            name: "OpenÉire Studios",
+            name: SITE_TITLE,
+            alternateName: SITE_TITLE_ASCII,
             url: buildAbsoluteSiteUrl("/"),
           }),
         ]}

--- a/openeire/src/pages/ProductDetailPage.tsx
+++ b/openeire/src/pages/ProductDetailPage.tsx
@@ -28,7 +28,7 @@ import { useBreadcrumb } from "../context/BreadcrumbContext";
 import RelatedProducts from "../components/RelatedProducts";
 import LicenseRequestModal from "../components/LicenseRequestModal";
 import SEOHead from "../components/SEOHead";
-import { buildAbsoluteSiteUrl } from "../config/site";
+import { SITE_TITLE, buildAbsoluteSiteUrl } from "../config/site";
 import { toastInfo } from "../utils/toast";
 import {
   isDigitalProductType,
@@ -440,6 +440,7 @@ const ProductDetailPage: React.FC = () => {
   const imageUrl = isPhysicalNestedDetail(product)
     ? product.photo.preview_image || product.preview_image || ""
     : product.preview_image || product.thumbnail_image || "";
+  const pageImageUrl = imageUrl ? buildAbsoluteSiteUrl(imageUrl) : undefined;
   const videoPreviewUrl =
     isVideo &&
     isVideoDetail(product) &&
@@ -483,7 +484,7 @@ const ProductDetailPage: React.FC = () => {
               ? `Buy ${product.title} for personal use or request commercial licensing`
               : `Buy ${product.title}`
         }
-        image={imageUrl || undefined}
+        image={pageImageUrl}
         canonicalPath={location.pathname}
         type={isPhysical ? "product" : "website"}
         noindex={isDigital}
@@ -509,8 +510,9 @@ const ProductDetailPage: React.FC = () => {
                   name: product.title,
                   description: reviewDescription || product.title,
                   url: buildAbsoluteSiteUrl(location.pathname),
-                  image: imageUrl || undefined,
-                  brandName: "OpenÉire Studios",
+                  image: pageImageUrl,
+                  brandName: SITE_TITLE,
+                  sku: activePhysicalVariant.sku || undefined,
                   price: Number.parseFloat(activePhysicalVariant.price),
                   priceCurrency: "EUR",
                   availability: "https://schema.org/InStock",
@@ -519,8 +521,8 @@ const ProductDetailPage: React.FC = () => {
                   name: product.title,
                   description: reviewDescription || product.title,
                   url: buildAbsoluteSiteUrl(location.pathname),
-                  image: imageUrl || undefined,
-                  creatorName: "OpenÉire Studios",
+                  image: pageImageUrl,
+                  creatorName: SITE_TITLE,
                   artform: "Photography",
                 }),
               ]

--- a/openeire/src/pages/RefundPolicy.tsx
+++ b/openeire/src/pages/RefundPolicy.tsx
@@ -16,7 +16,7 @@ const RefundPolicy: React.FC = () => {
           <strong>Last Updated: March 2026</strong>
         </p>
         <p>
-          OpenEire Studios sells two distinct product types: digital media
+          OpenÉire Studios sells two distinct product types: digital media
           licences and physical art prints. Because these products are fulfilled
           differently, the refund and return rules are different as well. Nothing
           in this policy affects your statutory rights under Irish or European
@@ -41,7 +41,7 @@ const RefundPolicy: React.FC = () => {
       <p>
         Under EU consumer law, customers generally have a 14-day right to
         cancel online purchases. By purchasing a digital download from
-        OpenEire Studios, you explicitly consent to immediate digital delivery
+        OpenÉire Studios, you explicitly consent to immediate digital delivery
         and acknowledge that you lose that withdrawal right once download
         access begins.
       </p>

--- a/openeire/src/pages/ShippingPolicy.tsx
+++ b/openeire/src/pages/ShippingPolicy.tsx
@@ -16,7 +16,7 @@ const ShippingPolicy: React.FC = () => {
           <strong>Last Updated: March 2026</strong>
         </p>
         <p>
-          At OpenEire Studios, we deliver our premium media in two formats:
+          At OpenÉire Studios, we deliver our premium media in two formats:
           digital vault delivery for commercial licences and digital downloads,
           and physical print delivery for bespoke, museum-quality art prints.
           We currently ship physical prints exclusively to Ireland and the United
@@ -120,7 +120,7 @@ const ShippingPolicy: React.FC = () => {
           duties that apply at delivery.
         </li>
         <li>
-          OpenEire Studios is not responsible for delays caused by customs
+          OpenÉire Studios is not responsible for delays caused by customs
           processing.
         </li>
       </ul>

--- a/openeire/src/pages/TermsAndConditions.tsx
+++ b/openeire/src/pages/TermsAndConditions.tsx
@@ -16,7 +16,7 @@ const TermsAndConditions: React.FC = () => {
           <strong>Last Updated: March 2026</strong>
         </p>
         <p>
-          Welcome to OpenEire Studios. These Terms & Conditions ("Terms")
+          Welcome to OpenÉire Studios. These Terms & Conditions ("Terms")
           govern your access to and use of our website, as well as the purchase
           of any physical prints, digital downloads, or commercial media
           licenses. By accessing our website or placing an order, you agree to
@@ -28,9 +28,9 @@ const TermsAndConditions: React.FC = () => {
 
       <h2>1. About Us</h2>
       <p>
-        This website is operated by OpenEire Studios, based in Ireland.
+        This website is operated by OpenÉire Studios, based in Ireland.
         Throughout the site, the terms "we", "us", and "our" refer to
-        OpenEire Studios.
+        OpenÉire Studios.
       </p>
 
       <h2>2. Products and Services</h2>
@@ -48,10 +48,10 @@ const TermsAndConditions: React.FC = () => {
       </ol>
       <h3>Purchasing a Licence, Not Ownership</h3>
       <p>
-        When you purchase digital media from OpenEire Studios, you are
+        When you purchase digital media from OpenÉire Studios, you are
         purchasing a limited licence to use the asset, not the ownership of
         the asset itself. All copyright and intellectual property rights remain
-        the exclusive property of OpenEire Studios.
+        the exclusive property of OpenÉire Studios.
       </p>
 
       <h2>3. Intellectual Property & Strict Licensing Rules</h2>
@@ -155,7 +155,7 @@ const TermsAndConditions: React.FC = () => {
 
       <h2>7. Limitation of Liability</h2>
       <p>
-        To the maximum extent permitted by applicable law, OpenEire Studios
+        To the maximum extent permitted by applicable law, OpenÉire Studios
         shall not be liable for any indirect, incidental, special,
         consequential, or punitive damages, including without limitation loss
         of profits, data, use, goodwill, or other intangible losses, resulting
@@ -167,7 +167,7 @@ const TermsAndConditions: React.FC = () => {
 
       <h2>8. Indemnification</h2>
       <p>
-        You agree to indemnify and hold harmless OpenEire Studios and its
+        You agree to indemnify and hold harmless OpenÉire Studios and its
         affiliates, partners, and employees from any claim or demand, including
         reasonable legal fees, made by any third party due to or arising out of
         your breach of these Terms, your violation of any law, or your misuse
@@ -178,7 +178,7 @@ const TermsAndConditions: React.FC = () => {
       <p>
         These Terms and any separate agreements whereby we provide services
         shall be governed by and construed in accordance with the laws of
-        Ireland and applicable European Union law. OpenEire Studios reserves
+        Ireland and applicable European Union law. OpenÉire Studios reserves
         the right to pursue enforcement and remedies for copyright infringement
         in the jurisdiction where the infringement occurs and/or where the
         licensee is established.

--- a/openeire/src/pages/USAerialPhotographyPrintsPage.tsx
+++ b/openeire/src/pages/USAerialPhotographyPrintsPage.tsx
@@ -136,7 +136,7 @@ const USAerialPhotographyPrintsPage: React.FC = () => {
         {
           question: "Are these original aerial photography prints?",
           answer:
-            "Yes. The collection is built around original aerial photography curated by OpenEire Studios.",
+            "Yes. The collection is built around original aerial photography curated by OpenÉire Studios.",
         },
         {
           question: "What makes aerial wall art different?",

--- a/openeire/src/pages/USFineArtPrintsPage.tsx
+++ b/openeire/src/pages/USFineArtPrintsPage.tsx
@@ -54,7 +54,7 @@ const faqItems = [
   {
     question: "Are these original aerial photography prints?",
     answer:
-      "Yes. The collection centers on original aerial photography curated by OpenEire Studios rather than generic stock wall art.",
+      "Yes. The collection centers on original aerial photography curated by OpenÉire Studios rather than generic stock wall art.",
   },
   {
     question: "Are prints suitable for collectors and interior spaces?",
@@ -71,7 +71,7 @@ const USFineArtPrintsPage: React.FC = () => {
   return (
     <div className="bg-black min-h-screen text-white pb-20">
       <SEOHead
-        title="Fine Art Landscape Prints USA | Aerial Wall Art | OpenEire Studios"
+        title="Fine Art Landscape Prints USA | Aerial Wall Art | OpenÉire Studios"
         description="Premium aerial fine art prints shipped to the United States. Landscape wall art from Ireland in curated formats for collectors, interiors, and distinctive spaces."
         canonicalPath="/us/fine-art-prints"
         schema={[
@@ -101,7 +101,7 @@ const USFineArtPrintsPage: React.FC = () => {
               Fine Art Prints for Collectors and Interiors in the United States
             </h1>
             <p className="mt-5 max-w-3xl text-base leading-relaxed text-gray-300 md:text-lg">
-              Discover premium aerial wall art from OpenEire Studios, available
+              Discover premium aerial wall art from OpenÉire Studios, available
               to buyers in the United States. These fine art prints are made for
               interiors, collectors, and gift buyers who want landscape artwork
               with atmosphere rather than generic decor.
@@ -248,7 +248,7 @@ const USFineArtPrintsPage: React.FC = () => {
       <section className="container mx-auto px-4 lg:px-8 pt-8 md:pt-20">
         <div className="grid gap-8 lg:grid-cols-12 lg:items-start">
           <div className="space-y-5 lg:col-span-7">
-            <h2 className={SECTION_TITLE_CLASS}>Why choose OpenEire Studios</h2>
+            <h2 className={SECTION_TITLE_CLASS}>Why choose OpenÉire Studios</h2>
             <div className="space-y-4">
               <div className="flex gap-3 rounded-2xl border border-white/10 bg-white/5 p-5">
                 <FaMapMarkedAlt className="mt-0.5 shrink-0 text-accent" />

--- a/openeire/src/pages/USLargeWallArtPage.tsx
+++ b/openeire/src/pages/USLargeWallArtPage.tsx
@@ -75,7 +75,7 @@ const USLargeWallArtPage: React.FC = () => {
       premiumTitle="Statement pieces with a more considered finish"
       premiumIntro={
         <>
-          OpenEire Studios approaches large wall art as physical artwork for
+          OpenÉire Studios approaches large wall art as physical artwork for
           real interiors, not oversized filler. The emphasis stays on curation,
           composition, and how a piece feels once it owns the room.
         </>
@@ -107,7 +107,7 @@ const USLargeWallArtPage: React.FC = () => {
       relevanceTitle="Buying large wall art in the United States"
       relevanceParagraphs={[
         <>
-          Large wall art from OpenEire Studios is available to buyers in the
+          Large wall art from OpenÉire Studios is available to buyers in the
           United States as made-to-order physical pieces.
         </>,
         <>

--- a/openeire/src/pages/USWallArtForLivingRoomPage.tsx
+++ b/openeire/src/pages/USWallArtForLivingRoomPage.tsx
@@ -75,7 +75,7 @@ const USWallArtForLivingRoomPage: React.FC = () => {
       premiumTitle="Curated prints for rooms people actually live in"
       premiumIntro={
         <>
-          OpenEire Studios treats living room wall art as part of the interior
+          OpenÉire Studios treats living room wall art as part of the interior
           composition. The collection is made for buyers who want a more refined
           answer than generic decor or trend-led poster sets.
         </>
@@ -110,7 +110,7 @@ const USWallArtForLivingRoomPage: React.FC = () => {
       relevanceTitle="Wall art for living spaces in the United States"
       relevanceParagraphs={[
         <>
-          Living room wall art from OpenEire Studios is available to buyers in
+          Living room wall art from OpenÉire Studios is available to buyers in
           the United States as made-to-order physical prints.
         </>,
         <>

--- a/openeire/src/pages/USWallArtForOfficePage.tsx
+++ b/openeire/src/pages/USWallArtForOfficePage.tsx
@@ -72,7 +72,7 @@ const USWallArtForOfficePage: React.FC = () => {
       premiumTitle="Professional interiors still deserve real artwork"
       premiumIntro={
         <>
-          OpenEire Studios positions office wall art as a design decision, not
+          OpenÉire Studios positions office wall art as a design decision, not
           an afterthought. The collection is curated for environments that want
           visual distinction without tipping into generic decor.
         </>
@@ -107,7 +107,7 @@ const USWallArtForOfficePage: React.FC = () => {
       relevanceTitle="Wall art for offices and workspaces in the United States"
       relevanceParagraphs={[
         <>
-          Office wall art from OpenEire Studios is available to buyers in the
+          Office wall art from OpenÉire Studios is available to buyers in the
           United States through the same print ordering flow used across the
           collection.
         </>,

--- a/openeire/src/pages/USWallArtPrintsPage.tsx
+++ b/openeire/src/pages/USWallArtPrintsPage.tsx
@@ -76,7 +76,7 @@ const USWallArtPrintsPage: React.FC = () => {
       premiumTitle="Premium positioning for interiors"
       premiumIntro={
         <>
-          OpenEire Studios wall art prints are meant to feel intentional in the
+          OpenÉire Studios wall art prints are meant to feel intentional in the
           room. The collection is curated for buyers who want artwork that can
           hold space visually, not simply cover it.
         </>
@@ -104,7 +104,7 @@ const USWallArtPrintsPage: React.FC = () => {
       relevanceTitle="For United States buyers"
       relevanceParagraphs={[
         <>
-          Wall art prints from OpenEire Studios are available to buyers in the
+          Wall art prints from OpenÉire Studios are available to buyers in the
           United States as made-to-order physical pieces.
         </>,
         <>

--- a/openeire/tests/seoSchema.test.ts
+++ b/openeire/tests/seoSchema.test.ts
@@ -3,6 +3,7 @@ import {
   buildArticleSchema,
   buildBreadcrumbSchema,
   buildFAQPageSchema,
+  buildOrganizationSchema,
   buildProductSchema,
   buildVisualArtworkSchema,
   buildWebsiteSchema,
@@ -70,6 +71,37 @@ describe("seoSchema helpers", () => {
     });
   });
 
+  it("normalizes product image arrays and omits empty image arrays", () => {
+    expect(
+      buildProductSchema({
+        name: "Cliffs at Dusk",
+        description: "Premium aerial print",
+        url: "https://example.com/gallery/physical/cliffs-at-dusk",
+        brandName: "OpenEire Studios",
+        image: [
+          "https://example.com/images/cliffs-1.jpg",
+          "",
+          "https://example.com/images/cliffs-2.jpg",
+        ],
+      }),
+    ).toMatchObject({
+      image: [
+        "https://example.com/images/cliffs-1.jpg",
+        "https://example.com/images/cliffs-2.jpg",
+      ],
+    });
+
+    expect(
+      buildProductSchema({
+        name: "Empty images",
+        description: "No usable images",
+        url: "https://example.com/gallery/physical/empty-images",
+        brandName: "OpenEire Studios",
+        image: [],
+      }),
+    ).not.toHaveProperty("image");
+  });
+
   it("builds article and artwork schema with the required base fields", () => {
     expect(
       buildArticleSchema({
@@ -115,6 +147,50 @@ describe("seoSchema helpers", () => {
       "@type": "WebSite",
       name: "OpenEire Studios",
       url: "https://example.com",
+    });
+  });
+
+  it("builds organization and website schema with optional brand metadata", () => {
+    expect(
+      buildOrganizationSchema({
+        type: "OnlineStore",
+        name: "OpenÉire Studios",
+        alternateName: "OpenEire Studios",
+        url: "https://openeire.ie",
+        logo: "https://openeire.ie/logo.png",
+        description: "Premium aerial photography and licensing.",
+        contactEmail: "studio@openeire.ie",
+        sameAs: ["https://instagram.com/openeirestudios"],
+      }),
+    ).toEqual({
+      "@context": "https://schema.org",
+      "@type": "OnlineStore",
+      name: "OpenÉire Studios",
+      alternateName: "OpenEire Studios",
+      url: "https://openeire.ie",
+      logo: "https://openeire.ie/logo.png",
+      description: "Premium aerial photography and licensing.",
+      contactPoint: [
+        {
+          "@type": "ContactPoint",
+          email: "studio@openeire.ie",
+        },
+      ],
+      sameAs: ["https://instagram.com/openeirestudios"],
+    });
+
+    expect(
+      buildWebsiteSchema({
+        name: "OpenÉire Studios",
+        alternateName: "OpenEire Studios",
+        url: "https://openeire.ie",
+      }),
+    ).toEqual({
+      "@context": "https://schema.org",
+      "@type": "WebSite",
+      name: "OpenÉire Studios",
+      alternateName: "OpenEire Studios",
+      url: "https://openeire.ie",
     });
   });
 


### PR DESCRIPTION
## Summary

This PR finishes a frontend launch-polish pass focused on three things:

- stronger Google/social metadata
- consistent `OpenÉire Studios` branding in user-facing copy
- better mobile usability by preventing the Iubenda floating button from covering toast messages

## What changed

### 1. SEO / structured data
- Fixed site-level brand constants in `site.ts`
- Improved `SEOHead` to:
  - use absolute `og:image`
  - use absolute `twitter:image`
  - include `max-image-preview:large` on indexable pages
  - provide a default social preview image fallback
- Expanded schema helpers to support richer:
  - `Organization`
  - `WebSite`
  - `Product`
- Added/strengthened organization and website schema on:
  - homepage
  - about page
- Updated physical product detail pages so product schema uses public absolute preview images and branded metadata

### 2. Logo / brand consistency
- Pointed organization schema to an existing public square logo asset:
  - `simple-logo-black.png`
- Cleaned user-facing brand text to `OpenÉire Studios` across the touched FAQ, landing, and legal pages
- Kept ASCII fallback only in the explicit alternate-name/config use case

### 3. Mobile toast visibility
- The app-wide toaster was anchored at `bottom-center`, which let the Iubenda floating button cover part of toast messages on mobile
- Added a compact-viewport bottom offset so toasts render above the Iubenda button on smaller screens
- Desktop toast placement stays effectively unchanged

## Why

This PR improves launch readiness without changing the visual design:

- Google and social crawlers get stronger brand/page metadata
- structured data uses a crawlable public logo and public preview images
- buyer-facing pages use consistent brand spelling
- mobile feedback toasts remain readable even with the Iubenda widget present

## Files of note

- `src/config/site.ts`
- `src/components/SEOHead.tsx`
- `src/lib/seoSchema.ts`
- `src/pages/HomePage.tsx`
- `src/pages/AboutPage.tsx`
- `src/pages/ProductDetailPage.tsx`
- `src/App.tsx`

## Build / verification

Ran:
- `npm run build`

Result:
- build passed

Notes:
- first build attempt hit local sandbox `spawn EPERM`
- reran outside sandbox successfully
- existing Vite chunk-size / `"use client"` warnings remain, but the production build completed

## Manual checks

- Inspect homepage HTML and confirm `Organization` + `WebSite` JSON-LD exists
- Inspect one physical product page and confirm `Product` JSON-LD uses a public preview image URL
- Verify og:image/twitter:image resolve to absolute URLs
- Run Google Rich Results Test on homepage and one physical product page
- On mobile, trigger success/error toasts and confirm the Iubenda button no longer covers the message text
