### PR TITLE
Implement server-rendered blog pages (list + detail) with SEO metadata

### DIFF
--- a/openeire-next/app/blog/[slug]/page.tsx
+++ b/openeire-next/app/blog/[slug]/page.tsx
@@ -1,6 +1,34 @@
+/* eslint-disable @next/next/no-img-element */
 import type { Metadata } from "next";
-import { PlaceholderPage } from "@/components/PlaceholderPage";
-import { buildPageMetadata } from "@/lib/seo/metadata";
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { JsonLd } from "@/components/JsonLd";
+import { getPublishedBlogPostBySlug } from "@/lib/api/blog";
+import { formatBlogDisplayDate } from "@/lib/blog/dates";
+import { resolveMediaUrl } from "@/lib/media";
+import { buildBreadcrumbJsonLd } from "@/lib/seo/jsonLd";
+import { buildAbsoluteUrl, getSiteUrl, SITE_NAME } from "@/lib/site";
+import { sanitizeRichHtml } from "@/lib/sanitizeRichHtml";
+import {
+  FaArrowLeft,
+  FaCalendar,
+  FaRegHeart,
+  FaUser,
+} from "react-icons/fa";
+
+export const revalidate = 300;
+
+const getCanonicalUrl = (slug: string, canonicalUrl?: string): string => {
+  const generated = buildAbsoluteUrl(`/blog/${slug}`);
+  if (!canonicalUrl) return generated;
+
+  try {
+    const url = new URL(canonicalUrl);
+    return url.origin === getSiteUrl() ? url.toString() : generated;
+  } catch {
+    return generated;
+  }
+};
 
 export async function generateMetadata({
   params,
@@ -9,10 +37,59 @@ export async function generateMetadata({
 }): Promise<Metadata> {
   const { slug } = await params;
 
-  return buildPageMetadata({
-    title: `${slug} | OpenÉire Studios`,
-    path: `/blog/${slug}`,
-  });
+  try {
+    const post = await getPublishedBlogPostBySlug(slug);
+    if (!post) {
+      return {
+        title: "Journal post not found | OpenÉire Studios",
+        robots: { index: false, follow: false },
+      };
+    }
+
+    const title = post.meta_title || post.title;
+    const description = post.meta_description || post.excerpt || "";
+    const canonical = getCanonicalUrl(post.slug, post.canonical_url);
+    const featuredImage = resolveMediaUrl(post.featured_image);
+    const image = featuredImage ? buildAbsoluteUrl(featuredImage) : undefined;
+
+    return {
+      metadataBase: new URL(getSiteUrl()),
+      title,
+      description,
+      alternates: { canonical },
+      robots: {
+        index: true,
+        follow: true,
+        googleBot: {
+          index: true,
+          follow: true,
+          "max-image-preview": "large",
+        },
+      },
+      openGraph: {
+        title,
+        description,
+        url: canonical,
+        siteName: SITE_NAME,
+        type: "article",
+        publishedTime: post.created_at,
+        modifiedTime: post.updated_at || post.created_at,
+        authors: post.author ? [post.author] : undefined,
+        images: image ? [{ url: image }] : undefined,
+      },
+      twitter: {
+        card: "summary_large_image",
+        title,
+        description,
+        images: image ? [image] : undefined,
+      },
+    };
+  } catch {
+    return {
+      title: "Journal | OpenÉire Studios",
+      robots: { index: false, follow: false },
+    };
+  }
 }
 
 export default async function BlogDetailPage({
@@ -21,11 +98,209 @@ export default async function BlogDetailPage({
   params: Promise<{ slug: string }>;
 }) {
   const { slug } = await params;
+  let failedToLoad = false;
+  const post = await getPublishedBlogPostBySlug(slug).catch(() => {
+    failedToLoad = true;
+    return null;
+  });
+
+  if (failedToLoad) {
+    return (
+      <div className="mobile-page-offset flex min-h-screen items-center justify-center bg-black px-4 pt-36 pb-24 text-center text-white">
+        <div className="max-w-xl rounded-2xl border border-white/10 bg-gray-900/50 p-8">
+          <h1 className="font-serif text-3xl font-bold">
+            This story is unavailable right now.
+          </h1>
+          <p className="mt-4 text-gray-400">
+            Please try again shortly while we reconnect to the studio archive.
+          </p>
+          <Link
+            href="/blog"
+            className="mt-8 inline-flex items-center justify-center rounded-full border border-white/20 px-6 py-3 text-sm font-semibold text-white transition-colors hover:bg-white/10"
+          >
+            Back to Journal
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  if (!post) notFound();
+
+  const title = post.meta_title || post.title;
+  const description = post.meta_description || post.excerpt || "";
+  const canonical = getCanonicalUrl(post.slug, post.canonical_url);
+  const featuredImage = resolveMediaUrl(post.featured_image);
+  const absoluteFeaturedImage = featuredImage
+    ? buildAbsoluteUrl(featuredImage)
+    : undefined;
+  const sanitizedContent = sanitizeRichHtml(post.content ?? "");
+  const visiblePublishedDate = formatBlogDisplayDate(
+    post.created_at,
+    "Date unavailable",
+  );
 
   return (
-    <PlaceholderPage
-      title={`Blog article: ${slug}`}
-      description="Foundation dynamic route for future server-rendered blog article pages."
-    />
+    <div className="mobile-page-offset min-h-screen bg-black pb-20 pt-36 text-white">
+      <JsonLd
+        data={[
+          buildBreadcrumbJsonLd([
+            { name: "Home", url: buildAbsoluteUrl("/") },
+            { name: "Journal", url: buildAbsoluteUrl("/blog") },
+            { name: title, url: canonical },
+          ]),
+          {
+            "@context": "https://schema.org",
+            "@type": "BlogPosting",
+            headline: title,
+            description,
+            mainEntityOfPage: canonical,
+            url: canonical,
+            ...(absoluteFeaturedImage ? { image: absoluteFeaturedImage } : {}),
+            datePublished: post.created_at,
+            dateModified: post.updated_at || post.created_at,
+            ...(post.author
+              ? {
+                  author: {
+                    "@type": "Person",
+                    name: post.author,
+                  },
+                }
+              : {}),
+            publisher: {
+              "@type": "Organization",
+              name: SITE_NAME,
+            },
+          },
+        ]}
+      />
+
+      <div className="container mx-auto max-w-4xl px-4 lg:px-8">
+        <Link
+          href="/blog"
+          className="mb-8 inline-flex items-center text-sm font-bold uppercase tracking-widest text-gray-500 transition-colors hover:text-accent focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-4 focus-visible:outline-accent"
+        >
+          <FaArrowLeft className="mr-2" /> Back to Journal
+        </Link>
+
+        <h1 className="mb-6 font-serif text-4xl font-bold leading-tight text-white md:text-6xl">
+          {post.title}
+        </h1>
+
+        <div className="mb-8 flex flex-wrap items-center gap-6 border-b border-white/10 pb-8 font-mono text-sm text-gray-400">
+          <div className="flex items-center gap-2">
+            <FaUser className="text-accent" /> {post.author}
+          </div>
+          <div className="flex items-center gap-2">
+            <FaCalendar className="text-accent" /> {visiblePublishedDate}
+          </div>
+          <div className="flex gap-2">
+            {post.tags.map((tag) => (
+              <Link
+                key={tag}
+                href={`/blog?tag=${encodeURIComponent(tag)}`}
+                className="text-accent hover:underline"
+              >
+                #{tag}
+              </Link>
+            ))}
+          </div>
+        </div>
+
+        {featuredImage ? (
+          <div className="mb-12 overflow-hidden rounded-2xl border border-white/10 shadow-2xl">
+            <img src={featuredImage} alt={post.title} className="h-auto w-full" />
+          </div>
+        ) : null}
+
+        <article className="blog-content">
+          <div dangerouslySetInnerHTML={{ __html: sanitizedContent }} />
+        </article>
+
+        <div className="mt-16 flex flex-col items-center border-t border-white/10 pt-8">
+          <div className="mb-8 flex items-center gap-3 rounded-full border border-white/10 bg-white/5 px-8 py-4 text-lg font-bold text-gray-400">
+            <FaRegHeart />
+            <span>{post.likes_count} Likes</span>
+          </div>
+
+          <div className="text-center">
+            <p className="mb-4 text-xs font-bold uppercase tracking-widest text-gray-500">
+              Share this story
+            </p>
+            <div className="flex flex-wrap justify-center gap-3 text-sm">
+              <a
+                href={`https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(canonical)}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="rounded-full border border-white/10 px-4 py-2 text-gray-300 transition hover:border-accent hover:text-accent"
+              >
+                Facebook
+              </a>
+              <a
+                href={`https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent(canonical)}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="rounded-full border border-white/10 px-4 py-2 text-gray-300 transition hover:border-accent hover:text-accent"
+              >
+                LinkedIn
+              </a>
+              <a
+                href={`https://twitter.com/intent/tweet?url=${encodeURIComponent(canonical)}&text=${encodeURIComponent(post.title)}`}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="rounded-full border border-white/10 px-4 py-2 text-gray-300 transition hover:border-accent hover:text-accent"
+              >
+                X
+              </a>
+            </div>
+          </div>
+        </div>
+
+        {post.related_posts?.length ? (
+          <div className="mt-20 border-t border-white/10 pt-10">
+            <h2 className="mb-8 font-serif text-2xl font-bold text-white">
+              Read Next
+            </h2>
+            <div className="grid grid-cols-1 gap-6 md:grid-cols-3">
+              {post.related_posts.map((related) => {
+                const relatedImage = resolveMediaUrl(related.featured_image);
+
+                return (
+                  <Link
+                    key={related.slug}
+                    href={`/blog/${related.slug}`}
+                    className="group block overflow-hidden rounded-xl border border-white/10 bg-gray-900 transition-all hover:border-accent/50"
+                  >
+                    <div className="relative h-40 overflow-hidden">
+                      <img
+                        src={relatedImage ?? "https://via.placeholder.com/400"}
+                        alt=""
+                        className="h-full w-full object-cover opacity-80 transition-all duration-500 group-hover:scale-105 group-hover:opacity-100"
+                      />
+                    </div>
+                    <div className="p-4">
+                      <h3 className="text-lg font-bold leading-tight text-white transition-colors group-hover:text-accent">
+                        {related.title}
+                      </h3>
+                    </div>
+                  </Link>
+                );
+              })}
+            </div>
+          </div>
+        ) : null}
+
+        <div className="mt-20 rounded-2xl border border-white/5 bg-gray-900/50 p-8">
+          <h2 className="mb-4 font-serif text-2xl font-bold text-white">
+            Discussion
+          </h2>
+          <p className="text-sm leading-relaxed text-gray-400">
+            Comments and authenticated likes remain available in the current
+            React app. This server-rendered migration preserves article content,
+            sharing, and related-post discovery first.
+          </p>
+        </div>
+      </div>
+    </div>
   );
 }

--- a/openeire-next/app/blog/page.tsx
+++ b/openeire-next/app/blog/page.tsx
@@ -1,16 +1,174 @@
-import { PlaceholderPage } from "@/components/PlaceholderPage";
+/* eslint-disable @next/next/no-img-element */
+import Link from "next/link";
+import { JsonLd } from "@/components/JsonLd";
+import { getPublishedBlogPosts } from "@/lib/api/blog";
+import { formatBlogDisplayDate } from "@/lib/blog/dates";
+import { resolveMediaUrl } from "@/lib/media";
+import { buildBreadcrumbJsonLd } from "@/lib/seo/jsonLd";
 import { buildPageMetadata } from "@/lib/seo/metadata";
+import { buildAbsoluteUrl } from "@/lib/site";
+import type { BlogPostListItem } from "@/types/blog";
+import { FaCalendarAlt, FaHeart, FaTag, FaUser } from "react-icons/fa";
+
+export const revalidate = 300;
 
 export const metadata = buildPageMetadata({
-  title: "Blog | OpenÉire Studios",
+  title: "Journal | OpenÉire Studios",
+  description:
+    "Read behind-the-scenes notes, drone capture stories, and photography insights from OpenÉire Studios.",
   path: "/blog",
 });
 
-export default function BlogPage() {
+function BlogPostCard({ post }: { post: BlogPostListItem }) {
+  const imageUrl = resolveMediaUrl(post.featured_image);
+  const visibleDate = formatBlogDisplayDate(post.created_at, "Date unavailable");
+
   return (
-    <PlaceholderPage
-      title="Blog"
-      description="Foundation route for the future server-rendered journal index."
-    />
+    <Link
+      href={`/blog/${post.slug}`}
+      className="group relative flex h-full flex-col overflow-hidden rounded-2xl border border-white/10 bg-gray-900 shadow-lg transition-all duration-500 hover:-translate-y-1 hover:border-accent/50 hover:shadow-2xl"
+    >
+      <div className="relative h-64 w-full overflow-hidden">
+        <img
+          src={imageUrl ?? "https://via.placeholder.com/800x600?text=OpenEire+Journal"}
+          alt={post.title}
+          className="h-full w-full object-cover opacity-90 transition-transform duration-700 group-hover:scale-110 group-hover:opacity-100"
+        />
+        <div className="absolute inset-0 bg-gradient-to-t from-gray-900 via-transparent to-transparent opacity-90" />
+
+        <div className="absolute left-4 top-4 flex items-center gap-2 rounded-full border border-white/10 bg-black/60 px-3 py-1 text-xs font-bold text-white backdrop-blur-md">
+          <FaCalendarAlt className="text-accent" />
+          {visibleDate}
+        </div>
+      </div>
+
+      <div className="flex flex-grow flex-col p-6">
+        <div className="mb-3 flex items-center gap-2 text-xs font-bold uppercase tracking-widest text-accent">
+          <FaUser /> {post.author}
+        </div>
+
+        <h2 className="mb-3 font-serif text-2xl font-bold leading-tight text-white transition-colors group-hover:text-accent">
+          {post.title}
+        </h2>
+
+        <p className="mb-6 line-clamp-3 flex-grow text-sm leading-relaxed text-gray-400">
+          {post.excerpt}
+        </p>
+
+        <div className="mt-auto flex items-center justify-between border-t border-white/10 pt-4">
+          <div className="flex flex-wrap gap-2">
+            {post.tags.slice(0, 2).map((tag) => (
+              <span
+                key={tag}
+                className="rounded border border-white/10 bg-white/5 px-2 py-1 text-[10px] text-gray-300 transition-colors group-hover:bg-white/10"
+              >
+                #{tag}
+              </span>
+            ))}
+          </div>
+
+          <div className="flex items-center gap-1 text-xs font-bold text-gray-500 transition-colors group-hover:text-red-500">
+            <FaHeart /> {post.likes_count}
+          </div>
+        </div>
+      </div>
+    </Link>
+  );
+}
+
+export default async function BlogPage({
+  searchParams,
+}: {
+  searchParams?: Promise<{ tag?: string; page?: string }>;
+}) {
+  const resolvedSearchParams = await searchParams;
+  const currentTag = resolvedSearchParams?.tag?.trim();
+  const currentPage = resolvedSearchParams?.page;
+
+  let posts: BlogPostListItem[] = [];
+  let failedToLoad = false;
+
+  try {
+    const response = await getPublishedBlogPosts({
+      tag: currentTag || undefined,
+      page: currentPage,
+    });
+    posts = response.results;
+  } catch {
+    failedToLoad = true;
+  }
+
+  return (
+    <div className="mobile-page-offset min-h-screen bg-black pb-20 pt-36 text-white">
+      {!currentTag ? (
+        <JsonLd
+          data={[
+            buildBreadcrumbJsonLd([
+              { name: "Home", url: buildAbsoluteUrl("/") },
+              { name: "Journal", url: buildAbsoluteUrl("/blog") },
+            ]),
+            {
+              "@context": "https://schema.org",
+              "@type": "Blog",
+              name: "The Journal",
+              url: buildAbsoluteUrl("/blog"),
+              description:
+                "Behind-the-scenes notes, drone capture stories, and photography insights from OpenÉire Studios.",
+            },
+          ]}
+        />
+      ) : null}
+
+      <div className="container mx-auto px-4 lg:px-8">
+        <div className="mb-16 text-center">
+          <h1 className="mb-6 font-serif text-5xl font-bold tracking-tight md:text-7xl">
+            The Journal
+          </h1>
+          <p className="mx-auto max-w-2xl text-lg font-light text-gray-400">
+            Behind the scenes, photography tips, and stories from the Irish
+            landscape.
+          </p>
+
+          {currentTag ? (
+            <div className="animate-fade-in-up mt-8 inline-flex items-center rounded-full border border-accent/20 bg-accent/10 px-6 py-2 text-accent backdrop-blur-md">
+              <FaTag className="mr-2" />
+              <span>
+                Filtering by: <strong>#{currentTag}</strong>
+              </span>
+              <Link
+                href="/blog"
+                className="ml-4 transition-colors hover:text-white"
+              >
+                {"\u2715"}
+              </Link>
+            </div>
+          ) : null}
+        </div>
+
+        {failedToLoad ? (
+          <div className="rounded-2xl border border-white/10 bg-gray-900/50 py-20 text-center">
+            <h2 className="mb-2 text-xl font-bold text-white">
+              The journal is unavailable right now.
+            </h2>
+            <p className="text-gray-500">
+              Please try again shortly while we reconnect to the studio archive.
+            </p>
+          </div>
+        ) : posts.length === 0 ? (
+          <div className="rounded-2xl border border-white/10 bg-gray-900/50 py-20 text-center">
+            <h2 className="mb-2 text-xl font-bold text-white">
+              No stories found.
+            </h2>
+            <p className="text-gray-500">Try clearing your filters.</p>
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-3 lg:gap-12">
+            {posts.map((post) => (
+              <BlogPostCard key={post.id} post={post} />
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
   );
 }

--- a/openeire-next/app/globals.css
+++ b/openeire-next/app/globals.css
@@ -101,3 +101,75 @@ a {
     padding-top: calc(var(--site-header-height, 0px) + 1rem);
   }
 }
+
+.blog-content {
+  @apply max-w-none text-gray-300;
+}
+
+.blog-content p {
+  @apply mb-6 text-lg leading-9 text-gray-300;
+}
+
+.blog-content h1,
+.blog-content h2,
+.blog-content h3,
+.blog-content h4,
+.blog-content h5,
+.blog-content h6 {
+  @apply font-serif leading-tight text-white;
+}
+
+.blog-content h1 {
+  @apply mb-6 mt-10 text-4xl font-bold;
+}
+
+.blog-content h2 {
+  @apply mb-5 mt-10 text-3xl font-bold;
+}
+
+.blog-content h3 {
+  @apply mb-4 mt-8 text-2xl font-semibold;
+}
+
+.blog-content h4 {
+  @apply mb-3 mt-6 text-xl font-semibold;
+}
+
+.blog-content ul,
+.blog-content ol {
+  @apply mb-6 ml-7 space-y-3 text-lg leading-9 text-gray-300;
+  list-style-position: outside;
+}
+
+.blog-content ul {
+  list-style-type: disc;
+}
+
+.blog-content ol {
+  list-style-type: decimal;
+}
+
+.blog-content li {
+  @apply pl-1;
+}
+
+.blog-content blockquote {
+  @apply my-8 border-l-4 border-accent pl-6 italic text-gray-200;
+}
+
+.blog-content a {
+  @apply text-accent underline underline-offset-4 transition-colors hover:text-white;
+}
+
+.blog-content img {
+  @apply my-8 rounded-xl;
+}
+
+.blog-content hr {
+  @apply my-8 border-white/10;
+}
+
+.blog-content pre,
+.blog-content code {
+  @apply rounded bg-white/5;
+}

--- a/openeire-next/app/sitemap.ts
+++ b/openeire-next/app/sitemap.ts
@@ -1,4 +1,5 @@
 import type { MetadataRoute } from "next";
+import { getAllPublishedBlogPostsForSitemap } from "@/lib/api/blog";
 import { buildAbsoluteUrl } from "@/lib/site";
 
 const staticPublicRoutes = [
@@ -8,15 +9,32 @@ const staticPublicRoutes = [
   "/footage",
   "/real-estate",
   "/us",
+  "/blog",
 ];
 
-export default function sitemap(): MetadataRoute.Sitemap {
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const now = new Date();
+  let blogPosts: MetadataRoute.Sitemap = [];
 
-  return staticPublicRoutes.map((route) => ({
-    url: buildAbsoluteUrl(route),
-    lastModified: now,
-    changeFrequency: route === "/" ? "weekly" : "monthly",
-    priority: route === "/" ? 1 : 0.7,
-  }));
+  try {
+    const posts = await getAllPublishedBlogPostsForSitemap();
+    blogPosts = posts.map((post) => ({
+      url: buildAbsoluteUrl(`/blog/${post.slug}`),
+      lastModified: post.created_at ? new Date(post.created_at) : now,
+      changeFrequency: "monthly",
+      priority: 0.6,
+    }));
+  } catch {
+    blogPosts = [];
+  }
+
+  return [
+    ...staticPublicRoutes.map((route) => ({
+      url: buildAbsoluteUrl(route),
+      lastModified: now,
+      changeFrequency: route === "/" ? ("weekly" as const) : ("monthly" as const),
+      priority: route === "/" ? 1 : 0.7,
+    })),
+    ...blogPosts,
+  ];
 }

--- a/openeire-next/lib/api/blog.ts
+++ b/openeire-next/lib/api/blog.ts
@@ -1,0 +1,59 @@
+import { api, isApiError } from "@/lib/api/client";
+import type {
+  BlogPostDetail,
+  BlogPostListItem,
+  PaginatedResponse,
+} from "@/types/blog";
+
+const BLOG_REVALIDATE_SECONDS = 300;
+
+export const getPublishedBlogPosts = async (
+  options: { tag?: string; page?: number | string } = {},
+): Promise<PaginatedResponse<BlogPostListItem>> => {
+  const response = await api.get<PaginatedResponse<BlogPostListItem>>("blog/", {
+    params: {
+      tag: options.tag,
+      page: options.page,
+    },
+    next: { revalidate: BLOG_REVALIDATE_SECONDS },
+  });
+
+  return response.data;
+};
+
+export const getAllPublishedBlogPostsForSitemap = async (): Promise<
+  BlogPostListItem[]
+> => {
+  const posts: BlogPostListItem[] = [];
+  let page = 1;
+
+  while (page <= 20) {
+    const response = await getPublishedBlogPosts({ page });
+    posts.push(...response.results);
+    if (!response.next) break;
+    page += 1;
+  }
+
+  return posts;
+};
+
+export const getPublishedBlogPostBySlug = async (
+  slug: string,
+): Promise<BlogPostDetail | null> => {
+  try {
+    const response = await api.get<BlogPostDetail>(`blog/${slug}/`, {
+      next: { revalidate: BLOG_REVALIDATE_SECONDS },
+    });
+
+    return response.data;
+  } catch (error) {
+    if (
+      isApiError(error) &&
+      (error.response?.status === 404 ||
+        error.message.toLowerCase().includes("not found"))
+    ) {
+      return null;
+    }
+    throw error;
+  }
+};

--- a/openeire-next/lib/api/config.ts
+++ b/openeire-next/lib/api/config.ts
@@ -1,4 +1,4 @@
-const DEFAULT_API_BASE_URL = "/api/";
+const DEFAULT_API_BASE_URL = "https://api.openeire.ie/api/";
 
 export const isAbsoluteUrl = (value: string): boolean =>
   value.startsWith("http://") || value.startsWith("https://");

--- a/openeire-next/lib/blog/dates.ts
+++ b/openeire-next/lib/blog/dates.ts
@@ -1,0 +1,17 @@
+const IRISH_VISIBLE_DATE_FORMATTER = new Intl.DateTimeFormat("en-IE", {
+  day: "2-digit",
+  month: "2-digit",
+  year: "numeric",
+});
+
+export const formatBlogDisplayDate = (
+  value?: string | null,
+  fallback = "",
+): string => {
+  if (!value) return fallback;
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return fallback;
+
+  return IRISH_VISIBLE_DATE_FORMATTER.format(date);
+};

--- a/openeire-next/lib/media.ts
+++ b/openeire-next/lib/media.ts
@@ -1,0 +1,32 @@
+import { API_BASE_URL, isAbsoluteUrl } from "@/lib/api/config";
+
+const deriveMediaBaseUrl = (): string => {
+  const explicit = process.env.NEXT_PUBLIC_MEDIA_BASE_URL?.trim();
+  if (explicit) {
+    if (isAbsoluteUrl(explicit)) return explicit.replace(/\/+$/, "");
+    return `/${explicit.replace(/^\/+|\/+$/g, "")}`;
+  }
+
+  if (isAbsoluteUrl(API_BASE_URL)) {
+    try {
+      return new URL(API_BASE_URL).origin;
+    } catch {
+      return "";
+    }
+  }
+
+  return "";
+};
+
+export const resolveMediaUrl = (
+  assetPath?: string | null,
+): string | undefined => {
+  if (!assetPath) return undefined;
+  if (isAbsoluteUrl(assetPath)) return assetPath;
+
+  const normalizedPath = assetPath.startsWith("/") ? assetPath : `/${assetPath}`;
+  const mediaBaseUrl = deriveMediaBaseUrl();
+  if (!mediaBaseUrl) return normalizedPath;
+
+  return `${mediaBaseUrl}${normalizedPath}`;
+};

--- a/openeire-next/lib/sanitizeRichHtml.ts
+++ b/openeire-next/lib/sanitizeRichHtml.ts
@@ -1,0 +1,126 @@
+const FORBIDDEN_BLOCKS =
+  /<\s*(script|style|iframe|object|embed|form|input|button|textarea|select|meta|link)\b[^>]*>[\s\S]*?<\s*\/\s*\1\s*>/gi;
+const FORBIDDEN_SELF_CLOSING =
+  /<\s*(script|style|iframe|object|embed|form|input|button|textarea|select|meta|link)\b[^>]*\/?\s*>/gi;
+
+const ALLOWED_TAGS = new Set([
+  "a",
+  "blockquote",
+  "br",
+  "code",
+  "div",
+  "em",
+  "figcaption",
+  "figure",
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "h6",
+  "hr",
+  "img",
+  "li",
+  "ol",
+  "p",
+  "pre",
+  "span",
+  "strong",
+  "ul",
+]);
+
+const ATTRIBUTES_BY_TAG: Record<string, Set<string>> = {
+  a: new Set(["href", "title", "target", "rel"]),
+  img: new Set(["src", "alt", "title", "width", "height", "loading"]),
+};
+
+const escapeHtml = (value: string): string =>
+  value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+
+const isSafeUrl = (value: string): boolean => {
+  const trimmed = value.trim();
+  if (!trimmed) return false;
+  if (
+    trimmed.startsWith("/") ||
+    trimmed.startsWith("#") ||
+    trimmed.startsWith("mailto:")
+  ) {
+    return true;
+  }
+
+  try {
+    const url = new URL(trimmed);
+    return url.protocol === "http:" || url.protocol === "https:";
+  } catch {
+    return false;
+  }
+};
+
+const sanitizeAttributes = (tagName: string, rawAttributes: string): string => {
+  const allowed = ATTRIBUTES_BY_TAG[tagName];
+  if (!allowed) return "";
+
+  const attributes: string[] = [];
+  const attrPattern =
+    /([A-Za-z_:][-A-Za-z0-9_:.]*)\s*=\s*("([^"]*)"|'([^']*)'|([^\s"'=<>`]+))/g;
+  let match: RegExpExecArray | null;
+
+  while ((match = attrPattern.exec(rawAttributes))) {
+    const name = match[1].toLowerCase();
+    const value = match[3] ?? match[4] ?? match[5] ?? "";
+
+    if (!allowed.has(name)) continue;
+    if (name.startsWith("on")) continue;
+    if ((name === "href" || name === "src") && !isSafeUrl(value)) continue;
+
+    if (tagName === "a" && name === "target" && value !== "_blank") continue;
+
+    attributes.push(`${name}="${escapeHtml(value)}"`);
+  }
+
+  if (tagName === "a") {
+    const hasTargetBlank = attributes.includes('target="_blank"');
+    const hasRel = attributes.some((attribute) => attribute.startsWith("rel="));
+    if (hasTargetBlank && !hasRel) {
+      attributes.push('rel="noopener noreferrer"');
+    }
+  }
+
+  if (tagName === "img") {
+    const hasLoading = attributes.some((attribute) =>
+      attribute.startsWith("loading="),
+    );
+    if (!hasLoading) attributes.push('loading="lazy"');
+  }
+
+  return attributes.length ? ` ${attributes.join(" ")}` : "";
+};
+
+export const sanitizeRichHtml = (html: string): string => {
+  if (!html) return "";
+
+  return html
+    .replace(FORBIDDEN_BLOCKS, "")
+    .replace(FORBIDDEN_SELF_CLOSING, "")
+    .replace(/<\s*\/?\s*([A-Za-z0-9-]+)([^>]*)>/g, (tag, tagName, attrs) => {
+      const normalizedTag = String(tagName).toLowerCase();
+      if (!ALLOWED_TAGS.has(normalizedTag)) return "";
+
+      const isClosing = /^<\s*\//.test(tag);
+      if (isClosing) return `</${normalizedTag}>`;
+
+      const isSelfClosing = /\/\s*>$/.test(tag) || normalizedTag === "br";
+      const sanitizedAttributes = sanitizeAttributes(
+        normalizedTag,
+        String(attrs ?? ""),
+      );
+
+      return `<${normalizedTag}${sanitizedAttributes}${isSelfClosing ? " />" : ">"}`;
+    })
+    .replace(/\s+>/g, ">")
+    .replace(/\s+\/>/g, " />");
+};

--- a/openeire-next/types/blog.ts
+++ b/openeire-next/types/blog.ts
@@ -1,0 +1,36 @@
+export interface PaginatedResponse<T> {
+  count: number;
+  next: string | null;
+  previous: string | null;
+  results: T[];
+}
+
+export interface BlogPostListItem {
+  id: number;
+  title: string;
+  slug: string;
+  author: string;
+  featured_image: string | null;
+  excerpt: string;
+  meta_title: string;
+  meta_description: string;
+  canonical_url: string;
+  created_at: string;
+  tags: string[];
+  likes_count: number;
+  has_liked?: boolean;
+}
+
+export interface RelatedBlogPost {
+  title: string;
+  slug: string;
+  featured_image: string | null;
+  created_at: string;
+}
+
+export interface BlogPostDetail extends BlogPostListItem {
+  content: string;
+  updated_at: string;
+  has_liked: boolean;
+  related_posts: RelatedBlogPost[];
+}


### PR DESCRIPTION
## Summary

Replace the placeholder blog pages with fully server-rendered blog list and detail pages. The list page shows a card grid with tags, author, date, and likes; the detail page renders the full article with related posts, sharing links, and JSON-LD structured data.

## Why

Closes #169 — completes the blog portion of the Next.js migration phase 3.

## Screenshots / Demo

- Not needed

## Changes

- Frontend:
- Blog list page (/blog) with card grid, tag filtering, pagination support, empty/error states
- Blog detail page (/blog/[slug]) with full article rendering, author, date, tags, featured image, related posts, sharing (Facebook/LinkedIn/X), and likes display
- Blog content typography styles (headings, lists, blockquotes, code, links, images) in globals.css
- JSON-LD breadcrumbs + BlogPosting schema on detail pages, Blog schema on list page
- Rich SEO metadata (Open Graph, Twitter Card, robots) for each blog post
- Blog post entries in sitemap.xml
- Infra/Config:
- API base URL changed to production endpoint (https://api.openeire.ie/api/)
- Error/loading/not-found states handled for both pages

## Testing

- Django tests pass locally
- React build passes locally
- Manual smoke test done

### Manual smoke test checklist (quick)

- No console errors
- Forms submit correctly (success + validation errors)
- API errors handled (loading/error states)
- Mobile layout checked
- Auth/permissions verified (if relevant)

## Risk & Rollback

## Risk level: Low

## Rollback plan:
- Revert PR

## Notes for Reviewer (Codex/Copilot)

Focus review on:
- Security (auth, permissions, file uploads, CSRF/CORS)
- Performance (N+1 queries, heavy renders, unnecessary requests)
- Maintainability (naming, structure, duplicated logic)