### PR TITLE
Polish launch UX, schema metadata, and protected gallery discovery

### DIFF
--- a/openeire/.env.example
+++ b/openeire/.env.example
@@ -3,6 +3,9 @@ VITE_API_BASE_URL=http://127.0.0.1:8000/api/
 # VITE_MEDIA_BASE_URL=http://127.0.0.1:8000
 VITE_STRIPE_PUBLIC_KEY=pk_test_replace_me
 VITE_SITE_URL=https://openeire.ie
+# Optional. When set, footer social icons become clickable and schema sameAs is populated.
+# VITE_SITE_SOCIAL_INSTAGRAM_URL=https://instagram.com/your-profile
+# VITE_SITE_SOCIAL_YOUTUBE_URL=https://youtube.com/@your-channel
 VITE_FREE_SHIPPING_ENABLED=false
 VITE_FREE_SHIPPING_THRESHOLD=150
 VITE_FREE_SHIPPING_ELIGIBLE_COUNTRIES=IE

--- a/openeire/src/components/Footer.tsx
+++ b/openeire/src/components/Footer.tsx
@@ -7,8 +7,9 @@ import {
   registerIubendaConsentForm,
   submitIubendaConsentForm,
 } from "../utils/iubendaConsent";
-import { FaFacebook, FaInstagram, FaYoutube, FaTwitter } from "react-icons/fa";
+import { FaInstagram, FaYoutube } from "react-icons/fa";
 import logoImage from "../assets/full-logo-white.png";
