### PR TITLE
Add newsletter signup modal and WELCOME10 checkout discount support

### DIFF
--- a/openeire/src/App.tsx
+++ b/openeire/src/App.tsx
@@ -9,6 +9,7 @@ import BackToTop from "./components/BackToTop";
 import Breadcrumbs from "./components/Breadcrumbs";
 import ScrollToTop from "./components/ScrollToTop";
 import AnalyticsListener from "./components/AnalyticsListener";
+import NewsletterSignupModal from "./components/NewsletterSignupModal";
 import ProtectedRoute from "./components/ProtectedRoute";
 import StaffRoute from "./components/StaffRoute";
 import GalleryGuard from "./components/GalleryGuard";
@@ -306,6 +307,7 @@ function App() {
           </Suspense>
         </main>
         <BackToTop />
+        <NewsletterSignupModal />
         <Footer />
       </BreadcrumbProvider>
     </>

--- a/openeire/src/components/CheckoutDiscountCard.tsx
+++ b/openeire/src/components/CheckoutDiscountCard.tsx
@@ -1,0 +1,112 @@
+import React from "react";
+import { FaTag } from "react-icons/fa";
+
+interface CheckoutDiscountCardProps {
+  value: string;
+  onChange: (value: string) => void;
+  onApply: () => void;
+  onRemove: () => void;
+  isApplying: boolean;
+  appliedCode: string | null;
+  discountAmount: number;
+  discountLabel: string | null;
+  errorMessage: string | null;
+  disabled?: boolean;
+}
+
+const CheckoutDiscountCard: React.FC<CheckoutDiscountCardProps> = ({
+  value,
+  onChange,
+  onApply,
+  onRemove,
+  isApplying,
+  appliedCode,
+  discountAmount,
+  discountLabel,
+  errorMessage,
+  disabled = false,
+}) => {
+  const hasAppliedDiscount = Boolean(appliedCode && discountAmount > 0);
+
+  return (
+    <div className="mb-4 rounded-2xl border border-white/10 bg-gray-900 p-6 shadow-xl">
+      <div className="mb-4 flex items-center gap-3">
+        <div className="rounded-full border border-white/10 bg-white/5 p-2 text-accent">
+          <FaTag className="text-sm" />
+        </div>
+        <div>
+          <h2 className="font-serif text-lg font-bold text-white">
+            Welcome Discount
+          </h2>
+          <p className="text-xs uppercase tracking-[0.2em] text-gray-500">
+            Art prints only
+          </p>
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-3">
+        <label className="block">
+          <span className="mb-2 block text-xs font-bold uppercase tracking-[0.2em] text-gray-500">
+            Discount Code
+          </span>
+          <div className="flex flex-col gap-3 sm:flex-row">
+            <input
+              type="text"
+              value={value}
+              onChange={(event) => onChange(event.target.value)}
+              placeholder="WELCOME10"
+              autoCapitalize="characters"
+              spellCheck={false}
+              disabled={disabled || isApplying}
+              className="w-full rounded-xl border border-white/10 bg-black/30 px-4 py-3 text-white placeholder:text-gray-500 focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500 disabled:cursor-not-allowed disabled:opacity-60"
+            />
+            <button
+              type="button"
+              onClick={onApply}
+              disabled={disabled || isApplying}
+              className="inline-flex min-w-[132px] items-center justify-center rounded-xl bg-white px-4 py-3 text-sm font-bold text-black transition-colors hover:bg-brand-500 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {isApplying ? "Applying..." : hasAppliedDiscount ? "Reapply" : "Apply"}
+            </button>
+          </div>
+        </label>
+
+        {hasAppliedDiscount && (
+          <div className="rounded-xl border border-brand-500/20 bg-brand-500/10 px-4 py-4">
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <p className="text-sm font-bold text-white">
+                  {discountLabel || appliedCode} applied
+                </p>
+                <p className="mt-1 text-sm text-brand-100/80">
+                  You&apos;re saving €{discountAmount.toFixed(2)} on eligible art
+                  prints.
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={onRemove}
+                className="inline-flex items-center justify-center rounded-full border border-white/10 px-4 py-2 text-xs font-bold uppercase tracking-[0.18em] text-gray-300 transition-colors hover:border-white/20 hover:text-white"
+              >
+                Remove
+              </button>
+            </div>
+          </div>
+        )}
+
+        {errorMessage && (
+          <div className="rounded-xl border border-red-500/20 bg-red-500/10 px-4 py-3 text-sm text-red-300">
+            {errorMessage}
+          </div>
+        )}
+
+        <p className="text-xs leading-6 text-gray-500">
+          Applies to art prints only. Shipping, digital licences, commercial
+          licences, and custom services are excluded.
+        </p>
+      </div>
+    </div>
+  );
+};
+
+export default CheckoutDiscountCard;

--- a/openeire/src/components/Footer.tsx
+++ b/openeire/src/components/Footer.tsx
@@ -32,7 +32,7 @@ const Footer: React.FC = () => {
     e.preventDefault();
     setLoading(true);
     try {
-      await newsletterSignup(email);
+      await newsletterSignup({ email, source: "footer" });
       submitIubendaConsentForm("newsletter-signup-form");
       toast.success("Welcome to the community! \uD83C\uDDEE\uD83C\uDDEA");
       setEmail("");

--- a/openeire/src/components/NewsletterSignupModal.tsx
+++ b/openeire/src/components/NewsletterSignupModal.tsx
@@ -1,0 +1,328 @@
+import React, { useEffect, useMemo, useState } from "react";
+import ReactDOM from "react-dom";
+import { useLocation } from "react-router-dom";
+import { FaCheckCircle, FaTimes } from "react-icons/fa";
+import { newsletterSignup } from "../services/api";
+import { getNewsletterToastErrorMessage } from "../utils/toast";
+import {
+  registerIubendaConsentForm,
+  submitIubendaConsentForm,
+} from "../utils/iubendaConsent";
+
+const DISMISSED_UNTIL_KEY = "openeire:newsletter-modal-dismissed-until";
+const SUBSCRIBED_KEY = "openeire:newsletter-modal-subscribed";
+const DISMISS_DURATION_MS = 14 * 24 * 60 * 60 * 1000;
+const WELCOME_CODE = "WELCOME10";
+const MODAL_FORM_ID = "newsletter-modal-signup-form";
+const MODAL_SUBMIT_ID = "newsletter-modal-submit";
+
+const BLOCKED_PATH_PREFIXES = [
+  "/bag",
+  "/checkout",
+  "/checkout-success",
+  "/login",
+  "/logout",
+  "/register",
+  "/profile",
+  "/request-password-reset",
+  "/password-reset/confirm",
+  "/verify-pending",
+  "/verify-email",
+  "/staff/",
+  "/gallery-gate",
+  "/gallery/digital",
+  "/gallery/photo",
+  "/gallery/video",
+  "/403",
+  "/404",
+  "/500",
+];
+
+const shouldBlockModalForPath = (pathname: string): boolean =>
+  BLOCKED_PATH_PREFIXES.some((prefix) =>
+    pathname === prefix || pathname.startsWith(`${prefix}/`),
+  );
+
+const hasActiveDismissal = (): boolean => {
+  if (typeof window === "undefined") return false;
+  const dismissedUntil = Number(window.localStorage.getItem(DISMISSED_UNTIL_KEY));
+  return Number.isFinite(dismissedUntil) && dismissedUntil > Date.now();
+};
+
+const hasCompletedSignup = (): boolean => {
+  if (typeof window === "undefined") return false;
+  return window.localStorage.getItem(SUBSCRIBED_KEY) === "1";
+};
+
+const NewsletterSignupModal: React.FC = () => {
+  const location = useLocation();
+  const [isOpen, setIsOpen] = useState(false);
+  const [email, setEmail] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isSuccess, setIsSuccess] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const isEligibleRoute = useMemo(
+    () => !shouldBlockModalForPath(location.pathname),
+    [location.pathname],
+  );
+
+  useEffect(() => {
+    return registerIubendaConsentForm({
+      formId: MODAL_FORM_ID,
+      submitButtonId: MODAL_SUBMIT_ID,
+      subject: {
+        email: "email",
+      },
+      preferences: {
+        newsletter: "newsletter_consent",
+      },
+    });
+  }, []);
+
+  useEffect(() => {
+    if (!isEligibleRoute) {
+      setIsOpen(false);
+      return;
+    }
+
+    if (typeof window === "undefined") return;
+    if (hasActiveDismissal() || hasCompletedSignup()) return;
+
+    let didTrigger = false;
+
+    const openModal = () => {
+      if (didTrigger || hasActiveDismissal() || hasCompletedSignup()) return;
+      didTrigger = true;
+      setIsOpen(true);
+    };
+
+    const timeoutId = window.setTimeout(openModal, 10_000);
+    const handleScroll = () => {
+      const scrollableHeight =
+        document.documentElement.scrollHeight - window.innerHeight;
+      if (scrollableHeight <= 0) return;
+
+      const scrolledRatio = window.scrollY / scrollableHeight;
+      if (scrolledRatio >= 0.4) {
+        openModal();
+      }
+    };
+
+    window.addEventListener("scroll", handleScroll, { passive: true });
+
+    return () => {
+      window.clearTimeout(timeoutId);
+      window.removeEventListener("scroll", handleScroll);
+    };
+  }, [isEligibleRoute, location.key]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        setIsOpen(false);
+      }
+    };
+
+    const scrollY = window.scrollY;
+    const originalBodyOverflow = document.body.style.overflow;
+    const originalBodyPosition = document.body.style.position;
+    const originalBodyTop = document.body.style.top;
+    const originalBodyWidth = document.body.style.width;
+
+    document.body.style.overflow = "hidden";
+    document.body.style.position = "fixed";
+    document.body.style.top = `-${scrollY}px`;
+    document.body.style.width = "100%";
+    window.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      document.body.style.overflow = originalBodyOverflow;
+      document.body.style.position = originalBodyPosition;
+      document.body.style.top = originalBodyTop;
+      document.body.style.width = originalBodyWidth;
+      window.removeEventListener("keydown", handleKeyDown);
+      window.scrollTo({ top: scrollY, behavior: "auto" });
+    };
+  }, [isOpen]);
+
+  const closeWithDismissal = () => {
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(
+        DISMISSED_UNTIL_KEY,
+        String(Date.now() + DISMISS_DURATION_MS),
+      );
+    }
+    setIsOpen(false);
+  };
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setIsSubmitting(true);
+    setErrorMessage(null);
+
+    try {
+      await newsletterSignup({
+        email,
+        source: "newsletter_modal",
+      });
+      submitIubendaConsentForm(MODAL_FORM_ID);
+      if (typeof window !== "undefined") {
+        window.localStorage.setItem(SUBSCRIBED_KEY, "1");
+        window.localStorage.removeItem(DISMISSED_UNTIL_KEY);
+      }
+      setIsSuccess(true);
+      setEmail("");
+    } catch (error) {
+      setErrorMessage(getNewsletterToastErrorMessage(error));
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  if (!isOpen) return null;
+
+  const modalContent = (
+    <div
+      className="fixed inset-0 z-50 flex items-end justify-center p-4 sm:items-center sm:p-6"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="newsletter-signup-modal-title"
+    >
+      <div
+        className="fixed inset-0 bg-black/70 backdrop-blur-sm"
+        onClick={closeWithDismissal}
+      />
+      <div className="relative z-10 w-full max-w-xl overflow-hidden rounded-[28px] border border-white/10 bg-[radial-gradient(circle_at_top,_rgba(245,197,24,0.08),_transparent_35%),linear-gradient(180deg,_rgba(17,24,39,0.98),_rgba(5,8,14,0.98))] shadow-[0_30px_80px_rgba(0,0,0,0.45)]">
+        <button
+          type="button"
+          onClick={closeWithDismissal}
+          aria-label="Close newsletter signup modal"
+          className="absolute right-4 top-4 rounded-full border border-white/10 bg-white/5 p-2 text-gray-300 transition-colors hover:border-white/20 hover:text-white"
+        >
+          <FaTimes />
+        </button>
+
+        <div className="px-6 pb-6 pt-8 sm:px-10 sm:pb-10 sm:pt-10">
+          {isSuccess ? (
+            <div className="space-y-5">
+              <div className="inline-flex h-12 w-12 items-center justify-center rounded-full bg-brand-500/15 text-brand-500">
+                <FaCheckCircle className="text-xl" />
+              </div>
+              <div className="space-y-3">
+                <h2
+                  id="newsletter-signup-modal-title"
+                  className="font-serif text-3xl font-bold text-white"
+                >
+                  You&apos;re in
+                </h2>
+                <p className="text-base leading-relaxed text-gray-300">
+                  Use code <span className="font-bold text-white">{WELCOME_CODE}</span>{" "}
+                  at checkout for 10% off your first art print.
+                </p>
+                <p className="text-sm leading-relaxed text-gray-400">
+                  If Brevo email delivery is configured, we&apos;ll send the code
+                  there too.
+                </p>
+                <p className="text-xs uppercase tracking-[0.22em] text-gray-500">
+                  Applies to art prints only. Does not apply to shipping,
+                  digital licences, commercial licences, or custom services.
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={() => setIsOpen(false)}
+                className="inline-flex rounded-full bg-brand-500 px-5 py-3 text-sm font-bold text-black transition-colors hover:bg-white"
+              >
+                Continue Browsing
+              </button>
+            </div>
+          ) : (
+            <div className="space-y-6">
+              <div className="space-y-4">
+                <p className="text-xs font-semibold uppercase tracking-[0.28em] text-accent">
+                  Collector Access
+                </p>
+                <h2
+                  id="newsletter-signup-modal-title"
+                  className="max-w-md font-serif text-3xl font-bold leading-tight text-white sm:text-4xl"
+                >
+                  Get 10% off your first art print
+                </h2>
+                <p className="max-w-lg text-sm leading-7 text-gray-300 sm:text-base">
+                  Join the OpenÉire list for new aerial print releases,
+                  behind-the-scenes stories, and early access to collections.
+                </p>
+              </div>
+
+              <form
+                id={MODAL_FORM_ID}
+                onSubmit={handleSubmit}
+                className="space-y-4"
+              >
+                <input
+                  type="hidden"
+                  name="newsletter_consent"
+                  value="true"
+                  readOnly
+                />
+                <label className="block">
+                  <span className="mb-2 block text-xs font-bold uppercase tracking-[0.22em] text-gray-500">
+                    Email Address
+                  </span>
+                  <input
+                    id="newsletter-modal-email"
+                    name="email"
+                    type="email"
+                    value={email}
+                    onChange={(event) => setEmail(event.target.value)}
+                    placeholder="you@example.com"
+                    required
+                    autoComplete="email"
+                    className="w-full rounded-2xl border border-white/10 bg-black/30 px-4 py-3 text-white placeholder:text-gray-500 focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500"
+                  />
+                </label>
+
+                {errorMessage && (
+                  <div className="rounded-2xl border border-red-500/20 bg-red-500/10 px-4 py-3 text-sm text-red-300">
+                    {errorMessage}
+                  </div>
+                )}
+
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+                  <button
+                    id={MODAL_SUBMIT_ID}
+                    type="submit"
+                    disabled={isSubmitting}
+                    className="inline-flex w-full items-center justify-center rounded-full bg-brand-500 px-5 py-3 text-sm font-bold text-black transition-colors hover:bg-white disabled:cursor-not-allowed disabled:opacity-60 sm:w-auto"
+                  >
+                    {isSubmitting ? "Joining..." : "Get my 10% code"}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={closeWithDismissal}
+                    className="inline-flex w-full items-center justify-center rounded-full border border-white/10 px-5 py-3 text-sm font-medium text-gray-300 transition-colors hover:border-white/20 hover:text-white sm:w-auto"
+                  >
+                    Maybe later
+                  </button>
+                </div>
+              </form>
+
+              <p className="text-xs leading-6 text-gray-500">
+                Applies to art prints only. Does not apply to shipping, digital
+                licences, commercial licences, or custom services.
+              </p>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+
+  return ReactDOM.createPortal(modalContent, document.body);
+};
+
+export default NewsletterSignupModal;

--- a/openeire/src/components/NewsletterSignupModal.tsx
+++ b/openeire/src/components/NewsletterSignupModal.tsx
@@ -39,13 +39,19 @@ const BLOCKED_PATH_PREFIXES = [
 ];
 
 const shouldBlockModalForPath = (pathname: string): boolean =>
-  BLOCKED_PATH_PREFIXES.some((prefix) =>
-    pathname === prefix || pathname.startsWith(`${prefix}/`),
-  );
+  BLOCKED_PATH_PREFIXES.some((prefix) => {
+    const normalizedPrefix = prefix.endsWith("/") ? prefix.slice(0, -1) : prefix;
+    return (
+      pathname === normalizedPrefix ||
+      pathname.startsWith(`${normalizedPrefix}/`)
+    );
+  });
 
 const hasActiveDismissal = (): boolean => {
   if (typeof window === "undefined") return false;
-  const dismissedUntil = Number(window.localStorage.getItem(DISMISSED_UNTIL_KEY));
+  const dismissedUntil = Number(
+    window.localStorage.getItem(DISMISSED_UNTIL_KEY),
+  );
   return Number.isFinite(dismissedUntil) && dismissedUntil > Date.now();
 };
 
@@ -67,7 +73,19 @@ const NewsletterSignupModal: React.FC = () => {
     [location.pathname],
   );
 
+  const closeWithDismissal = () => {
+    if (typeof window !== "undefined") {
+      window.localStorage.setItem(
+        DISMISSED_UNTIL_KEY,
+        String(Date.now() + DISMISS_DURATION_MS),
+      );
+    }
+    setIsOpen(false);
+  };
+
   useEffect(() => {
+    if (!isOpen || isSuccess) return;
+
     return registerIubendaConsentForm({
       formId: MODAL_FORM_ID,
       submitButtonId: MODAL_SUBMIT_ID,
@@ -78,7 +96,7 @@ const NewsletterSignupModal: React.FC = () => {
         newsletter: "newsletter_consent",
       },
     });
-  }, []);
+  }, [isOpen, isSuccess]);
 
   useEffect(() => {
     if (!isEligibleRoute) {
@@ -123,7 +141,7 @@ const NewsletterSignupModal: React.FC = () => {
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === "Escape") {
         event.preventDefault();
-        setIsOpen(false);
+        closeWithDismissal();
       }
     };
 
@@ -148,16 +166,6 @@ const NewsletterSignupModal: React.FC = () => {
       window.scrollTo({ top: scrollY, behavior: "auto" });
     };
   }, [isOpen]);
-
-  const closeWithDismissal = () => {
-    if (typeof window !== "undefined") {
-      window.localStorage.setItem(
-        DISMISSED_UNTIL_KEY,
-        String(Date.now() + DISMISS_DURATION_MS),
-      );
-    }
-    setIsOpen(false);
-  };
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
@@ -217,14 +225,14 @@ const NewsletterSignupModal: React.FC = () => {
                   id="newsletter-signup-modal-title"
                   className="font-serif text-3xl font-bold text-white"
                 >
-                  You&apos;re in
+                  You're in
                 </h2>
                 <p className="text-base leading-relaxed text-gray-300">
                   Use code <span className="font-bold text-white">{WELCOME_CODE}</span>{" "}
                   at checkout for 10% off your first art print.
                 </p>
                 <p className="text-sm leading-relaxed text-gray-400">
-                  If Brevo email delivery is configured, we&apos;ll send the code
+                  If Brevo email delivery is configured, we'll send the code
                   there too.
                 </p>
                 <p className="text-xs uppercase tracking-[0.22em] text-gray-500">

--- a/openeire/src/components/OrderSummary.tsx
+++ b/openeire/src/components/OrderSummary.tsx
@@ -28,6 +28,8 @@ interface OrderSummaryProps {
   freeShippingApplied?: boolean;
   freeShippingThreshold?: number | null;
   shippingCountry?: string | null;
+  discountAmount?: number;
+  discountLabel?: string | null;
 }
 
 const OrderSummary: React.FC<OrderSummaryProps> = ({
@@ -37,6 +39,8 @@ const OrderSummary: React.FC<OrderSummaryProps> = ({
   freeShippingApplied = false,
   freeShippingThreshold = null,
   shippingCountry = null,
+  discountAmount = 0,
+  discountLabel = null,
 }) => {
   const { cartItems: cart, cartTotal } = useCart();
   const { isAuthenticated } = useAuth();
@@ -65,7 +69,9 @@ const OrderSummary: React.FC<OrderSummaryProps> = ({
     FREE_SHIPPING_PROMO_ENABLED && hasPhysicalItems && !isPhysicalShippingPending;
 
   const grandTotal =
-    cartTotal + (hasPhysicalItems && !isPhysicalShippingPending ? shippingCost : 0);
+    cartTotal +
+    (hasPhysicalItems && !isPhysicalShippingPending ? shippingCost : 0) -
+    discountAmount;
 
   const handleBeginCheckout = useCallback(() => {
     if (typeof window === "undefined") return;
@@ -121,6 +127,14 @@ const OrderSummary: React.FC<OrderSummaryProps> = ({
             <span className="text-white font-medium">{"\u20AC"}{shippingCost.toFixed(2)}</span>
           )}
         </div>
+        {discountAmount > 0 && (
+          <div className="flex justify-between text-sm text-gray-400">
+            <span>{discountLabel || "Discount"}</span>
+            <span className="font-medium text-brand-500">
+              -€{discountAmount.toFixed(2)}
+            </span>
+          </div>
+        )}
       </div>
 
       <div className="border-t border-white/10 pt-6 mb-8">

--- a/openeire/src/pages/CheckoutPage.tsx
+++ b/openeire/src/pages/CheckoutPage.tsx
@@ -389,6 +389,14 @@ const CheckoutPage: React.FC = () => {
   }, [clearAppliedDiscount]);
 
   useEffect(() => {
+    if (checkoutCartItems.length > 0) return;
+
+    clearAppliedDiscount();
+    setDiscountCodeInput("");
+    setDiscountError(null);
+  }, [checkoutCartItems.length, clearAppliedDiscount]);
+
+  useEffect(() => {
     let isCancelled = false;
 
     const initializeCheckout = async () => {

--- a/openeire/src/pages/CheckoutPage.tsx
+++ b/openeire/src/pages/CheckoutPage.tsx
@@ -1,13 +1,19 @@
 ﻿/// <reference types="vite/client" />
 
-import React, { useState, useEffect, useMemo, useRef } from "react";
+import React, { useState, useEffect, useMemo, useRef, useCallback } from "react";
 import { loadStripe, StripeElementsOptions } from "@stripe/stripe-js";
 import { Elements } from "@stripe/react-stripe-js";
 import axios from "axios";
-import { isPhysicalCartOptions, useCart } from "../context/CartContext";
+import { CartItem, isPhysicalCartOptions, useCart } from "../context/CartContext";
 import { useAuth } from "../context/AuthContext";
-import { getProfile, UserProfile, api } from "../services/api";
+import {
+  getProfile,
+  UserProfile,
+  api,
+  validateDiscountCode,
+} from "../services/api";
 import CheckoutForm from "../components/CheckoutForm";
+import CheckoutDiscountCard from "../components/CheckoutDiscountCard";
 import OrderSummary from "../components/OrderSummary";
 import { Link } from "react-router-dom";
 import { FaLock, FaShieldAlt } from "react-icons/fa";
@@ -137,14 +143,67 @@ type CreatePaymentIntentPayload = {
   save_info: boolean;
   shipping_details?: CheckoutShippingDetailsPayload;
   shipping_method?: string;
+  discount_code?: string;
 };
 
 type CreatePaymentIntentResponse = {
   clientSecret: string;
   shippingCost?: number;
+  discountAmount?: number;
+  discountCode?: string;
+  discountLabel?: string;
+  totalPrice?: number;
   freeShippingApplied?: boolean;
   freeShippingThreshold?: number | string | null;
 };
+
+const buildCheckoutCartPayload = (
+  cartItems: CartItem[],
+): CheckoutCartItemPayload[] =>
+  cartItems.map((item) => {
+    const productType = item.product.product_type;
+    if (
+      !isPhysicalProductType(productType) &&
+      !isDigitalProductType(productType)
+    ) {
+      throw new Error(
+        "One or more bag items have an unsupported product type. Remove and re-add the item.",
+      );
+    }
+
+    if (isPhysicalProductType(productType)) {
+      const rawVariantId = isPhysicalCartOptions(item.options)
+        ? item.options.variantId
+        : Number(item.product.id);
+      const variantId = Number(rawVariantId);
+      if (!Number.isFinite(variantId) || variantId <= 0) {
+        throw new Error(
+          "One or more print options are invalid. Remove and re-add the item.",
+        );
+      }
+
+      return {
+        product_id: variantId,
+        product_type: "physical" as const,
+        quantity: item.quantity,
+        options: {
+          material: isPhysicalCartOptions(item.options)
+            ? item.options.material
+            : undefined,
+          size: isPhysicalCartOptions(item.options)
+            ? item.options.size
+            : undefined,
+          variantId,
+        },
+      };
+    }
+
+    return {
+      product_id: item.product.id,
+      product_type: productType,
+      quantity: item.quantity,
+    };
+  });
 
 const CheckoutPage: React.FC = () => {
   const [clientSecret, setClientSecret] = useState("");
@@ -162,6 +221,12 @@ const CheckoutPage: React.FC = () => {
   const [saveInfo, setSaveInfo] = useState(true);
   const [isUpdatingIntent, setIsUpdatingIntent] = useState(false);
   const [checkoutError, setCheckoutError] = useState<string | null>(null);
+  const [discountCodeInput, setDiscountCodeInput] = useState("");
+  const [appliedDiscountCode, setAppliedDiscountCode] = useState("");
+  const [discountAmount, setDiscountAmount] = useState(0);
+  const [discountLabel, setDiscountLabel] = useState<string | null>(null);
+  const [discountError, setDiscountError] = useState<string | null>(null);
+  const [isApplyingDiscount, setIsApplyingDiscount] = useState(false);
   const latestIntentRequestId = useRef(0);
   const checkoutAttemptIdRef = useRef<string>(
     typeof crypto !== "undefined" && typeof crypto.randomUUID === "function"
@@ -197,7 +262,10 @@ const CheckoutPage: React.FC = () => {
       ),
       purchase: {
         transaction_id: checkoutAttemptIdRef.current,
-        value: cartTotal + (hasPhysicalItems ? calculatedShippingCost : 0),
+        value:
+          cartTotal +
+          (hasPhysicalItems ? calculatedShippingCost : 0) -
+          discountAmount,
         currency: "EUR",
         tax: 0,
         shipping: hasPhysicalItems ? calculatedShippingCost : 0,
@@ -208,6 +276,7 @@ const CheckoutPage: React.FC = () => {
       calculatedShippingCost,
       cartTotal,
       checkoutCartItems,
+      discountAmount,
       hasDigitalItems,
       hasPhysicalItems,
     ],
@@ -237,6 +306,13 @@ const CheckoutPage: React.FC = () => {
   const hasResolvedAccountEmail = Boolean(
     isAuthenticated && profileData?.email,
   );
+  const normalizedDiscountInput = discountCodeInput.trim().toUpperCase();
+
+  const clearAppliedDiscount = useCallback(() => {
+    setAppliedDiscountCode("");
+    setDiscountAmount(0);
+    setDiscountLabel(null);
+  }, []);
 
   useEffect(() => {
     if (isAuthenticated) {
@@ -254,6 +330,63 @@ const CheckoutPage: React.FC = () => {
         : { ...prev, email: profileData.email },
     );
   }, [isAuthenticated, profileData?.email]);
+
+  const handleDiscountInputChange = useCallback((value: string) => {
+    setDiscountCodeInput(value.toUpperCase());
+    setDiscountError(null);
+  }, []);
+
+  const handleApplyDiscount = useCallback(async () => {
+    if (!normalizedDiscountInput) {
+      setDiscountError("Enter a discount code.");
+      return;
+    }
+
+    const customerEmail = shippingDetails.email.trim();
+    if (!customerEmail && !hasResolvedAccountEmail) {
+      setDiscountError("Enter your email before applying a discount code.");
+      return;
+    }
+
+    setIsApplyingDiscount(true);
+    setDiscountError(null);
+    setCheckoutError(null);
+
+    try {
+      const cart = buildCheckoutCartPayload(checkoutCartItems);
+      const response = await validateDiscountCode({
+        cart,
+        email: customerEmail || undefined,
+        discount_code: normalizedDiscountInput,
+      });
+
+      setAppliedDiscountCode(response.code);
+      setDiscountAmount(Number(response.discountAmount ?? 0));
+      setDiscountLabel(response.discountLabel || null);
+      setDiscountCodeInput(response.code);
+    } catch (error) {
+      clearAppliedDiscount();
+      setDiscountError(
+        getApiErrorMessage(error) ||
+          "We could not apply that discount code right now.",
+      );
+    } finally {
+      setIsApplyingDiscount(false);
+    }
+  }, [
+    checkoutCartItems,
+    clearAppliedDiscount,
+    hasResolvedAccountEmail,
+    normalizedDiscountInput,
+    shippingDetails.email,
+  ]);
+
+  const handleRemoveDiscount = useCallback(() => {
+    clearAppliedDiscount();
+    setDiscountCodeInput("");
+    setDiscountError(null);
+    setCheckoutError(null);
+  }, [clearAppliedDiscount]);
 
   useEffect(() => {
     let isCancelled = false;
@@ -299,57 +432,16 @@ const CheckoutPage: React.FC = () => {
       setCheckoutError(null);
 
       try {
-        const simplifiedCart: CheckoutCartItemPayload[] = checkoutCartItems.map(
-          (item) => {
-            const productType = item.product.product_type;
-            if (
-              !isPhysicalProductType(productType) &&
-              !isDigitalProductType(productType)
-            ) {
-              throw new Error(
-                "One or more bag items have an unsupported product type. Remove and re-add the item.",
-              );
-            }
-
-            if (isPhysicalProductType(productType)) {
-              const rawVariantId = isPhysicalCartOptions(item.options)
-                ? item.options.variantId
-                : Number(item.product.id);
-              const variantId = Number(rawVariantId);
-              if (!Number.isFinite(variantId) || variantId <= 0) {
-                throw new Error(
-                  "One or more print options are invalid. Remove and re-add the item.",
-                );
-              }
-
-              return {
-                product_id: variantId,
-                product_type: "physical",
-                quantity: item.quantity,
-                options: {
-                  material: isPhysicalCartOptions(item.options)
-                    ? item.options.material
-                    : undefined,
-                  size: isPhysicalCartOptions(item.options)
-                    ? item.options.size
-                    : undefined,
-                  variantId,
-                },
-              };
-            }
-
-            return {
-              product_id: item.product.id,
-              product_type: productType,
-              quantity: item.quantity,
-            };
-          },
-        );
+        const simplifiedCart = buildCheckoutCartPayload(checkoutCartItems);
 
         const payload: CreatePaymentIntentPayload = {
           cart: simplifiedCart,
           save_info: saveInfo,
         };
+
+        if (appliedDiscountCode) {
+          payload.discount_code = appliedDiscountCode;
+        }
 
         if (hasPhysicalItems) {
           payload.shipping_details = {
@@ -378,6 +470,9 @@ const CheckoutPage: React.FC = () => {
         setCalculatedShippingCost(
           hasPhysicalItems ? Number(response.data.shippingCost ?? 0) : 0,
         );
+        setDiscountAmount(Number(response.data.discountAmount ?? 0));
+        setDiscountLabel(response.data.discountLabel || null);
+        setAppliedDiscountCode(response.data.discountCode || "");
         setFreeShippingApplied(Boolean(response.data.freeShippingApplied));
         const parsedFreeShippingThreshold = Number(
           response.data.freeShippingThreshold,
@@ -390,10 +485,24 @@ const CheckoutPage: React.FC = () => {
       } catch (error) {
         if (isCancelled || requestId !== latestIntentRequestId.current) return;
         resetCheckoutIntentState();
-        setCheckoutError(
-          getApiErrorMessage(error) ||
-            "We could not prepare checkout right now. Please review your details and try again.",
-        );
+        const apiErrorMessage = getApiErrorMessage(error);
+        const errorCode = axios.isAxiosError(error)
+          ? String(error.response?.data?.code || "")
+          : "";
+
+        if (errorCode.startsWith("DISCOUNT_")) {
+          clearAppliedDiscount();
+          setDiscountError(
+            apiErrorMessage ||
+              "That discount code could not be applied to this checkout.",
+          );
+          setCheckoutError(null);
+        } else {
+          setCheckoutError(
+            apiErrorMessage ||
+              "We could not prepare checkout right now. Please review your details and try again.",
+          );
+        }
       } finally {
         if (!isCancelled && requestId === latestIntentRequestId.current) {
           setIsUpdatingIntent(false);
@@ -411,6 +520,8 @@ const CheckoutPage: React.FC = () => {
     hasPhysicalItems,
     isAuthenticated,
     physicalAddressKey,
+    appliedDiscountCode,
+    clearAppliedDiscount,
     requiresAuthenticatedCheckout,
     saveInfo,
     shippingMethodKey,
@@ -544,6 +655,18 @@ const CheckoutPage: React.FC = () => {
           </div>
 
           <div className="lg:col-span-2 lg:sticky lg:top-28">
+            <CheckoutDiscountCard
+              value={discountCodeInput}
+              onChange={handleDiscountInputChange}
+              onApply={handleApplyDiscount}
+              onRemove={handleRemoveDiscount}
+              isApplying={isApplyingDiscount}
+              appliedCode={appliedDiscountCode || null}
+              discountAmount={discountAmount}
+              discountLabel={discountLabel}
+              errorMessage={discountError}
+              disabled={checkoutCartItems.length === 0}
+            />
             <OrderSummary
               isCheckoutPage
               shippingCost={calculatedShippingCost}
@@ -551,6 +674,8 @@ const CheckoutPage: React.FC = () => {
               freeShippingApplied={freeShippingApplied}
               freeShippingThreshold={freeShippingThreshold}
               shippingCountry={shippingDetails.country}
+              discountAmount={discountAmount}
+              discountLabel={discountLabel}
             />
             <div className="mt-4 flex items-center justify-center gap-2 text-xs text-gray-500">
               <FaLock /> SSL Secured - Stripe Protected

--- a/openeire/src/services/api.ts
+++ b/openeire/src/services/api.ts
@@ -479,9 +479,6 @@ export const validateDiscountCode = async (
     );
     return response.data;
   } catch (error) {
-    if (axios.isAxiosError(error) && error.response) {
-      throw error.response.data;
-    }
     throw error;
   }
 };

--- a/openeire/src/services/api.ts
+++ b/openeire/src/services/api.ts
@@ -435,11 +435,48 @@ export const getTestimonials = async (): Promise<Testimonial[]> => {
   }
 };
 
+export type NewsletterSignupPayload = {
+  email: string;
+  first_name?: string;
+  source?: string;
+};
+
+export type DiscountValidationPayload = {
+  cart: unknown[];
+  email?: string;
+  discount_code: string;
+};
+
+export type DiscountValidationResponse = {
+  code: string;
+  discountAmount: number;
+  discountPercent: number;
+  discountLabel: string;
+  eligibleSubtotal: number;
+};
+
 export const newsletterSignup = async (
-  email: string
+  payload: NewsletterSignupPayload,
 ): Promise<{ email: string }> => {
   try {
-    const response = await api.post("home/newsletter-signup/", { email });
+    const response = await api.post("home/newsletter-signup/", payload);
+    return response.data;
+  } catch (error) {
+    if (axios.isAxiosError(error) && error.response) {
+      throw error.response.data;
+    }
+    throw error;
+  }
+};
+
+export const validateDiscountCode = async (
+  payload: DiscountValidationPayload,
+): Promise<DiscountValidationResponse> => {
+  try {
+    const response = await api.post<DiscountValidationResponse>(
+      "checkout/validate-discount/",
+      payload,
+    );
     return response.data;
   } catch (error) {
     if (axios.isAxiosError(error) && error.response) {


### PR DESCRIPTION
## Summary
This PR adds two launch-facing conversion improvements to the frontend:

- a premium newsletter signup modal for public browsing pages
- checkout coupon support for the universal `WELCOME10` art print discount

It keeps the existing checkout, Stripe, licence, and fulfilment flows intact, and only extends the frontend to use backend support that already exists.

## What changed

### Newsletter modal
- added a reusable `NewsletterSignupModal`
- shows only on public browsing pages
- does not show on checkout, checkout success, auth/account, staff, or protected gallery routes
- triggers after either:
  - 10 seconds on page
  - or 40% scroll depth
- stores dismissal in `localStorage` for 14 days
- stores successful signup state in `localStorage` so it does not reappear
- submits to the existing newsletter endpoint with:
  - `source: "newsletter_modal"`
- shows inline success state with `WELCOME10`
- includes close button, overlay close, and `ESC` close
- uses a calm, premium, on-brand modal style without becoming aggressive

### Footer newsletter source
- updated footer newsletter signup to send:
  - `source: "footer"`

### Checkout discount support
- added a checkout discount card for entering `WELCOME10`
- validates discount codes via the backend `validate-discount` endpoint
- passes applied `discount_code` into `create-payment-intent`
- shows:
  - applied discount label
  - discount amount
  - updated total
  - backend validation errors clearly
- keeps shipping separate from the discount
- handles non-eligible carts cleanly
- preserves the recent Stripe billing-details regression fix

### API helper updates
- extended newsletter signup API helper to accept payloads with `source`
- added frontend helper for discount validation

## Files changed
- `openeire/src/App.tsx`
- `openeire/src/components/Footer.tsx`
- `openeire/src/components/OrderSummary.tsx`
- `openeire/src/pages/CheckoutPage.tsx`
- `openeire/src/services/api.ts`
- `openeire/src/components/CheckoutDiscountCard.tsx`
- `openeire/src/components/NewsletterSignupModal.tsx`

## Validation
- `npm run build` passed

## Backend assumptions
This PR assumes the backend already supports:
- `POST /api/home/newsletter-signup/` with optional `source`
- `POST /api/checkout/validate-discount/`
- `POST /api/checkout/create-payment-intent/` with optional `discount_code`

## Manual QA
- confirm newsletter modal appears on public pages after 10s or 40% scroll
- confirm modal does not appear on checkout, success, login/register/profile, staff, or protected gallery routes
- confirm dismiss persists for 14 days
- confirm successful modal signup persists and shows `WELCOME10`
- confirm footer newsletter signup still works
- apply `WELCOME10` to an art print checkout and confirm:
  - shipping is not discounted
  - total updates correctly
  - invalid code errors are clear
  - digital-only carts show the backend eligibility error clearly
- complete a discounted payment successfully and confirm normal order flow still works