### PR TITLE
Remove Axios and migrate API calls to native fetch

### DIFF
--- a/openeire/package-lock.json
+++ b/openeire/package-lock.json
@@ -13,7 +13,6 @@
         "@stripe/stripe-js": "^7.9.0",
         "@tailwindcss/vite": "^4.1.13",
         "@tanstack/react-query": "^5.90.2",
-        "axios": "1.13.5",
         "dompurify": "^3.3.3",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
@@ -2297,17 +2296,6 @@
         "postcss": "^8.1.0"
       }
     },
-    "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
-      "license": "MIT",
-      "dependencies": {
-        "follow-redirects": "^1.15.11",
-        "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
-      }
-    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -3148,42 +3136,6 @@
       "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://github.com/sponsors/RubenVerborgh"
-        }
-      ],
-      "license": "MIT",
-      "engines": {
-        "node": ">=4.0"
-      },
-      "peerDependenciesMeta": {
-        "debug": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
-      "license": "MIT",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
     },
     "node_modules/fraction.js": {
       "version": "4.3.7",
@@ -4256,12 +4208,6 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
       }
-    },
-    "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/openeire/package.json
+++ b/openeire/package.json
@@ -16,7 +16,6 @@
     "@stripe/stripe-js": "^7.9.0",
     "@tailwindcss/vite": "^4.1.13",
     "@tanstack/react-query": "^5.90.2",
-    "axios": "1.13.5",
     "dompurify": "^3.3.3",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",

--- a/openeire/src/pages/CheckoutPage.tsx
+++ b/openeire/src/pages/CheckoutPage.tsx
@@ -1,9 +1,8 @@
-﻿/// <reference types="vite/client" />
+/// <reference types="vite/client" />
 
 import React, { useState, useEffect, useMemo, useRef, useCallback } from "react";
 import { loadStripe, StripeElementsOptions } from "@stripe/stripe-js";
 import { Elements } from "@stripe/react-stripe-js";
