### PR TITLE
Fix Stripe PaymentElement billing details regression

### DIFF
--- a/openeire/src/components/CheckoutForm.tsx
+++ b/openeire/src/components/CheckoutForm.tsx
@@ -148,6 +148,25 @@ const CheckoutPaymentSection: React.FC<CheckoutPaymentSectionProps> = ({
     const confirmParams: ConfirmPaymentData = {
       return_url: `${window.location.origin}/checkout-success`,
       receipt_email: shippingDetails.email,
+      payment_method_data: {
+        billing_details: {
+          name: shippingDetails.name || undefined,
+          email: shippingDetails.email || undefined,
+          phone: shippingDetails.phone || undefined,
+          ...(hasPhysicalItems
+            ? {
+                address: {
+                  line1: shippingDetails.line1 || undefined,
+                  line2: shippingDetails.line2 || undefined,
+                  city: shippingDetails.city || undefined,
+                  state: shippingDetails.state || undefined,
+                  country: shippingDetails.country || undefined,
+                  postal_code: shippingDetails.postal_code || undefined,
+                },
+              }
+            : {}),
+        },
+      },
     };
 
     if (hasPhysicalItems) {


### PR DESCRIPTION
## Summary
This fixes the recent Stripe checkout regression caused by hiding billing email/phone fields in the `PaymentElement` without passing the same data explicitly into `stripe.confirmPayment()`.

## What changed
- added `confirmParams.payment_method_data.billing_details` in `CheckoutForm.tsx`
- always pass billing email and name from `shippingDetails` when available
- pass phone and address for physical checkout
- keep `receipt_email` unchanged
- keep physical `shipping` details unchanged
- continue hiding duplicate Stripe email/phone fields in the `PaymentElement`

## Why
Stripe now requires billing fields to be supplied during confirmation when those fields are disabled in the `PaymentElement` via `fields.billingDetails.* = "never"`.

Without this, checkout fails with:
`You specified 'never' for fields.billing_details.email ... but did not pass confirmParams.payment_method_data.billing_details.email ...`

## Scope
- frontend only
- no backend API changes
- no webhook changes
- no Prodigi changes

## Validation
- `npm run build` passed

## Manual check
- complete a physical test checkout with a Stripe test card
- confirm no duplicate email/phone fields appear in the payment section
- confirm no Stripe console error about missing `billing_details`
- confirm payment succeeds and order completion flow still works