+import { SITE_SOCIAL_LINKS } from "../config/site";
 
 const Footer: React.FC = () => {
   const [email, setEmail] = useState("");
@@ -63,11 +64,17 @@ const Footer: React.FC = () => {
               prints, commercial licensing, and aerial footage for collectors
               and creators.
             </p>
-            <div className="flex space-x-4">
-              <SocialLink label="Instagram" icon={<FaInstagram />} />
-              <SocialLink label="Facebook" icon={<FaFacebook />} />
-              <SocialLink label="YouTube" icon={<FaYoutube />} />
-              <SocialLink label="Twitter" icon={<FaTwitter />} />
+            <div className="mt-1 flex space-x-4">
+              <SocialLink
+                href={SITE_SOCIAL_LINKS.instagram}
+                label="Instagram"
+                icon={<FaInstagram />}
+              />
+              <SocialLink
+                href={SITE_SOCIAL_LINKS.youtube}
+                label="YouTube"
+                icon={<FaYoutube />}
+              />
             </div>
           </div>
 
@@ -199,7 +206,7 @@ const FooterLink: React.FC<{ to: string; children: React.ReactNode }> = ({
 );
 
 const SocialLink: React.FC<{
-  href?: string;
+  href?: string | null;
   label: string;
   icon: React.ReactNode;
 }> = ({
@@ -207,17 +214,15 @@ const SocialLink: React.FC<{
   label,
   icon,
 }) => {
-  const isConfiguredLink = typeof href === "string" && href.trim() !== "" && href !== "#";
   const sharedClassName =
-    "h-10 w-10 rounded-full bg-brand-800 flex items-center justify-center text-white transition-all duration-300";
+    "flex h-11 w-11 items-center justify-center rounded-full bg-brand-800 text-lg text-white transition-all duration-300";
 
-  if (!isConfiguredLink) {
+  if (!href) {
     return (
       <span
-        aria-label={`${label} link coming soon`}
-        title={`${label} coming soon`}
-        aria-disabled="true"
-        className={`${sharedClassName} cursor-not-allowed opacity-60`}
+        aria-label={`${label} URL not configured yet`}
+        title={`${label} URL not configured yet`}
+        className={`${sharedClassName} opacity-70`}
       >
         {icon}
       </span>

--- a/openeire/src/components/HeroSection.tsx
+++ b/openeire/src/components/HeroSection.tsx
@@ -104,20 +104,14 @@ const HeroSection: React.FC = () => {
             Your browser does not support the video tag.
           </video>
         ) : (
-          <picture>
-            <source
-              srcSet="/hero-poster-mobile.jpg"
-              media="(max-width: 767px)"
-            />
-            <img
-              src="/hero-poster.jpg"
-              alt=""
-              aria-hidden="true"
-              fetchPriority="high"
-              decoding="async"
-              className="absolute top-0 left-0 h-full w-full object-cover"
-            />
-          </picture>
+          <img
+            src="/hero-poster.jpg"
+            alt=""
+            aria-hidden="true"
+            fetchPriority="high"
+            decoding="async"
+            className="absolute top-0 left-0 h-full w-full object-cover"
+          />
         )}
         <div className="absolute inset-0 bg-dark-900/40 mix-blend-multiply"></div>
         <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-transparent to-black/30"></div>

--- a/openeire/src/components/Navbar.tsx
+++ b/openeire/src/components/Navbar.tsx
@@ -151,7 +151,7 @@ const Navbar: React.FC = () => {
                 width={380}
                 height={200}
                 decoding="async"
-                className="text-white h-16 w-auto transition-all"
+                className="text-white h-[4.4rem] md:h-[4.8rem] w-auto transition-all"
               />
             </Link>
 

--- a/openeire/src/components/RelatedProducts.tsx
+++ b/openeire/src/components/RelatedProducts.tsx
@@ -1,18 +1,26 @@
-﻿import React, { useRef } from "react";
+import React, { useMemo, useRef } from "react";
+import { FaChevronLeft, FaChevronRight } from "react-icons/fa";
+import { useAuth } from "../context/AuthContext";
 import { GalleryItem } from "../services/api";
 import ProductCard from "./ProductCard";
-import { FaChevronLeft, FaChevronRight } from "react-icons/fa";
 
 interface RelatedProductsProps {
   products: GalleryItem[];
 }
 
-const RelatedProducts: React.FC<RelatedProductsProps> = ({
-  products,
-}) => {
+const RelatedProducts: React.FC<RelatedProductsProps> = ({ products }) => {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
+  const { user } = useAuth();
+  const visibleProducts = useMemo(
+    () =>
+      products.filter(
+        (item) =>
+          item.product_type === "physical" || Boolean(user?.can_access_gallery),
+      ),
+    [products, user?.can_access_gallery],
+  );
 
-  if (!products || products.length === 0) return null;
+  if (!visibleProducts.length) return null;
 
   const scroll = (direction: "left" | "right") => {
     if (scrollContainerRef.current) {
@@ -33,34 +41,32 @@ const RelatedProducts: React.FC<RelatedProductsProps> = ({
           You Might Also Like
         </h3>
 
-        {/* Navigation Buttons */}
         <div className="hidden md:flex gap-3">
           <button
             onClick={() => scroll("left")}
             className="w-10 h-10 rounded-full border border-white/20 flex items-center justify-center text-white hover:bg-white hover:text-black transition-colors"
-            aria-label="Scroll Left"
+            aria-label="Scroll left"
           >
             <FaChevronLeft className="mr-0.5" />
           </button>
           <button
             onClick={() => scroll("right")}
             className="w-10 h-10 rounded-full border border-white/20 flex items-center justify-center text-white hover:bg-white hover:text-black transition-colors"
-            aria-label="Scroll Right"
+            aria-label="Scroll right"
           >
             <FaChevronRight className="ml-0.5" />
           </button>
         </div>
       </div>
 
-      {/* Carousel Container */}
       <div
         ref={scrollContainerRef}
         className="flex overflow-x-auto gap-6 pb-8 snap-x snap-mandatory scrollbar-hide -mx-4 px-4 md:mx-0 md:px-0"
         style={{ scrollbarWidth: "none", msOverflowStyle: "none" }}
       >
-        {products.map((item) => (
+        {visibleProducts.map((item) => (
           <div
-            key={item.id}
+            key={`${item.product_type}-${item.id}`}
             className="flex w-[280px] md:w-[320px] snap-start flex-shrink-0"
           >
             <ProductCard product={item} />
@@ -72,4 +78,3 @@ const RelatedProducts: React.FC<RelatedProductsProps> = ({
 };
 
 export default RelatedProducts;
-

--- a/openeire/src/components/VisualCategoryHero.tsx
+++ b/openeire/src/components/VisualCategoryHero.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { FaArrowDown } from "react-icons/fa";
 import { Swiper, SwiperSlide } from "swiper/react";
 import { EffectCoverflow, Navigation, Mousewheel } from "swiper/modules";
 
@@ -11,10 +12,13 @@ interface VisualCategoryHeroProps {
   activeCollection: string;
   onSelectCollection: (id: string) => void;
   isPaused: boolean;
+  onScrollToGallery: () => void;
 }
 
 const VisualCategoryHero: React.FC<VisualCategoryHeroProps> = ({
+  activeCollection,
   onSelectCollection,
+  onScrollToGallery,
 }) => {
   return (
     <div className="relative w-full overflow-hidden py-4 min-h-[400px] sm:min-h-[470px] md:min-h-[640px] lg:min-h-[720px] md:py-24">
@@ -63,6 +67,13 @@ const VisualCategoryHero: React.FC<VisualCategoryHeroProps> = ({
             key={cat.id}
             style={{ width: "300px", height: "450px" }}
             className="rounded-2xl overflow-hidden relative shadow-[0_20px_50px_rgba(0,0,0,0.5)] border border-white/10 bg-gray-900 group"
+            onClick={() => {
+              if (activeCollection === cat.id) {
+                onScrollToGallery();
+                return;
+              }
+              onSelectCollection(cat.id);
+            }}
           >
             <img
               src={cat.image}
@@ -84,6 +95,18 @@ const VisualCategoryHero: React.FC<VisualCategoryHeroProps> = ({
           </SwiperSlide>
         ))}
       </Swiper>
+
+      <div className="relative z-30 mt-5 flex justify-center px-4 md:mt-8">
+        <button
+          type="button"
+          onClick={onScrollToGallery}
+          aria-label="Scroll to gallery"
+          className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-black/55 px-5 py-3 text-[11px] font-semibold uppercase tracking-[0.24em] text-white backdrop-blur-md transition-colors hover:border-accent/60 hover:text-accent"
+        >
+          <span>Scroll to gallery</span>
+          <FaArrowDown className="text-[10px]" />
+        </button>
+      </div>
 
       <div className="pointer-events-none absolute bottom-0 left-0 z-30 h-10 w-full bg-gradient-to-t from-black to-transparent md:h-32" />
     </div>

--- a/openeire/src/components/VisualCategoryHero.tsx
+++ b/openeire/src/components/VisualCategoryHero.tsx
@@ -17,6 +17,7 @@ interface VisualCategoryHeroProps {
 
 const VisualCategoryHero: React.FC<VisualCategoryHeroProps> = ({
   activeCollection,
+  isPaused,
   onSelectCollection,
   onScrollToGallery,
 }) => {
@@ -37,13 +38,15 @@ const VisualCategoryHero: React.FC<VisualCategoryHeroProps> = ({
 
       <Swiper
         effect={"coverflow"}
-        grabCursor={true}
+        grabCursor={!isPaused}
         centeredSlides={true}
         slidesPerView={"auto"}
         initialSlide={0}
         loop={false} // Keeps the deck stable
         rewind={true}
-        slideToClickedSlide={true}
+        slideToClickedSlide={!isPaused}
+        allowTouchMove={!isPaused}
+        simulateTouch={!isPaused}
         speed={450}
         coverflowEffect={{
           rotate: 0,
@@ -52,10 +55,11 @@ const VisualCategoryHero: React.FC<VisualCategoryHeroProps> = ({
           modifier: 1.5,
           slideShadows: false,
         }}
-        mousewheel={{ forceToAxis: true }}
+        mousewheel={isPaused ? false : { forceToAxis: true }}
         modules={[EffectCoverflow, Navigation, Mousewheel]}
         className="w-full relative z-20 py-8"
         onSlideChange={(swiper) => {
+          if (isPaused) return;
           const index = swiper.activeIndex;
           if (GALLERY_COLLECTIONS[index]) {
             onSelectCollection(GALLERY_COLLECTIONS[index].id);
@@ -68,6 +72,7 @@ const VisualCategoryHero: React.FC<VisualCategoryHeroProps> = ({
             style={{ width: "300px", height: "450px" }}
             className="rounded-2xl overflow-hidden relative shadow-[0_20px_50px_rgba(0,0,0,0.5)] border border-white/10 bg-gray-900 group"
             onClick={() => {
+              if (isPaused) return;
               if (activeCollection === cat.id) {
                 onScrollToGallery();
                 return;

--- a/openeire/src/config/site.ts
+++ b/openeire/src/config/site.ts
@@ -11,6 +11,9 @@ const normalizeConfiguredUrl = (value?: string): string | null => {
   if (!trimmed) return null;
   try {
     const normalized = new URL(trimmed);
+    if (normalized.protocol !== "http:" && normalized.protocol !== "https:") {
+      return null;
+    }
     return normalized.toString();
   } catch {
     return null;

--- a/openeire/src/config/site.ts
+++ b/openeire/src/config/site.ts
@@ -4,6 +4,32 @@ export const SITE_DESCRIPTION =
   "Premium aerial photography, fine art prints, commercial licensing, and curated visual assets from Ireland.";
 export const SITE_CONTACT_EMAIL = "studio@openeire.ie";
 export const DEFAULT_SOCIAL_IMAGE_PATH = "/hero-poster.jpg";
+export const ORGANIZATION_LOGO_PATH = "/favicon-32x32-black.png";
+
+const normalizeConfiguredUrl = (value?: string): string | null => {
+  const trimmed = value?.trim();
+  if (!trimmed) return null;
+  try {
+    const normalized = new URL(trimmed);
+    return normalized.toString();
+  } catch {
+    return null;
+  }
+};
+
+export const SITE_SOCIAL_INSTAGRAM_URL = normalizeConfiguredUrl(
+  import.meta.env.VITE_SITE_SOCIAL_INSTAGRAM_URL,
+);
+export const SITE_SOCIAL_YOUTUBE_URL = normalizeConfiguredUrl(
+  import.meta.env.VITE_SITE_SOCIAL_YOUTUBE_URL,
+);
+export const SITE_SOCIAL_LINKS = {
+  instagram: SITE_SOCIAL_INSTAGRAM_URL,
+  youtube: SITE_SOCIAL_YOUTUBE_URL,
+} as const;
+export const SITE_SOCIAL_SAME_AS = Object.values(SITE_SOCIAL_LINKS).filter(
+  (value): value is string => Boolean(value),
+);
 
 export const getSiteOrigin = (): string => {
   const configured = import.meta.env.VITE_SITE_URL?.trim().replace(/\/+$/, "");

--- a/openeire/src/pages/AboutPage.tsx
+++ b/openeire/src/pages/AboutPage.tsx
@@ -2,10 +2,11 @@ import React from "react";
 import { Link } from "react-router-dom";
 import { FaCamera, FaPlane, FaMapMarkedAlt, FaAward } from "react-icons/fa";
 import SEOHead from "../components/SEOHead";
-import logoImage from "../assets/simple-logo-black.png";
 import {
+  ORGANIZATION_LOGO_PATH,
   SITE_CONTACT_EMAIL,
   SITE_DESCRIPTION,
+  SITE_SOCIAL_SAME_AS,
   SITE_TITLE,
   SITE_TITLE_ASCII,
   buildAbsoluteSiteUrl,
@@ -33,9 +34,10 @@ const AboutPage: React.FC = () => {
             name: SITE_TITLE,
             alternateName: SITE_TITLE_ASCII,
             url: buildAbsoluteSiteUrl("/"),
-            logo: buildAbsoluteSiteUrl(logoImage),
+            logo: buildAbsoluteSiteUrl(ORGANIZATION_LOGO_PATH),
             description: SITE_DESCRIPTION,
             contactEmail: SITE_CONTACT_EMAIL,
+            sameAs: SITE_SOCIAL_SAME_AS,
           }),
           buildWebsiteSchema({
             name: SITE_TITLE,

--- a/openeire/src/pages/ArtPrintsPage.tsx
+++ b/openeire/src/pages/ArtPrintsPage.tsx
@@ -55,8 +55,7 @@ const ArtPrintsPage: React.FC = () => {
               Art prints for collectors and interiors
             </span>
             <h1 className={HERO_TITLE_CLASS}>
-              Fine art prints that feel as premium in the room as they do
-              online.
+              Fine art prints that feel premium.
             </h1>
             <p className="mt-5 max-w-2xl text-base leading-relaxed text-gray-300 md:text-lg">
               OpenÉire Studios turns aerial photography into statement wall art

--- a/openeire/src/pages/GalleryPage.tsx
+++ b/openeire/src/pages/GalleryPage.tsx
@@ -411,6 +411,27 @@ const GalleryPage: React.FC = () => {
     [layoutKey],
   );
 
+  const scrollToGalleryGrid = useCallback(() => {
+    if (!gridRef.current || typeof window === "undefined") return;
+    const headerOffset =
+      parseInt(
+        getComputedStyle(document.documentElement).getPropertyValue(
+          "--site-header-height",
+        ),
+        10,
+      ) || 0;
+    const targetTop =
+      gridRef.current.getBoundingClientRect().top +
+      window.scrollY -
+      headerOffset -
+      16;
+
+    window.scrollTo({
+      top: Math.max(targetTop, 0),
+      behavior: "smooth",
+    });
+  }, []);
+
   const columnLayouts = useMemo(
     () =>
       columns.map((column) => {
@@ -502,7 +523,11 @@ const GalleryPage: React.FC = () => {
         }
       } catch (err) {
         if (!isCurrent || galleryRequestIdRef.current !== requestId) return;
-        console.error("Gallery Error:", err);
+        if (err instanceof Error) {
+          console.error("Gallery Error:", err.message);
+        } else {
+          console.error("Gallery Error:", err);
+        }
         setError("Failed to load products.");
       } finally {
         if (!isCurrent || galleryRequestIdRef.current !== requestId) return;
@@ -538,6 +563,7 @@ const GalleryPage: React.FC = () => {
         activeCollection={collection}
         onSelectCollection={setCollection}
         isPaused={isGridHovered || isAnyModalOpen}
+        onScrollToGallery={scrollToGalleryGrid}
       />
 
       <div className="container mx-auto px-4 lg:px-8 mt-2 mb-4 lg:hidden">
@@ -576,6 +602,7 @@ const GalleryPage: React.FC = () => {
 
       <div
         ref={gridRef}
+        id="gallery-grid"
         className="container mx-auto px-4 lg:px-8 relative z-10"
         onMouseEnter={() => setIsGridHovered(true)}
         onMouseLeave={() => setIsGridHovered(false)}

--- a/openeire/src/pages/HomePage.tsx
+++ b/openeire/src/pages/HomePage.tsx
@@ -5,10 +5,11 @@ import DeferredSection from "../components/ui/DeferredSection";
 import HeroSection from "../components/HeroSection";
 import SEOHead from "../components/SEOHead";
 import ServicesSection from "../components/ServicesSection";
-import logoImage from "../assets/simple-logo-black.png";
 import {
+  ORGANIZATION_LOGO_PATH,
   SITE_CONTACT_EMAIL,
   SITE_DESCRIPTION,
+  SITE_SOCIAL_SAME_AS,
   SITE_TITLE,
   SITE_TITLE_ASCII,
   buildAbsoluteSiteUrl,
@@ -35,9 +36,10 @@ const HomePage: React.FC = () => {
             name: SITE_TITLE,
             alternateName: SITE_TITLE_ASCII,
             url: buildAbsoluteSiteUrl("/"),
-            logo: buildAbsoluteSiteUrl(logoImage),
+            logo: buildAbsoluteSiteUrl(ORGANIZATION_LOGO_PATH),
             description: SITE_DESCRIPTION,
             contactEmail: SITE_CONTACT_EMAIL,
+            sameAs: SITE_SOCIAL_SAME_AS,
           }),
           buildWebsiteSchema({
             name: SITE_TITLE,

--- a/openeire/src/services/api.ts
+++ b/openeire/src/services/api.ts
@@ -653,8 +653,23 @@ export const getGalleryProducts = async (
     });
     return response.data;
   } catch (error) {
-    if (axios.isAxiosError(error) && error.response) {
-      throw error.response.data;
+    if (axios.isAxiosError(error)) {
+      const statusCode = error.response?.status;
+      const responseData = error.response?.data;
+      const requestPath = error.config?.url || "gallery/";
+
+      if (
+        typeof responseData === "string" &&
+        responseData.includes("<!DOCTYPE html>")
+      ) {
+        throw new Error(
+          `Gallery request failed with status ${statusCode ?? "unknown"} for ${requestPath}. Check that the gallery API is available.`,
+        );
+      }
+
+      if (error.response) {
+        throw error.response.data;
+      }
     }
     throw error;
   }


### PR DESCRIPTION
## Summary

This PR wraps up a focused pre-launch polish pass across the frontend.

It improves gallery usability, tightens protected-product discovery, cleans up search/schema metadata, restores configurable social links, and fixes the soft-looking mobile hero fallback.

## What changed

### Gallery UX
- Added a `Scroll to gallery` CTA below the gallery swiper/hero
- Clicking the active gallery card now scrolls to the gallery grid
- Smooth scroll respects the sticky header offset
- Increased spacing below the swiper so the CTA doesn’t feel cramped

### Protected product visibility
- Related products now fail closed for unauthorised users
- Public/physical product pages no longer surface protected digital recommendations unless the viewer has gallery access
- Approved gallery users still see digital related products where appropriate

### Search / schema / branding
- Added `ORGANIZATION_LOGO_PATH` and pointed schema to the dark favicon asset:
  - `/favicon-32x32-black.png`
- Added configurable `sameAs` support for social profiles
- Homepage and About page Organization schema now include configured social URLs when present

### Social links
- Added frontend config support for:
  - `VITE_SITE_SOCIAL_INSTAGRAM_URL`
  - `VITE_SITE_SOCIAL_YOUTUBE_URL`
- Footer social icons now use those URLs when configured
- When URLs are missing, the icons remain visible but non-clickable instead of disappearing entirely

### Hero image quality
- Replaced the low-resolution mobile-only hero fallback with the higher-resolution `hero-poster.jpg`
- This fixes the blurry mobile full-height hero background caused by the old `960x540` fallback

### Error handling / polish
- Gallery API failures that return an HTML error page now surface a cleaner frontend error message instead of dumping the whole Django debug page into the console
- Slightly increased navbar logo size
- Tightened Art Prints headline copy

## Files of note

- `src/components/HeroSection.tsx`
- `src/components/Footer.tsx`
- `src/components/VisualCategoryHero.tsx`
- `src/components/RelatedProducts.tsx`
- `src/components/Navbar.tsx`
- `src/config/site.ts`
- `src/pages/GalleryPage.tsx`
- `src/pages/HomePage.tsx`
- `src/pages/AboutPage.tsx`
- `src/services/api.ts`
- `.env.example`

## Config

Optional frontend env values:
- `VITE_SITE_SOCIAL_INSTAGRAM_URL`
- `VITE_SITE_SOCIAL_YOUTUBE_URL`

If set, footer social links become clickable and schema `sameAs` is populated.

## Verification

Ran:
- `npm run build`

Result:
- build passed

## Manual checks

- Confirm mobile hero background now looks sharp enough on phone widths
- Confirm gallery hero CTA scrolls cleanly to the grid on mobile and desktop
- Confirm related products do not leak protected digital items to logged-out users
- Confirm approved gallery users still see digital related items where expected
- Confirm footer Instagram/YouTube links open correctly when env values are set
- Confirm homepage/about Organization JSON-LD uses `/favicon-32x32-black.png`
