### PR TITLE
Add concrete GA4 tag ID to frontend entry HTML

### DIFF
--- a/openeire/index.html
+++ b/openeire/index.html
@@ -8,7 +8,7 @@
     <script
       id="openeire-ga-script"
       async
-      src="https://www.googletagmanager.com/gtag/js?id=%VITE_GA_MEASUREMENT_ID%"
+      src="https://www.googletagmanager.com/gtag/js?id=G-96JSG3FV42"
       onload="this.dataset.loaded='true'"
       onerror="this.dataset.loaded='error'"
     ></script>
@@ -25,7 +25,7 @@
         ad_personalization: "denied",
       });
       window.gtag("js", new Date());
-      window.gtag("config", "%VITE_GA_MEASUREMENT_ID%", {
+      window.gtag("config", "G-96JSG3FV42", {
         send_page_view: false,
       });
     </script>


### PR DESCRIPTION
## Summary

This PR updates the frontend entry HTML so the Google tag in `index.html` uses the concrete GA4 measurement ID directly.

The app already had a GA bootstrap in the Vite entry head, so this change keeps that structure intact and avoids adding a duplicate tag block.

## What changed

- updated the existing Google tag script URL in `index.html` to:
  - `https://www.googletagmanager.com/gtag/js?id=G-96JSG3FV42`
- updated the existing `gtag("config", ...)` call to use:
  - `G-96JSG3FV42`
- left the rest of the frontend entry HTML unchanged
- did not move analytics into React
- did not add a new analytics package
- did not remove existing scripts

## Why this approach

The frontend already had a Google tag bootstrap in `index.html`.

Adding a second raw GA snippet would have risked duplicate configuration or duplicate tracking, so the safer change was to make the existing entry-HTML bootstrap explicit with the real measurement ID.

## File changed

- `index.html`

## Verification

Ran:
- `npm run build`

Result:
- build passed

Also confirmed the built output contains the concrete GA tag in:
- `dist/index.html`

## Manual verification

- deploy or serve the updated frontend
- open the site with analytics consent allowed
- check DevTools Network and confirm:
  - `gtag/js?id=G-96JSG3FV42` loads from `googletagmanager.com`
- open GA4 Realtime and confirm page views begin appearing