-import axios from "axios";
 import { CartItem, isPhysicalCartOptions, useCart } from "../context/CartContext";
 import { useAuth } from "../context/AuthContext";
 import {
@@ -12,6 +11,7 @@ import {
   api,
   validateDiscountCode,
 } from "../services/api";
+import { isApiError } from "../services/fetchClient";
 import CheckoutForm from "../components/CheckoutForm";
 import CheckoutDiscountCard from "../components/CheckoutDiscountCard";
 import OrderSummary from "../components/OrderSummary";
@@ -57,6 +57,9 @@ const flattenApiErrors = (value: unknown, path = ""): string[] => {
   return [];
 };
 
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null;
+
 const hasCompletePhysicalAddress = (
   shippingDetails: ShippingDetails,
 ): boolean => {
@@ -86,14 +89,15 @@ const hasCompletePhysicalAddress = (
 };
 
 const getApiErrorMessage = (error: unknown): string | null => {
-  if (!axios.isAxiosError(error)) return null;
+  if (!isApiError(error)) return null;
 
   const data = error.response?.data;
   if (typeof data === "string") return data;
-  if (typeof data?.detail === "string") return data.detail;
-  if (typeof data?.error === "string") return data.error;
-  if (typeof data?.message === "string") return data.message;
-  if (Array.isArray(data?.non_field_errors)) {
+  if (!isRecord(data)) return null;
+  if (typeof data.detail === "string") return data.detail;
+  if (typeof data.error === "string") return data.error;
+  if (typeof data.message === "string") return data.message;
+  if (Array.isArray(data.non_field_errors)) {
     const firstError = data.non_field_errors.find(
       (entry: unknown) => typeof entry === "string",
     );
@@ -564,9 +568,11 @@ const CheckoutPage: React.FC = () => {
         if (isCancelled || requestId !== latestIntentRequestId.current) return;
         resetCheckoutIntentState();
         const apiErrorMessage = getApiErrorMessage(error);
-        const errorCode = axios.isAxiosError(error)
-          ? String(error.response?.data?.code || "")
-          : "";
+        const errorPayload = isApiError(error) ? error.response?.data : null;
+        const errorCode =
+          isRecord(errorPayload) && typeof errorPayload.code === "string"
+            ? errorPayload.code
+            : "";
 
         if (errorCode.startsWith("DISCOUNT_")) {
           clearAppliedDiscount();

--- a/openeire/src/pages/ProductDetailPage.tsx
+++ b/openeire/src/pages/ProductDetailPage.tsx
@@ -6,7 +6,6 @@ import React, {
   useRef,
 } from "react";
 import { useParams, useLocation, Link, useNavigate } from "react-router-dom";
-import axios from "axios";
 import {
   GalleryItem,
   getProductDetail,
@@ -19,6 +18,7 @@ import {
   ReviewProductType,
   VideoDetail,
 } from "../services/api";
+import { isApiError } from "../services/fetchClient";
 import ReviewForm from "../components/ReviewForm";
 import ProductReviewList from "../components/ProductReviewList";
 import { useCart } from "../context/CartContext";
@@ -128,7 +128,7 @@ const ProductDetailPage: React.FC = () => {
       setBreadcrumbTitle(location.pathname, data.title);
     } catch (err) {
       if (
-        axios.isAxiosError(err) &&
+        isApiError(err) &&
         shouldShowGalleryAccessCodeUx(type, err.response?.status)
       ) {
         toastInfo("Please re-enter your gallery access code.");

--- a/openeire/src/services/api.ts
+++ b/openeire/src/services/api.ts
@@ -1,15 +1,11 @@
-﻿import axios from "axios";
 import { emitErrorRoute } from "../utils/errorRouting";
 import { normalizeApiPath } from "../utils/apiPath";
-import { API_BASE_URL } from "../config/backend";
-
-// Create an Axios instance for our API
-export const api = axios.create({
-  baseURL: API_BASE_URL,
-  headers: {
-    "Content-Type": "application/json",
-  },
-});
+import {
+  api as fetchApi,
+  isApiError,
+  type ApiRequestConfig,
+  type ApiResponse,
+} from "./fetchClient";
 
 const getRequestPath = (url?: string): string => {
   if (!url) return "";
@@ -35,46 +31,54 @@ const shouldSkipForbiddenRouteRedirect = (requestPath: string): boolean =>
 const shouldHandleGlobalErrorRoute = (method?: string): boolean =>
   (method ?? "get").toLowerCase() === "get";
 
-// --- UNIFIED INTERCEPTOR ---
-// This handles BOTH User Authentication and Gallery Access
-api.interceptors.request.use(
-  (config) => {
-    const token = sessionStorage.getItem("accessToken");
-    if (token) {
-      config.headers.Authorization = `Bearer ${token}`;
-    }
+const handleGlobalApiError = (error: unknown, method?: string): void => {
+  if (!isApiError(error) || !shouldHandleGlobalErrorRoute(method)) {
+    return;
+  }
 
-    return config;
-  },
-  (error) => {
-    return Promise.reject(error);
-  },
-);
+  const statusCode = error.response?.status;
+  const requestPath = getRequestPath(error.request.url);
+  if (statusCode === 403 && !shouldSkipForbiddenRouteRedirect(requestPath)) {
+    emitErrorRoute("/403");
+  } else if (typeof statusCode === "number" && statusCode >= 500) {
+    emitErrorRoute("/500");
+  }
+};
 
-api.interceptors.response.use(
-  (response) => response,
-  (error) => {
-    if (axios.isAxiosError(error)) {
-      const method = error.config?.method;
-      if (!shouldHandleGlobalErrorRoute(method)) {
-        return Promise.reject(error);
-      }
+const withGlobalErrorRoute = async <T>(
+  method: string,
+  request: () => Promise<ApiResponse<T>>,
+): Promise<ApiResponse<T>> => {
+  try {
+    return await request();
+  } catch (error) {
+    handleGlobalApiError(error, method);
+    throw error;
+  }
+};
 
-      const statusCode = error.response?.status;
-      const requestPath = getRequestPath(error.config?.url);
-      if (
-        statusCode === 403 &&
-        !shouldSkipForbiddenRouteRedirect(requestPath)
-      ) {
-        emitErrorRoute("/403");
-      } else if (typeof statusCode === "number" && statusCode >= 500) {
-        emitErrorRoute("/500");
-      }
-    }
-
-    return Promise.reject(error);
-  },
-);
+export const api = {
+  get: <T = unknown>(path: string, config?: ApiRequestConfig) =>
+    withGlobalErrorRoute("get", () => fetchApi.get<T>(path, config)),
+  post: <T = unknown>(
+    path: string,
+    data?: unknown,
+    config?: ApiRequestConfig,
+  ) => withGlobalErrorRoute("post", () => fetchApi.post<T>(path, data, config)),
+  put: <T = unknown>(
+    path: string,
+    data?: unknown,
+    config?: ApiRequestConfig,
+  ) => withGlobalErrorRoute("put", () => fetchApi.put<T>(path, data, config)),
+  patch: <T = unknown>(
+    path: string,
+    data?: unknown,
+    config?: ApiRequestConfig,
+  ) =>
+    withGlobalErrorRoute("patch", () => fetchApi.patch<T>(path, data, config)),
+  delete: <T = unknown>(path: string, config?: ApiRequestConfig) =>
+    withGlobalErrorRoute("delete", () => fetchApi.delete<T>(path, config)),
+};
 
 // --- TYPES ---
 export interface UserProfile {
@@ -415,7 +419,7 @@ export const getOrderHistory = async (): Promise<OrderHistory[]> => {
     const response = await api.get("checkout/order-history/");
     return response.data;
   } catch (error) {
-    if (axios.isAxiosError(error) && error.response) {
+    if (isApiError(error) && error.response) {
       throw error.response.data;
     }
     throw error;
@@ -434,7 +438,7 @@ export const registerUser = async (
     return response.data;
   } catch (error) {
     // This is crucial for handling errors from the backend
-    if (axios.isAxiosError(error) && error.response) {
+    if (isApiError(error) && error.response) {
       // The backend will send error details in error.response.data
       throw error.response.data;
     }
@@ -449,7 +453,7 @@ export const changePassword = async (
     const response = await api.put("auth/password/change/", data);
     return response.data;
   } catch (error) {
-    if (axios.isAxiosError(error) && error.response) {
+    if (isApiError(error) && error.response) {
       throw error.response.data;
     }
     throw error;
@@ -461,7 +465,7 @@ export const getTestimonials = async (): Promise<Testimonial[]> => {
     const response = await api.get<Testimonial[]>("home/testimonials/");
     return response.data;
   } catch (error) {
-    if (axios.isAxiosError(error) && error.response) {
+    if (isApiError(error) && error.response) {
       throw error.response.data;
     }
     throw error;
@@ -495,7 +499,7 @@ export const newsletterSignup = async (
     const response = await api.post("home/newsletter-signup/", payload);
     return response.data;
   } catch (error) {
-    if (axios.isAxiosError(error) && error.response) {
+    if (isApiError(error) && error.response) {
       throw error.response.data;
     }
     throw error;
@@ -526,7 +530,7 @@ export const getBlogPosts = async (
     const response = await api.get<PaginatedResponse<BlogPostListItem>>(url);
     return response.data;
   } catch (error) {
-    if (axios.isAxiosError(error) && error.response) {
+    if (isApiError(error) && error.response) {
       throw error.response.data;
     }
     throw error;
@@ -542,7 +546,7 @@ export const getBlogPostDetail = async (
     const response = await api.get<BlogPostDetail>(`blog/${slug}/`);
     return response.data;
   } catch (error) {
-    if (axios.isAxiosError(error) && error.response) {
+    if (isApiError(error) && error.response) {
       throw error.response.data;
     }
     throw error;
@@ -554,7 +558,7 @@ export const toggleBlogLike = async (slug: string): Promise<LikeResponse> => {
     const response = await api.post<LikeResponse>(`blog/${slug}/like/`);
     return response.data;
   } catch (error) {
-    if (axios.isAxiosError(error) && error.response) {
+    if (isApiError(error) && error.response) {
       throw error.response.data;
     }
     throw error;
@@ -569,7 +573,7 @@ export const getComments = async (postSlug: string): Promise<Comment[]> => {
     );
     return response.data;
   } catch (error) {
-    if (axios.isAxiosError(error) && error.response) {
+    if (isApiError(error) && error.response) {
       throw error.response.data;
     }
     throw error;
@@ -588,7 +592,7 @@ export const postComment = async (
     );
     return response.data;
   } catch (error) {
-    if (axios.isAxiosError(error) && error.response) {
+    if (isApiError(error) && error.response) {
       throw error.response.data;
     }
     throw error;
@@ -605,7 +609,7 @@ export const verifyEmail = async (
     );
     return response.data;
   } catch (error) {
-    if (axios.isAxiosError(error) && error.response) {
+    if (isApiError(error) && error.response) {
       throw error.response.data;
     }
     throw error;
@@ -617,7 +621,7 @@ export const loginUser = async (data: LoginData): Promise<LoginResponse> => {
     const response = await api.post<LoginResponse>("auth/login/", data);
     return response.data;
   } catch (error) {
-    if (axios.isAxiosError(error) && error.response) {
+    if (isApiError(error) && error.response) {
       throw error.response.data;
     }
     throw error;
@@ -631,7 +635,7 @@ export const requestPasswordReset = async (
     const response = await api.post("auth/password/reset/", { email });
     return response.data;
   } catch (error) {
-    if (axios.isAxiosError(error) && error.response) {
+    if (isApiError(error) && error.response) {
       throw error.response.data;
     }
     throw error;
@@ -651,7 +655,7 @@ export const confirmPasswordReset = async (
     });
     return response.data;
   } catch (error) {
-    if (axios.isAxiosError(error) && error.response) {
+    if (isApiError(error) && error.response) {
       throw error.response.data;
     }
     throw error;
@@ -663,7 +667,7 @@ export const getProfile = async (): Promise<UserProfile> => {
     const response = await api.get<UserProfile>("auth/profile/");
     return response.data;
   } catch (error) {
-    if (axios.isAxiosError(error) && error.response) {
+    if (isApiError(error) && error.response) {
       throw error.response.data;
     }
     throw error;
@@ -677,7 +681,7 @@ export const updateProfile = async (
     const response = await api.patch<UserProfile>("auth/profile/", profileData);
     return response.data;
   } catch (error) {
-    if (axios.isAxiosError(error) && error.response) {
+    if (isApiError(error) && error.response) {
       throw error.response.data;
     }
     throw error;
@@ -696,7 +700,7 @@ export const resendVerificationEmail = async (
     const response = await api.post("auth/resend-verification/", { email });
     return response.data;
   } catch (error) {
-    if (axios.isAxiosError(error) && error.response) {
+    if (isApiError(error) && error.response) {
       throw error.response.data;
     }
     throw error;
@@ -720,10 +724,10 @@ export const getGalleryProducts = async (
     });
     return response.data;
   } catch (error) {
-    if (axios.isAxiosError(error)) {
+    if (isApiError(error)) {
       const statusCode = error.response?.status;
       const responseData = error.response?.data;
-      const requestPath = error.config?.url || "gallery/";
+      const requestPath = error.request.url || "gallery/";
 
       if (
         typeof responseData === "string" &&
@@ -782,7 +786,7 @@ export const submitProductReview = async (
     );
     return response.data;
   } catch (error) {
-    if (axios.isAxiosError(error) && error.response) {
+    if (isApiError(error) && error.response) {
       throw error.response.data;
     }
     throw error;
@@ -799,7 +803,7 @@ export const getProductReviews = async (
     );
     return response.data;
   } catch (error) {
-    if (axios.isAxiosError(error) && error.response) {
+    if (isApiError(error) && error.response) {
       throw error.response.data;
     }
     throw error;
@@ -811,7 +815,7 @@ export const sendContactMessage = async (contactData: ContactData) => {
     const response = await api.post("home/contact/", contactData);
     return response.data;
   } catch (error) {
-    if (axios.isAxiosError(error) && error.response) {
+    if (isApiError(error) && error.response) {
       throw error.response.data;
     }
     throw error;
@@ -872,7 +876,7 @@ export const getLikedBlogPosts = async (): Promise<PaginatedResponse<BlogPostLis
     const response = await api.get<PaginatedResponse<BlogPostListItem>>('blog/liked/');
     return response.data;
   } catch (error) {
-    if (axios.isAxiosError(error) && error.response) {
+    if (isApiError(error) && error.response) {
       throw error.response.data;
     }
     throw error;
@@ -885,7 +889,7 @@ export const submitLicenseRequest = async (payload: LicenseRequestPayload) => {
     const response = await api.post("license-requests/", payload);
     return response.data;
   } catch (error) {
-    if (axios.isAxiosError(error) && error.response) {
+    if (isApiError(error) && error.response) {
       throw error.response.data;
     }
     throw error;
@@ -899,7 +903,7 @@ export const submitRealEstateEnquiry = async (
     const response = await api.post("real-estate/enquiries/", payload);
     return response.data;
   } catch (error) {
-    if (axios.isAxiosError(error) && error.response) {
+    if (isApiError(error) && error.response) {
       throw error.response.data;
     }
     throw error;

--- a/openeire/src/services/fetchClient.ts
+++ b/openeire/src/services/fetchClient.ts
@@ -1,0 +1,217 @@
+import { API_BASE_URL } from "../config/backend";
+
+export interface ApiResponse<T = unknown> {
+  data: T;
+  status: number;
+  headers: Headers;
+  url: string;
+}
+
+export interface ApiRequestConfig {
+  params?: Record<string, unknown>;
+  headers?: HeadersInit;
+  signal?: AbortSignal;
+  data?: unknown;
+  body?: BodyInit | null;
+}
+
+export class ApiError extends Error {
+  response?: ApiResponse;
+  request: {
+    method: string;
+    url: string;
+  };
+  code?: string;
+
+  constructor({
+    message,
+    response,
+    request,
+    code,
+  }: {
+    message: string;
+    response?: ApiResponse;
+    request: ApiError["request"];
+    code?: string;
+  }) {
+    super(message);
+    this.name = "ApiError";
+    this.response = response;
+    this.request = request;
+    this.code = code;
+  }
+}
+
+export const isApiError = (error: unknown): error is ApiError =>
+  error instanceof ApiError;
+
+const isAbsoluteUrl = (value: string): boolean =>
+  value.startsWith("http://") || value.startsWith("https://");
+
+const isBodyInit = (value: unknown): value is BodyInit =>
+  (typeof Blob !== "undefined" && value instanceof Blob) ||
+  (typeof FormData !== "undefined" && value instanceof FormData) ||
+  (typeof URLSearchParams !== "undefined" && value instanceof URLSearchParams) ||
+  (typeof ArrayBuffer !== "undefined" && value instanceof ArrayBuffer) ||
+  (typeof ArrayBuffer !== "undefined" && ArrayBuffer.isView(value)) ||
+  (typeof ReadableStream !== "undefined" && value instanceof ReadableStream) ||
+  typeof value === "string";
+
+const buildUrl = (
+  path: string,
+  params?: Record<string, unknown>,
+): string => {
+  const baseUrl = isAbsoluteUrl(path)
+    ? path
+    : `${API_BASE_URL}${path.replace(/^\/+/, "")}`;
+  const origin =
+    typeof window !== "undefined" && window.location?.origin
+      ? window.location.origin
+      : "http://localhost";
+  const url = new URL(baseUrl, origin);
+
+  for (const [key, value] of Object.entries(params ?? {})) {
+    if (value === undefined || value === null || value === "") continue;
+    if (Array.isArray(value)) {
+      for (const entry of value) {
+        if (entry !== undefined && entry !== null && entry !== "") {
+          url.searchParams.append(key, String(entry));
+        }
+      }
+      continue;
+    }
+    url.searchParams.set(key, String(value));
+  }
+
+  return isAbsoluteUrl(baseUrl)
+    ? url.toString()
+    : `${url.pathname}${url.search}${url.hash}`;
+};
+
+const parseResponseBody = async (response: Response): Promise<unknown> => {
+  if (response.status === 204 || response.status === 205) {
+    return undefined;
+  }
+
+  const text = await response.text();
+  if (!text) return undefined;
+
+  const contentType = response.headers.get("content-type") ?? "";
+  if (contentType.includes("application/json")) {
+    try {
+      return JSON.parse(text);
+    } catch {
+      return text;
+    }
+  }
+
+  return text;
+};
+
+const getErrorMessage = (payload: unknown, fallback: string): string => {
+  if (typeof payload === "string" && payload.trim()) return payload.trim();
+  if (!payload || typeof payload !== "object") return fallback;
+
+  const record = payload as Record<string, unknown>;
+  for (const key of ["detail", "message", "error"]) {
+    const value = record[key];
+    if (typeof value === "string" && value.trim()) {
+      return value.trim();
+    }
+  }
+
+  return fallback;
+};
+
+const createRequestBody = (
+  data: unknown,
+  explicitBody: BodyInit | null | undefined,
+): {
+  body?: BodyInit | null;
+  shouldSetJsonContentType: boolean;
+} => {
+  if (explicitBody !== undefined) {
+    return { body: explicitBody, shouldSetJsonContentType: false };
+  }
+  if (data === undefined || data === null) {
+    return { body: undefined, shouldSetJsonContentType: false };
+  }
+  if (isBodyInit(data)) {
+    return { body: data, shouldSetJsonContentType: false };
+  }
+  return { body: JSON.stringify(data), shouldSetJsonContentType: true };
+};
+
+const request = async <T>(
+  method: string,
+  path: string,
+  config: ApiRequestConfig = {},
+): Promise<ApiResponse<T>> => {
+  const url = buildUrl(path, config.params);
+  const requestInfo = { method, url };
+  const headers = new Headers(config.headers);
+  const token =
+    typeof sessionStorage !== "undefined"
+      ? sessionStorage.getItem("accessToken")
+      : null;
+  const { body, shouldSetJsonContentType } = createRequestBody(
+    config.data,
+    config.body,
+  );
+
+  if (token) {
+    headers.set("Authorization", `Bearer ${token}`);
+  }
+  if (shouldSetJsonContentType && !headers.has("Content-Type")) {
+    headers.set("Content-Type", "application/json");
+  }
+
+  try {
+    const response = await fetch(url, {
+      method,
+      headers,
+      body: method === "GET" || method === "HEAD" ? undefined : body,
+      signal: config.signal,
+    });
+    const data = await parseResponseBody(response);
+    const apiResponse: ApiResponse<T> = {
+      data: data as T,
+      status: response.status,
+      headers: response.headers,
+      url,
+    };
+
+    if (!response.ok) {
+      throw new ApiError({
+        message: getErrorMessage(data, `Request failed with status ${response.status}.`),
+        response: apiResponse,
+        request: requestInfo,
+      });
+    }
+
+    return apiResponse;
+  } catch (error) {
+    if (isApiError(error)) throw error;
+
+    const isCancelled =
+      error instanceof DOMException && error.name === "AbortError";
+    throw new ApiError({
+      message: isCancelled ? "Request cancelled." : "Network request failed.",
+      request: requestInfo,
+      code: isCancelled ? "ERR_CANCELED" : "ERR_NETWORK",
+    });
+  }
+};
+
+export const api = {
+  get: <T>(path: string, config?: ApiRequestConfig) =>
+    request<T>("GET", path, config),
+  post: <T>(path: string, data?: unknown, config?: ApiRequestConfig) =>
+    request<T>("POST", path, { ...config, data }),
+  put: <T>(path: string, data?: unknown, config?: ApiRequestConfig) =>
+    request<T>("PUT", path, { ...config, data }),
+  patch: <T>(path: string, data?: unknown, config?: ApiRequestConfig) =>
+    request<T>("PATCH", path, { ...config, data }),
+  delete: <T>(path: string, config?: ApiRequestConfig) =>
+    request<T>("DELETE", path, config),
+};

--- a/openeire/src/utils/multipartVideoUpload.ts
+++ b/openeire/src/utils/multipartVideoUpload.ts
@@ -1,4 +1,3 @@
-﻿import axios from "axios";
 import {
   abortVideoUpload,
   completeVideoUpload,
@@ -9,6 +8,7 @@ import {
   type StartedVideoUpload,
   type VideoUploadPurpose,
 } from "../services/videoUploads";
+import { isApiError } from "../services/fetchClient";
 
 const DEFAULT_RETRY_LIMIT = 3;
 
@@ -40,6 +40,35 @@ export class MultipartUploadCancelledError extends Error {
   constructor(message = UPLOAD_CANCELLED_MESSAGE) {
     super(message);
     this.name = "MultipartUploadCancelledError";
+  }
+}
+
+export class UploadPartError extends Error {
+  code?: string;
+  status?: number;
+  data?: unknown;
+  requestUrl: string;
+
+  constructor(
+    message: string,
+    {
+      code,
+      status,
+      data,
+      requestUrl,
+    }: {
+      code?: string;
+      status?: number;
+      data?: unknown;
+      requestUrl: string;
+    },
+  ) {
+    super(message);
+    this.name = "UploadPartError";
+    this.code = code;
+    this.status = status;
+    this.data = data;
+    this.requestUrl = requestUrl;
   }
 }
 
@@ -98,27 +127,149 @@ const isDirectRequestUrl = (value?: string): boolean =>
   typeof value === "string" &&
   (value.startsWith("http://") || value.startsWith("https://"));
 
+const isUploadPartError = (error: unknown): error is UploadPartError =>
+  error instanceof UploadPartError;
+
+const parseHeaderString = (headers: string): Record<string, string> =>
+  headers
+    .trim()
+    .split(/[\r\n]+/)
+    .filter(Boolean)
+    .reduce<Record<string, string>>((acc, line) => {
+      const separatorIndex = line.indexOf(":");
+      if (separatorIndex === -1) return acc;
+      const key = line.slice(0, separatorIndex).trim().toLowerCase();
+      const value = line.slice(separatorIndex + 1).trim();
+      if (key) acc[key] = value;
+      return acc;
+    }, {});
+
+const parseResponseText = (text: string): unknown => {
+  if (!text.trim()) return undefined;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+};
+
+const getPayloadDetail = (payload: unknown): string | null => {
+  if (typeof payload === "string" && payload.trim()) {
+    return payload.trim();
+  }
+  if (!payload || typeof payload !== "object") {
+    return null;
+  }
+  const record = payload as Record<string, unknown>;
+  return (
+    (typeof record.detail === "string" && record.detail) ||
+    (typeof record.message === "string" && record.message) ||
+    null
+  );
+};
+
+const uploadPartWithProgress = ({
+  url,
+  chunk,
+  contentType,
+  signal,
+  onProgress,
+}: {
+  url: string;
+  chunk: Blob;
+  contentType: string;
+  signal: AbortSignal;
+  onProgress: (loadedBytes: number) => void;
+}): Promise<{ headers: Record<string, string> }> =>
+  new Promise((resolve, reject) => {
+    const xhr = new XMLHttpRequest();
+    let settled = false;
+
+    const rejectOnce = (error: unknown) => {
+      if (settled) return;
+      settled = true;
+      signal.removeEventListener("abort", abortHandler);
+      reject(error);
+    };
+
+    const resolveOnce = (value: { headers: Record<string, string> }) => {
+      if (settled) return;
+      settled = true;
+      signal.removeEventListener("abort", abortHandler);
+      resolve(value);
+    };
+
+    const abortHandler = () => {
+      xhr.abort();
+      rejectOnce(new MultipartUploadCancelledError());
+    };
+
+    xhr.upload.onprogress = (event) => {
+      onProgress(Math.min(event.loaded, chunk.size));
+    };
+
+    xhr.onerror = () => {
+      rejectOnce(
+        new UploadPartError("Network request failed.", {
+          code: "ERR_NETWORK",
+          requestUrl: url,
+        }),
+      );
+    };
+
+    xhr.onabort = () => {
+      rejectOnce(new MultipartUploadCancelledError());
+    };
+
+    xhr.onload = () => {
+      const headers = parseHeaderString(xhr.getAllResponseHeaders());
+      if (xhr.status >= 200 && xhr.status < 300) {
+        resolveOnce({ headers });
+        return;
+      }
+      rejectOnce(
+        new UploadPartError(`Upload part request failed with status ${xhr.status}.`, {
+          status: xhr.status,
+          data: parseResponseText(xhr.responseText),
+          requestUrl: url,
+        }),
+      );
+    };
+
+    signal.addEventListener("abort", abortHandler, { once: true });
+    xhr.open("PUT", url);
+    xhr.setRequestHeader("Content-Type", contentType);
+    xhr.send(chunk);
+  });
+
 export const getMultipartUploadErrorMessage = (error: unknown): string => {
-  if (axios.isAxiosError(error) && error.code === "ERR_CANCELED") {
+  if (
+    error instanceof MultipartUploadCancelledError ||
+    (isUploadPartError(error) && error.code === "ERR_CANCELED")
+  ) {
     return UPLOAD_CANCELLED_MESSAGE;
   }
 
-  if (axios.isAxiosError(error)) {
-    const requestUrl = typeof error.config?.url === "string" ? error.config.url : "";
+  if (isUploadPartError(error)) {
+    const requestUrl = error.requestUrl;
     const isDirectR2Request = isDirectRequestUrl(requestUrl);
 
     if (error.code === "ERR_NETWORK" && isDirectR2Request) {
       return R2_CORS_ERROR_MESSAGE;
     }
 
-    if (error.response?.status === 403 && isDirectR2Request) {
+    if (error.status === 403 && isDirectR2Request) {
       return R2_CORS_ERROR_MESSAGE;
     }
 
-    const detail =
-      (typeof error.response?.data?.detail === "string" && error.response.data.detail) ||
-      (typeof error.response?.data?.message === "string" && error.response.data.message);
+    const detail = getPayloadDetail(error.data);
+    if (detail) {
+      return detail;
+    }
+  }
 
+  if (isApiError(error)) {
+    const detail = getPayloadDetail(error.response?.data);
     if (detail) {
       return detail;
     }
@@ -133,7 +284,8 @@ export const getMultipartUploadErrorMessage = (error: unknown): string => {
 
 const isCancellationError = (error: unknown): boolean =>
   error instanceof MultipartUploadCancelledError ||
-  (axios.isAxiosError(error) && error.code === "ERR_CANCELED");
+  (isApiError(error) && error.code === "ERR_CANCELED") ||
+  (isUploadPartError(error) && error.code === "ERR_CANCELED");
 
 export const isMultipartUploadCancelledError = (
   error: unknown,
@@ -221,18 +373,18 @@ export const createMultipartVideoUpload = ({
             part_number: partNumber,
           });
 
-          const response = await axios.put(url, chunk, {
+          const response = await uploadPartWithProgress({
+            url,
+            chunk,
+            contentType: uploadContentType,
             signal: abortController.signal,
-            headers: {
-              "Content-Type": uploadContentType,
-            },
-            onUploadProgress: (event) => {
-              partProgress.set(partNumber, Math.min(event.loaded, chunk.size));
+            onProgress: (loadedBytes) => {
+              partProgress.set(partNumber, loadedBytes);
               emitProgress();
             },
           });
 
-          const etagHeader = response.headers.etag || response.headers.ETag;
+          const etagHeader = response.headers.etag;
           const etag = String(etagHeader || "").trim();
           if (!etag) {
             throw new Error(`Missing ETag for uploaded part ${partNumber}.`);

--- a/openeire/src/utils/sanitizeHtml.ts
+++ b/openeire/src/utils/sanitizeHtml.ts
@@ -1,4 +1,4 @@
-﻿import DOMPurify from "dompurify";
+import DOMPurify from "dompurify";
 
 export const sanitizeRichHtml = (html: string): string =>
   DOMPurify.sanitize(html, {
@@ -17,5 +17,6 @@ export const sanitizeRichHtml = (html: string): string =>
       "meta",
       "link",
     ],
+    FORBID_ATTR: ["style"],
     ALLOW_DATA_ATTR: false,
   });

--- a/openeire/src/utils/toast.ts
+++ b/openeire/src/utils/toast.ts
@@ -1,5 +1,5 @@
-﻿import axios from "axios";
 import toast, { ToastOptions } from "react-hot-toast";
+import { isApiError } from "../services/fetchClient";
 
 export const toastInfo = (
   message: string,
@@ -36,7 +36,7 @@ const isRecord = (value: unknown): value is UnknownRecord =>
 const getStatusAndPayload = (
   error: unknown,
 ): { status?: number; payload?: unknown } => {
-  if (axios.isAxiosError(error)) {
+  if (isApiError(error)) {
     return {
       status: error.response?.status,
       payload: error.response?.data,
@@ -113,6 +113,10 @@ export const getToastErrorMessage = (
   options: ToastErrorOptions,
 ): string => {
   const { status, payload } = getStatusAndPayload(error);
+
+  if (isApiError(error) && !error.response) {
+    return options.networkMessage ?? options.fallback;
+  }
 
   const directMessage = getStringValue(payload);
   if (directMessage) return directMessage;

--- a/openeire/tests/multipartVideoUpload.test.ts
+++ b/openeire/tests/multipartVideoUpload.test.ts
@@ -1,7 +1,7 @@
-import { describe, expect, it, vi, beforeEach } from "vitest";
-import axios from "axios";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   MultipartUploadCancelledError,
+  UploadPartError,
   createMultipartVideoUpload,
   getMultipartUploadErrorMessage,
   inferVideoContentType,
@@ -13,17 +13,6 @@ import {
   requestVideoUploadStart,
 } from "../src/services/videoUploads";
 
-vi.mock("axios", () => ({
-  default: {
-    put: vi.fn(),
-    isAxiosError: (error: unknown) =>
-      typeof error === "object" &&
-      error !== null &&
-      "isAxiosError" in error &&
-      (error as { isAxiosError?: boolean }).isAxiosError === true,
-  },
-}));
-
 vi.mock("../src/services/videoUploads", () => ({
   requestVideoUploadStart: vi.fn(),
   requestVideoUploadPartUrl: vi.fn(),
@@ -31,9 +20,36 @@ vi.mock("../src/services/videoUploads", () => ({
   abortVideoUpload: vi.fn(),
 }));
 
+class PendingUploadXMLHttpRequest {
+  static instances: PendingUploadXMLHttpRequest[] = [];
+
+  upload = {
+    onprogress: null as ((event: ProgressEvent) => void) | null,
+  };
+  status = 200;
+  responseText = "";
+  onload: ((event: ProgressEvent) => void) | null = null;
+  onerror: ((event: ProgressEvent) => void) | null = null;
+  onabort: ((event: ProgressEvent) => void) | null = null;
+
+  open = vi.fn();
+  setRequestHeader = vi.fn();
+  send = vi.fn();
+  getAllResponseHeaders = vi.fn(() => 'ETag: "etag-1"\r\n');
+  abort = vi.fn(() => {
+    this.onabort?.({} as ProgressEvent);
+  });
+
+  constructor() {
+    PendingUploadXMLHttpRequest.instances.push(this);
+  }
+}
+
 describe("multipartVideoUpload helpers", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.unstubAllGlobals();
+    PendingUploadXMLHttpRequest.instances = [];
   });
 
   it("sorts completed parts by ascending part number", () => {
@@ -58,21 +74,20 @@ describe("multipartVideoUpload helpers", () => {
   });
 
   it("maps direct R2 network failures to the CORS guidance message", () => {
-    const message = getMultipartUploadErrorMessage({
-      isAxiosError: true,
-      code: "ERR_NETWORK",
-      config: { url: "https://r2.example.com/upload-part" },
-    });
+    const message = getMultipartUploadErrorMessage(
+      new UploadPartError("Network request failed.", {
+        code: "ERR_NETWORK",
+        requestUrl: "https://r2.example.com/upload-part",
+      }),
+    );
 
     expect(message).toContain("Cloudflare R2 CORS");
   });
 
   it("maps cancelled uploads to an explicit cancellation message", () => {
-    const message = getMultipartUploadErrorMessage({
-      isAxiosError: true,
-      code: "ERR_CANCELED",
-      config: { url: "https://r2.example.com/upload-part" },
-    });
+    const message = getMultipartUploadErrorMessage(
+      new MultipartUploadCancelledError(),
+    );
 
     expect(message).toBe("Upload cancelled.");
   });
@@ -81,9 +96,12 @@ describe("multipartVideoUpload helpers", () => {
 describe("createMultipartVideoUpload", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.unstubAllGlobals();
+    PendingUploadXMLHttpRequest.instances = [];
   });
 
   it("aborts only once and rejects with MultipartUploadCancelledError on cancel", async () => {
+    vi.stubGlobal("XMLHttpRequest", PendingUploadXMLHttpRequest);
     vi.mocked(requestVideoUploadStart).mockResolvedValue({
       upload_id: "upload-123",
       object_key: "previews/videos/fanore-beach.mp4",
@@ -99,26 +117,6 @@ describe("createMultipartVideoUpload", () => {
       success: true,
       status: "aborted",
     });
-    vi.mocked(axios.put).mockImplementation(
-      (_url, _chunk, config?: { signal?: AbortSignal }) =>
-        new Promise((_resolve, reject) => {
-          if (config?.signal?.aborted) {
-            reject({
-              isAxiosError: true,
-              code: "ERR_CANCELED",
-              config: { url: "https://r2.example.com/upload-part" },
-            });
-            return;
-          }
-          config?.signal?.addEventListener("abort", () => {
-            reject({
-              isAxiosError: true,
-              code: "ERR_CANCELED",
-              config: { url: "https://r2.example.com/upload-part" },
-            });
-          });
-        }),
-    );
 
     const file = new File(["preview-video"], "preview.mp4", { type: "video/mp4" });
     const task = createMultipartVideoUpload({
@@ -127,11 +125,15 @@ describe("createMultipartVideoUpload", () => {
     });
 
     await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
 
     const cancelPromise = task.cancel();
     await expect(task.promise).rejects.toBeInstanceOf(MultipartUploadCancelledError);
     await cancelPromise;
 
+    expect(PendingUploadXMLHttpRequest.instances).toHaveLength(1);
+    expect(PendingUploadXMLHttpRequest.instances[0].abort).toHaveBeenCalledTimes(1);
     expect(abortVideoUpload).toHaveBeenCalledTimes(1);
   });
 });

--- a/openeire/tests/toast.test.ts
+++ b/openeire/tests/toast.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { ApiError } from "../src/services/fetchClient";
 import { getLoginToastErrorMessage, getToastErrorMessage } from "../src/utils/toast";
 describe("toast error helpers", () => {
   it("uses detail matchers before returning raw backend detail", () => {
@@ -65,12 +66,13 @@ describe("toast error helpers", () => {
     );
     expect(message).toBe("Too many requests. Please wait a moment and try again.");
   });
-  it("uses the configured fallback for axios network errors without a response", () => {
+  it("uses the configured fallback for network errors without a response", () => {
     const message = getToastErrorMessage(
-      {
-        isAxiosError: true,
-        message: "Network Error",
-      },
+      new ApiError({
+        message: "Network request failed.",
+        request: { method: "GET", url: "/api/auth/login/" },
+        code: "ERR_NETWORK",
+      }),
       {
         fallback: "We couldn't reach the server. Please try again.",
       },


### PR DESCRIPTION
## Summary
- Replaced Axios with a native `fetch` client that preserves the existing API helper contract.
- Kept bearer-token auth, JSON/FormData support, response status/data access, and global GET error routing.
- Replaced direct multipart upload PUTs with `XMLHttpRequest` so upload progress and cancellation still work without Axios.
- Removed `axios` from `package.json` and `package-lock.json`.
- Updated tests for fetch-style API errors and XHR upload cancellation.
- Confirmed `plain-crypto-js` is not present.

## Security Checks
- `npm ls axios`: empty after removal.
- `npm ls plain-crypto-js`: empty.
- `rg "axios|plain-crypto-js" package.json package-lock.json src tests`: no matches.
- `npm audit`: 0 vulnerabilities.
- `npm audit --omit=dev`: 0 vulnerabilities.

## Testing
- `npm.cmd run lint` passed.
- `npm.cmd run test` passed: 10 test files, 40 tests.
- `npm.cmd run build` passed.

## Notes
- Native `fetch` does not expose upload progress, so the direct R2 multipart upload step now uses `XMLHttpRequest` only for preserving progress/cancel behaviour.
- Existing Vite build warnings about `"use client"` directives and chunk size remain unchanged.