### PR TITLE
Polish product detail mobile UX and commercial licence modal behaviour

### DIFF
--- a/openeire/src/components/LicenseRequestModal.tsx
+++ b/openeire/src/components/LicenseRequestModal.tsx
@@ -138,7 +138,7 @@ const LicenseRequestModal: React.FC<LicenseRequestModalProps> = ({
         duration: formData.duration,
       });
       toast.success(
-        "License request submitted! We will be in touch shortly with a custom quote.",
+        "Licence request submitted! We will be in touch shortly with a custom quote.",
       );
       handleClose();
     } catch (error) {
@@ -170,7 +170,7 @@ const LicenseRequestModal: React.FC<LicenseRequestModalProps> = ({
               id="commercial-license-modal-title"
               className="text-xl font-serif font-bold text-white"
             >
-              Request Commercial License
+              Request Commercial Licence
             </h2>
             <p className="text-xs text-gray-400 mt-1 uppercase tracking-widest">
               For: {assetTitle}
@@ -235,14 +235,14 @@ const LicenseRequestModal: React.FC<LicenseRequestModalProps> = ({
             />
             {shouldLockEmail && user?.email && (
               <p className="text-xs text-gray-500 mt-2">
-                Signed-in license requests use your account email: {user.email}
+                Signed-in licence requests use your account email: {user.email}
               </p>
             )}
           </div>
 
           <div className="border-t border-white/10 pt-4 mt-2">
             <h3 className="text-sm font-bold text-white mb-4">
-              License Schedule Details
+              Licence Schedule Details
             </h3>
           </div>
 
@@ -371,8 +371,8 @@ const LicenseRequestModal: React.FC<LicenseRequestModalProps> = ({
                 className="mt-1 w-4 h-4 rounded border-gray-600 text-accent focus:ring-accent bg-black"
               />
               <span className="text-xs text-gray-300 leading-relaxed">
-                I understand this is a digital license, not a transfer of
-                ownership. This license strictly prohibits using the asset as
+                I understand this is a digital licence, not a transfer of
+                ownership. This licence strictly prohibits using the asset as
                 the primary value component of physical merchandise or
                 Print-on-Demand (POD) products for resale.
               </span>
@@ -403,7 +403,7 @@ const LicenseRequestModal: React.FC<LicenseRequestModalProps> = ({
                   : "bg-white text-black hover:bg-gray-200 active:scale-[0.98]"
               }`}
             >
-              {isSubmitting ? "Submitting..." : "Submit License Request"}
+              {isSubmitting ? "Submitting..." : "Submit Licence Request"}
             </button>
           </div>
         </form>

--- a/openeire/src/components/LicenseRequestModal.tsx
+++ b/openeire/src/components/LicenseRequestModal.tsx
@@ -64,6 +64,29 @@ const LicenseRequestModal: React.FC<LicenseRequestModalProps> = ({
     );
   }, [isOpen, isAuthenticated, user?.email]);
 
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const scrollY = window.scrollY;
+    const originalBodyOverflow = document.body.style.overflow;
+    const originalBodyPosition = document.body.style.position;
+    const originalBodyTop = document.body.style.top;
+    const originalBodyWidth = document.body.style.width;
+
+    document.body.style.overflow = "hidden";
+    document.body.style.position = "fixed";
+    document.body.style.top = `-${scrollY}px`;
+    document.body.style.width = "100%";
+
+    return () => {
+      document.body.style.overflow = originalBodyOverflow;
+      document.body.style.position = originalBodyPosition;
+      document.body.style.top = originalBodyTop;
+      document.body.style.width = originalBodyWidth;
+      window.scrollTo({ top: scrollY, behavior: "auto" });
+    };
+  }, [isOpen]);
+
   if (!isOpen) return null;
 
   const shouldLockEmail = Boolean(isAuthenticated && user?.email);
@@ -126,19 +149,27 @@ const LicenseRequestModal: React.FC<LicenseRequestModalProps> = ({
   };
 
   const modalContent = (
-    <div className="fixed inset-0 z-50 flex items-center justify-center p-4 animate-fade-in overflow-y-auto pt-20 pb-20">
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4 sm:p-6 animate-fade-in"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="commercial-license-modal-title"
+    >
       <div
         className="inset-0 bg-black/80 backdrop-blur-sm fixed"
         onClick={handleClose}
       ></div>
       <div
-        className="relative bg-gray-900 border border-white/10 rounded-2xl w-full max-w-2xl overflow-hidden shadow-2xl my-auto"
+        className="relative my-auto flex max-h-[calc(100dvh-2rem)] w-full max-w-2xl flex-col overflow-hidden rounded-2xl border border-white/10 bg-gray-900 shadow-2xl"
         onClick={(e) => e.stopPropagation()}
       >
         {/* HEADER */}
         <div className="flex justify-between items-center p-6 border-b border-white/10 bg-gray-900 sticky top-0 z-10">
           <div>
-            <h2 className="text-xl font-serif font-bold text-white">
+            <h2
+              id="commercial-license-modal-title"
+              className="text-xl font-serif font-bold text-white"
+            >
               Request Commercial License
             </h2>
             <p className="text-xs text-gray-400 mt-1 uppercase tracking-widest">
@@ -147,14 +178,18 @@ const LicenseRequestModal: React.FC<LicenseRequestModalProps> = ({
           </div>
           <button
             onClick={handleClose}
-            className="text-gray-400 hover:text-white transition-colors"
+            className="shrink-0 text-gray-400 transition-colors hover:text-white"
+            aria-label="Close commercial licence request"
           >
             <FaTimes className="text-xl" />
           </button>
         </div>
 
         {/* FORM */}
-        <form onSubmit={handleSubmit} className="p-6 space-y-5">
+        <form
+          onSubmit={handleSubmit}
+          className="space-y-5 overflow-y-auto overscroll-contain p-6"
+        >
           {/* Section 1: Client Details */}
           <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div>

--- a/openeire/src/components/Navbar.tsx
+++ b/openeire/src/components/Navbar.tsx
@@ -144,19 +144,19 @@ const Navbar: React.FC = () => {
         <div className="container mx-auto px-4 lg:px-8">
           <div className="flex items-center justify-between">
             {/* LEFT: Logo */}
-            <Link to="/" className="flex items-center">
+            <Link to="/" className="flex shrink-0 items-center">
               <img
                 src={logoImage}
                 alt={"Open\u00C9ire Studios Logo"}
                 width={380}
                 height={200}
                 decoding="async"
-                className="text-white h-[4.4rem] md:h-[4.8rem] w-auto transition-all"
+                className="h-[4.15rem] w-auto shrink-0 text-white transition-all lg:h-[4.4rem] xl:h-[4.8rem]"
               />
             </Link>
 
             {/* CENTER: Main Navigation (Desktop) */}
-            <div className="hidden md:flex items-center space-x-8 font-medium text-sm tracking-wide uppercase">
+            <div className="hidden lg:flex items-center space-x-8 font-medium text-sm tracking-wide uppercase">
               <NavLink
                 to="/art-prints"
                 className={hoverColor}
@@ -218,7 +218,7 @@ const Navbar: React.FC = () => {
               <button
                 type="button"
                 onClick={() => setIsMobileMenuOpen((prev) => !prev)}
-                className="md:hidden inline-flex items-center justify-center w-10 h-10 rounded-full border border-white/10 text-white hover:bg-white/10 transition-all"
+                className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/10 text-white transition-all hover:bg-white/10 lg:hidden"
                 aria-label={isMobileMenuOpen ? "Close menu" : "Open menu"}
                 aria-expanded={isMobileMenuOpen}
                 aria-controls="mobile-nav"
@@ -253,7 +253,7 @@ const Navbar: React.FC = () => {
               </button>
 
               {/* User Menu */}
-              <div className="hidden md:flex items-center space-x-4 text-sm font-medium">
+              <div className="hidden lg:flex items-center space-x-4 text-sm font-medium">
                 {isAuthenticated ? (
                   <>
                     <NavLink
@@ -293,7 +293,7 @@ const Navbar: React.FC = () => {
 
           {/* Mobile Menu Panel */}
           {isMobileMenuOpen && (
-            <div id="mobile-nav" className="md:hidden px-4 pb-4">
+            <div id="mobile-nav" className="px-4 pb-4 lg:hidden">
               <div className="mt-4 rounded-2xl border border-white/10 bg-dark/95 backdrop-blur-md shadow-lg p-4 space-y-4">
                 <NavLink
                   to="/art-prints"

--- a/openeire/src/components/ReviewCard.tsx
+++ b/openeire/src/components/ReviewCard.tsx
@@ -15,17 +15,19 @@ const ReviewCard: React.FC<ReviewCardProps> = ({ review }) => {
   });
 
   return (
-    <div className="bg-white/5 p-6 rounded-xl border border-white/5 mb-6 backdrop-blur-sm transition-colors hover:bg-white/10">
-      <div className="flex items-start justify-between mb-4">
-        <div className="flex items-center gap-3">
+    <div className="mb-6 rounded-xl border border-white/5 bg-white/5 p-4 backdrop-blur-sm transition-colors hover:bg-white/10 sm:p-6">
+      <div className="mb-4 flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="flex min-w-0 items-center gap-3">
           {/* User Icon Placeholder */}
-          <div className="w-10 h-10 rounded-full bg-gradient-to-br from-gray-700 to-black flex items-center justify-center text-gray-400">
+          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-gradient-to-br from-gray-700 to-black text-gray-400">
             <FaUserCircle className="text-2xl" />
           </div>
 
-          <div>
-            <p className="font-bold text-white text-sm">{review.user}</p>
-            <div className="flex items-center gap-2 mt-0.5">
+          <div className="min-w-0">
+            <p className="break-words text-sm font-bold text-white">
+              {review.user}
+            </p>
+            <div className="mt-0.5 flex items-center gap-2">
               <div className="scale-75 origin-left">
                 <StarRating
                   rating={review.rating}
@@ -36,20 +38,20 @@ const ReviewCard: React.FC<ReviewCardProps> = ({ review }) => {
             </div>
           </div>
         </div>
-        <p className="text-xs text-gray-500 font-medium uppercase tracking-wider">
+        <p className="max-w-full break-words pr-1 text-[11px] font-medium uppercase tracking-wider text-gray-500 sm:pl-4 sm:text-xs sm:text-right">
           {createdAt}
         </p>
       </div>
 
       {review.comment && (
-        <p className="text-gray-300 text-sm leading-relaxed font-sans pl-14">
+        <p className="pl-0 font-sans text-sm leading-relaxed text-gray-300 sm:pl-14">
           "{review.comment}"
         </p>
       )}
 
       {/* Admin Reply Section */}
       {review.admin_reply && (
-        <div className="mt-6 ml-14 p-4 bg-black/40 border-l-2 border-accent rounded-r-lg">
+        <div className="mt-6 rounded-r-lg border-l-2 border-accent bg-black/40 p-4 sm:ml-14">
           <div className="flex items-center gap-2 mb-2">
             <span className="text-[10px] font-bold text-accent uppercase tracking-widest border border-accent/30 px-2 py-0.5 rounded-full">
               Official Response

--- a/openeire/src/pages/ProductDetailPage.tsx
+++ b/openeire/src/pages/ProductDetailPage.tsx
@@ -474,7 +474,7 @@ const ProductDetailPage: React.FC = () => {
     : null;
 
   return (
-    <div className="bg-black min-h-screen text-white pt-24 pb-20 font-sans selection:bg-accent selection:text-black mobile-page-offset">
+    <div className="bg-black min-h-screen overflow-x-hidden text-white pt-24 pb-20 font-sans selection:bg-accent selection:text-black mobile-page-offset">
       <SEOHead
         title={product.title}
         description={
@@ -735,9 +735,18 @@ const ProductDetailPage: React.FC = () => {
                     </p>
                     <button
                       onClick={handleRequestLicense}
-                      className="w-full py-4 bg-transparent border-2 border-white/20 text-white font-bold text-lg rounded-xl hover:bg-white hover:text-black transition-all transform active:scale-[0.98] flex items-center justify-center gap-3"
+                      className="flex w-full min-w-0 items-center justify-center overflow-hidden rounded-xl border-2 border-white/20 bg-transparent px-3 py-4 text-center font-bold text-white transition-all active:scale-[0.98] hover:bg-white hover:text-black text-sm sm:px-4 sm:text-base 2xl:text-lg"
                     >
-                      <FaFileContract /> Request Commercial Licence
+                      <FaFileContract
+                        className="hidden shrink-0 2xl:block"
+                        aria-hidden="true"
+                      />
+                      <span className="block max-w-full truncate text-center whitespace-nowrap">
+                        <span className="2xl:hidden">Request Licence</span>
+                        <span className="hidden 2xl:inline">
+                          Request Commercial Licence
+                        </span>
+                      </span>
                     </button>
                   </div>
                 </div>

--- a/openeire/src/utils/toast.ts
+++ b/openeire/src/utils/toast.ts
@@ -207,7 +207,7 @@ export const getGoogleLoginToastErrorMessage = (error: unknown): string =>
 export const getLicenseRequestToastErrorMessage = (error: unknown): string =>
   getToastErrorMessage(error, {
     fallback:
-      "Could not submit your license request. Please review the form and try again.",
+      "Could not submit your licence request. Please review the form and try again.",
     fieldPriority: [
       "email",
       "client_name",
@@ -220,7 +220,8 @@ export const getLicenseRequestToastErrorMessage = (error: unknown): string =>
     ],
     statusMessages: {
       429: "You've reached the request limit for now. Please try again later.",
-      503: "License requests are temporarily unavailable. Please try again shortly.",
+      503:
+        "Licence requests are temporarily unavailable. Please try again shortly.",
     },
   });
 


### PR DESCRIPTION
## Summary

This PR is a focused frontend polish pass on the product detail experience, especially at narrow mobile widths and awkward tablet/desktop breakpoints.

It fixes the commercial licence CTA layout, improves modal scrolling behaviour, prevents a product detail overflow issue, adjusts the navbar breakpoint to avoid logo compression, and tightens review card layout on small screens.

## What changed

### Commercial licence CTA
- improved the digital purchase card CTA responsiveness
- kept the existing click behaviour and modal flow unchanged
- used a shorter label on narrower layouts:
  - `Request Licence`
- only shows the longer `Request Commercial Licence` label on very wide layouts
- hides the icon except on very wide screens to avoid layout breakage

### Commercial licence modal scrolling
- locks page/body scrolling while the modal is open
- keeps the overlay fixed to the viewport
- makes the modal form scroll internally
- uses a dynamic viewport-height max height so the modal remains usable on smaller laptops
- restores the original page scroll position when the modal closes

### Product detail overflow
- added local overflow protection on the product detail page to stop horizontal scrolling on narrow viewports

### Navbar breakpoint / logo compression
- moved the desktop navigation breakpoint later so the mobile menu takes over sooner
- prevents the logo from shrinking/compressing before the menu swap
- keeps desktop and mobile behaviour otherwise unchanged

### Review card mobile overflow
- stacked review header content more gracefully on small screens
- allowed long reviewer names/emails to wrap safely inside the card
- ensured date text stays inside the card
- reduced mobile indent pressure for the comment/reply layout

## Files changed

- `src/pages/ProductDetailPage.tsx`
- `src/components/LicenseRequestModal.tsx`
- `src/components/Navbar.tsx`
- `src/components/ReviewCard.tsx`

## Why

These changes are intentionally narrow and production-safe:
- no checkout logic changes
- no API contract changes
- no modal API changes
- no backend changes

The goal was just to remove UI breakage and awkward responsive behaviour before launch.

## Verification

Ran:
- `npm run build`

Result:
- build passed

Notes:
- existing Vite dependency `"use client"` warnings and chunk-size warnings still appear, but there was no build failure

## Manual checks

- Product detail page at `320px`, `375px`, and `389px`
  - no horizontal scrolling
  - commercial licence CTA stays inside the card
  - review cards stay inside the card and remain readable

- Product detail page at `1024px`, `1283px`, `1440px`, `1535px`
  - CTA remains centered and contained
  - navbar no longer compresses the logo before switching to the menu

- Commercial licence modal
  - background page does not scroll while open
  - modal content scrolls internally
  - close button remains accessible
  - closing the modal restores the original page position