### PR TITLE
Reduce redundant Stripe billing fields

### DIFF
--- a/openeire/src/components/CheckoutForm.tsx
+++ b/openeire/src/components/CheckoutForm.tsx
@@ -4,7 +4,10 @@ import {
   useElements,
   PaymentElement,
 } from "@stripe/react-stripe-js";
-import { ConfirmPaymentData } from "@stripe/stripe-js";
+import {
+  ConfirmPaymentData,
+  StripePaymentElementOptions,
+} from "@stripe/stripe-js";
 import { UserProfile, getCountries, Country } from "../services/api";
 import { useCart } from "../context/CartContext";
 import { FaTruck, FaCreditCard, FaBoxOpen } from "react-icons/fa";
@@ -92,6 +95,45 @@ const CheckoutPaymentSection: React.FC<CheckoutPaymentSectionProps> = ({
   const stripe = useStripe();
   const elements = useElements();
   const [isLoading, setIsLoading] = useState(false);
+  const paymentElementOptions = React.useMemo<StripePaymentElementOptions>(
+    () => ({
+      defaultValues: {
+        billingDetails: {
+          name: shippingDetails.name || undefined,
+          email: shippingDetails.email || undefined,
+          phone: shippingDetails.phone || undefined,
+          ...(hasPhysicalItems
+            ? {
+                address: {
+                  line1: shippingDetails.line1 || undefined,
+                  line2: shippingDetails.line2 || undefined,
+                  city: shippingDetails.city || undefined,
+                  state: shippingDetails.state || undefined,
+                  country: shippingDetails.country || undefined,
+                  postal_code: shippingDetails.postal_code || undefined,
+                },
+              }
+            : {}),
+        },
+      },
+      fields: {
+        billingDetails: {
+          name: "auto",
+          // Email is already collected in the checkout form and sent via receipt_email.
+          email: "never",
+          // Physical checkout collects phone above; digital checkout does not.
+          phone: hasPhysicalItems ? "never" : "auto",
+          address: hasPhysicalItems ? "if_required" : "auto",
+        },
+      },
+      wallets: {
+        applePay: "auto",
+        googlePay: "auto",
+        link: "auto",
+      },
+    }),
+    [hasPhysicalItems, shippingDetails],
+  );
 
   const handlePaymentSubmit = useCallback(async () => {
     if (!isPaymentReady) {
@@ -169,7 +211,7 @@ const CheckoutPaymentSection: React.FC<CheckoutPaymentSectionProps> = ({
       </div>
 
       {isPaymentReady ? (
-        <PaymentElement />
+        <PaymentElement options={paymentElementOptions} />
       ) : (
         <div className="rounded-xl border border-white/10 bg-black/40 p-4 text-sm text-gray-400">
           {hasPhysicalItems


### PR DESCRIPTION
## Summary

This PR is a focused checkout-form cleanup only.

It removes redundant billing fields from the Stripe payment section while preserving the existing checkout flow, payment confirmation logic, backend contract, and payment method support controlled by the backend.

## What changed

### Stripe PaymentElement cleanup
- confirmed checkout already collects customer email in the OpenEire checkout form
- confirmed physical checkout already collects phone in the OpenEire checkout form
- configured `PaymentElement` to:
  - stop redundantly collecting billing email
  - stop redundantly collecting billing phone for physical checkout
  - keep wallets on `auto`

### What stays the same
- card payments still work
- Apple Pay / Google Pay remain available when supported by Stripe/browser/device
- Link remains controlled by Stripe availability
- checkout form structure stays the same
- backend payment flow is unchanged from the frontend side

## Files changed

- `src/components/CheckoutForm.tsx`

## What caused the extra email/phone fields?

The redundant email and phone fields under the card section were coming from Stripe `PaymentElement` billing detail fields, not from the OpenEire checkout form itself.

## What payment methods remain visible from the frontend side?

Frontend-side:
- card remains
- Apple Pay / Google Pay remain on supported browsers/devices
- Link remains `auto`

The full payment method list is still determined by the backend PaymentIntent configuration.

## Verification

Ran:
- `npm run build`

Result:
- build passed

## Manual checks

- open checkout and confirm the top OpenEire checkout form still collects customer email
- for physical checkout, confirm the OpenEire checkout form still collects phone
- confirm the redundant billing email field is no longer shown inside Stripe
- confirm the redundant billing phone field is no longer shown for physical checkout
- confirm card payment still works
- confirm Apple Pay / Google Pay still appear when supported