### PR TITLE
Add iubenda consent, media preview, share controls, and enquiry forms

### DIFF
--- a/openeire-next/app/contact/page.tsx
+++ b/openeire-next/app/contact/page.tsx
@@ -1,0 +1,41 @@
+import type { Metadata } from "next";
+import { JsonLd } from "@/components/JsonLd";
+import { ContactForm } from "@/components/contact/ContactForm";
+import { buildPageMetadata } from "@/lib/seo/metadata";
+import { buildBreadcrumbJsonLd } from "@/lib/seo/jsonLd";
+import { buildAbsoluteUrl } from "@/lib/site";
+
+export const metadata: Metadata = buildPageMetadata({
+  title: "Contact OpenEire Studios | Prints, Licensing & Drone Work",
+  description:
+    "Get in touch about fine art print enquiries, commercial licensing, or bespoke drone capture projects in Ireland.",
+  path: "/contact",
+});
+
+export default function ContactPage() {
+  return (
+    <div className="page-top-offset min-h-screen overflow-x-hidden bg-black pb-20 text-white">
+      <JsonLd
+        data={buildBreadcrumbJsonLd([
+          { name: "Home", url: buildAbsoluteUrl("/") },
+          { name: "Contact", url: buildAbsoluteUrl("/contact") },
+        ])}
+      />
+
+      <div className="container mx-auto max-w-7xl px-4 lg:px-8">
+        <div className="mb-16 px-2 text-center">
+          <h1 className="mb-6 font-serif text-4xl font-bold md:text-6xl">
+            Get in Touch
+          </h1>
+          <p className="mx-auto max-w-2xl text-lg font-light leading-relaxed text-gray-400">
+            Have a question about a specific print, commercial licensing rights,
+            or a custom drone shot? We are here to help bring your vision to
+            life.
+          </p>
+        </div>
+
+        <ContactForm />
+      </div>
+    </div>
+  );
+}

--- a/openeire-next/app/gallery/physical/[id]/page.tsx
+++ b/openeire-next/app/gallery/physical/[id]/page.tsx
@@ -1,10 +1,11 @@
-/* eslint-disable @next/next/no-img-element */
 import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
 import { JsonLd } from "@/components/JsonLd";
 import { GalleryProductCard } from "@/components/gallery/GalleryProductCard";
+import { ProductMediaPreview } from "@/components/gallery/ProductMediaPreview";
 import { SpecBox } from "@/components/gallery/SpecBox";
+import { ShareControls } from "@/components/share/ShareControls";
 import { getPublicPhysicalProduct } from "@/lib/api/gallery";
 import {
   formatEuro,
@@ -192,18 +193,8 @@ export default async function PhysicalProductPage({
         <div className="grid grid-cols-1 gap-12 lg:grid-cols-12 lg:gap-20">
           <div className="lg:col-span-8">
             <div className="sticky top-32">
-              <div className="group relative mx-auto w-fit overflow-hidden rounded-xl border border-white/10 bg-black shadow-2xl">
-                {imageUrl ? (
-                  <img
-                    src={imageUrl}
-                    alt={product.title}
-                    className="block h-auto max-h-[75vh] w-auto max-w-full shadow-lg"
-                  />
-                ) : (
-                  <div className="flex aspect-[4/3] min-h-[320px] w-full items-center justify-center bg-gray-900 px-8 text-center text-gray-500">
-                    Preview image unavailable
-                  </div>
-                )}
+              <div className="relative mx-auto w-fit overflow-hidden rounded-xl border border-white/10 bg-black shadow-2xl">
+                <ProductMediaPreview imageUrl={imageUrl} title={product.title} />
               </div>
 
               <div className="mt-8 grid grid-cols-2 gap-px overflow-hidden rounded-lg border border-white/10 bg-white/10 md:grid-cols-4">
@@ -316,6 +307,8 @@ export default async function PhysicalProductPage({
                 ))}
               </div>
             ) : null}
+
+            <ShareControls title={product.title} url={canonical} />
           </div>
         </div>
 

--- a/openeire-next/app/globals.css
+++ b/openeire-next/app/globals.css
@@ -108,6 +108,13 @@ a {
   }
 }
 
+/* Keep the iubenda preferences button clear of our back-to-top control. */
+.iubenda-tp-btn.iubenda-cs-preferences-link {
+  left: 16px !important;
+  right: auto !important;
+  bottom: 16px !important;
+}
+
 .blog-content {
   @apply max-w-none text-gray-300;
 }

--- a/openeire-next/app/layout.tsx
+++ b/openeire-next/app/layout.tsx
@@ -1,7 +1,9 @@
 import type { Metadata } from "next";
+import Script from "next/script";
 import "./globals.css";
 import { Footer } from "@/components/layout/Footer";
 import { Navbar } from "@/components/layout/Navbar";
+import { Providers } from "@/components/Providers";
 import { buildDefaultMetadata } from "@/lib/seo/metadata";
 
 export const metadata: Metadata = buildDefaultMetadata();
@@ -22,11 +24,17 @@ export default function RootLayout({
         />
       </head>
       <body>
-        <div className="flex min-h-screen flex-col">
-          <Navbar />
-          <main className="flex-1">{children}</main>
-          <Footer />
-        </div>
+        <Script
+          src="https://embeds.iubenda.com/widgets/b39f0cd0-25d9-49f2-9306-1258615676f2.js"
+          strategy="afterInteractive"
+        />
+        <Providers>
+          <div className="flex min-h-screen flex-col">
+            <Navbar />
+            <main className="flex-1">{children}</main>
+            <Footer />
+          </div>
+        </Providers>
       </body>
     </html>
   );

--- a/openeire-next/app/real-estate/page.tsx
+++ b/openeire-next/app/real-estate/page.tsx
@@ -1,4 +1,5 @@
 import { JsonLd } from "@/components/JsonLd";
+import { RealEstateEnquiryForm } from "@/components/real-estate/RealEstateEnquiryForm";
 import {
   CardGrid,
   CtaBand,
@@ -132,10 +133,11 @@ export default function RealEstatePage() {
         title="Ready to plan a property shoot?"
         description="Send the property address, preferred package, and any access or timing notes so the shoot can be scoped safely and clearly."
         actions={[
-          { href: "/contact", label: "Request a Property Shoot" },
+          { href: "#enquiry", label: "Request a Property Shoot" },
           { href: "/licensing", label: "Review Licensing", variant: "secondary" },
         ]}
       />
+      <RealEstateEnquiryForm />
     </div>
   );
 }

--- a/openeire-next/app/sitemap.ts
+++ b/openeire-next/app/sitemap.ts
@@ -11,6 +11,7 @@ const staticPublicRoutes = [
   "/real-estate",
   "/us",
   "/blog",
+  "/contact",
   "/gallery/physical",
 ];
 

--- a/openeire-next/components/BackToTop.tsx
+++ b/openeire-next/components/BackToTop.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export function BackToTop() {
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    const toggleVisibility = () => {
+      setIsVisible(window.scrollY > 300);
+    };
+
+    toggleVisibility();
+    window.addEventListener("scroll", toggleVisibility, { passive: true });
+    return () => window.removeEventListener("scroll", toggleVisibility);
+  }, []);
+
+  if (!isVisible) return null;
+
+  const scrollToTop = () => {
+    const prefersReducedMotion = window.matchMedia(
+      "(prefers-reduced-motion: reduce)",
+    ).matches;
+    window.scrollTo({
+      top: 0,
+      behavior: prefersReducedMotion ? "auto" : "smooth",
+    });
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={scrollToTop}
+      className="fixed bottom-24 right-4 z-50 rounded-full bg-green-600 p-3 text-white shadow-lg transition-all duration-300 hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500 focus:ring-offset-2"
+      aria-label="Back to top"
+    >
+      <svg
+        className="h-6 w-6"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+        aria-hidden="true"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M5 10l7-7m0 0l7 7m-7-7v18"
+        />
+      </svg>
+    </button>
+  );
+}

--- a/openeire-next/components/Providers.tsx
+++ b/openeire-next/components/Providers.tsx
@@ -1,0 +1,16 @@
+"use client";
+
+import type { ReactNode } from "react";
+import { BackToTop } from "@/components/BackToTop";
+import { NewsletterSignupModal } from "@/components/newsletter/NewsletterSignupModal";
+import { ToastProvider } from "@/components/ui/ToastProvider";
+
+export function Providers({ children }: { children: ReactNode }) {
+  return (
+    <ToastProvider>
+      {children}
+      <NewsletterSignupModal />
+      <BackToTop />
+    </ToastProvider>
+  );
+}

--- a/openeire-next/components/contact/ContactForm.tsx
+++ b/openeire-next/components/contact/ContactForm.tsx
@@ -1,0 +1,264 @@
+"use client";
+
+import { useEffect, useState, type ChangeEvent, type FormEvent } from "react";
+import {
+  FaCheckCircle,
+  FaEnvelope,
+  FaMapMarkerAlt,
+  FaPaperPlane,
+} from "react-icons/fa";
+import { sendContactMessage, getApiErrorMessage } from "@/lib/api/publicForms";
+import {
+  registerIubendaConsentForm,
+  submitIubendaConsentForm,
+} from "@/lib/iubendaConsent";
+import { useToast } from "@/components/ui/ToastProvider";
+import type { ContactData } from "@/types/publicForms";
+
+const FORM_ID = "contact-form";
+const SUBMIT_ID = "contact-submit";
+
+const inputClass =
+  "w-full rounded-lg border border-white/20 bg-black p-4 text-white placeholder-gray-600 outline-none transition-all focus:border-accent focus:ring-1 focus:ring-accent";
+const labelClass =
+  "mb-2 block text-xs font-bold uppercase tracking-widest text-gray-500";
+
+const initialFormData: ContactData = {
+  name: "",
+  email: "",
+  subject: "",
+  message: "",
+};
+
+export function ContactForm() {
+  const [formData, setFormData] = useState<ContactData>(initialFormData);
+  const [status, setStatus] = useState<"idle" | "submitting" | "success">(
+    "idle",
+  );
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const { showToast } = useToast();
+
+  useEffect(() => {
+    return registerIubendaConsentForm({
+      formId: FORM_ID,
+      submitButtonId: SUBMIT_ID,
+      subject: {
+        full_name: "name",
+        email: "email",
+      },
+      preferences: {
+        contact_request: "contact_request",
+      },
+    });
+  }, []);
+
+  const handleChange = (
+    event: ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>,
+  ) => {
+    const { name, value } = event.target;
+    setFormData((current) => ({ ...current, [name]: value }));
+    setErrorMessage(null);
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setStatus("submitting");
+    setErrorMessage(null);
+
+    try {
+      await sendContactMessage({
+        name: formData.name.trim(),
+        email: formData.email.trim(),
+        subject: formData.subject,
+        message: formData.message.trim(),
+      });
+      submitIubendaConsentForm(FORM_ID);
+      setStatus("success");
+      setFormData(initialFormData);
+      showToast("Message sent successfully.", "success");
+    } catch (error) {
+      const message = getApiErrorMessage(
+        error,
+        "We could not send your message. Please try again.",
+      );
+      setErrorMessage(message);
+      setStatus("idle");
+      showToast(message, "error");
+    }
+  };
+
+  return (
+    <div className="grid grid-cols-1 gap-12 lg:grid-cols-12 lg:gap-16">
+      <div className="min-w-0 space-y-6 lg:col-span-5">
+        <div className="group flex w-full min-w-0 max-w-full items-start gap-4 overflow-hidden rounded-2xl border border-white/10 bg-gray-900 p-6 transition-colors hover:border-brand-500/30 sm:gap-6 sm:p-8">
+          <div className="shrink-0 rounded-full border border-white/10 bg-black p-4 text-brand-500 transition-colors group-hover:bg-brand-500 group-hover:text-black">
+            <FaEnvelope className="text-xl" aria-hidden="true" />
+          </div>
+          <div className="min-w-0">
+            <h3 className="mb-1 text-lg font-bold text-white">Email Us</h3>
+            <p className="mb-2 text-sm text-gray-400">
+              For print enquiries, commercial licensing, and custom drone work.
+            </p>
+            <a
+              href="mailto:contact@openeire.ie"
+              className="block break-all font-mono text-sm text-brand-500 hover:underline sm:text-base"
+            >
+              contact@openeire.ie
+            </a>
+          </div>
+        </div>
+
+        <div className="group flex w-full min-w-0 max-w-full items-start gap-4 overflow-hidden rounded-2xl border border-white/10 bg-gray-900 p-6 transition-colors hover:border-brand-500/30 sm:gap-6 sm:p-8">
+          <div className="shrink-0 rounded-full border border-white/10 bg-black p-4 text-brand-500 transition-colors group-hover:bg-brand-500 group-hover:text-black">
+            <FaMapMarkerAlt className="text-xl" aria-hidden="true" />
+          </div>
+          <div className="min-w-0">
+            <h3 className="mb-1 text-lg font-bold text-white">Studio</h3>
+            <p className="text-sm text-gray-400">
+              Loughrea, Co. Galway, Ireland
+              <br />
+              <span className="mt-1 block text-xs uppercase tracking-widest opacity-50">
+                By Appointment Only
+              </span>
+            </p>
+          </div>
+        </div>
+      </div>
+
+      <div className="min-w-0 lg:col-span-7">
+        <div className="relative overflow-hidden rounded-3xl border border-white/10 bg-gray-900 p-8 shadow-2xl md:p-10">
+          <div className="pointer-events-none absolute right-0 top-0 h-64 w-64 translate-x-1/2 -translate-y-1/2 rounded-full bg-brand-500/5 blur-3xl" />
+
+          {status === "success" ? (
+            <div className="animate-fade-in-up flex min-h-[400px] flex-col items-center justify-center text-center">
+              <div className="mb-6 flex h-20 w-20 items-center justify-center rounded-full bg-brand-500/10">
+                <FaCheckCircle className="text-4xl text-brand-500" />
+              </div>
+              <h2 className="mb-4 font-serif text-3xl font-bold text-white">
+                Message Sent
+              </h2>
+              <p className="mb-8 max-w-md text-gray-400">
+                Thank you for reaching out. A member of our team will get back
+                to you within 24 hours.
+              </p>
+              <button
+                type="button"
+                onClick={() => setStatus("idle")}
+                className="rounded-lg border border-white/20 px-8 py-3 font-bold text-white transition-all hover:bg-brand-500 hover:text-black"
+              >
+                Send Another Message
+              </button>
+            </div>
+          ) : (
+            <form
+              id={FORM_ID}
+              onSubmit={handleSubmit}
+              className="relative z-10 space-y-6"
+            >
+              <input
+                type="hidden"
+                name="contact_request"
+                value="true"
+                readOnly
+              />
+              <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+                <div className="min-w-0">
+                  <label htmlFor="contact-name" className={labelClass}>
+                    Your Name
+                  </label>
+                  <input
+                    id="contact-name"
+                    type="text"
+                    name="name"
+                    required
+                    value={formData.name}
+                    onChange={handleChange}
+                    placeholder="John Doe"
+                    className={inputClass}
+                  />
+                </div>
+                <div className="min-w-0">
+                  <label htmlFor="contact-email" className={labelClass}>
+                    Email Address
+                  </label>
+                  <input
+                    id="contact-email"
+                    type="email"
+                    name="email"
+                    required
+                    value={formData.email}
+                    onChange={handleChange}
+                    placeholder="john@example.com"
+                    className={inputClass}
+                  />
+                </div>
+              </div>
+
+              <div>
+                <label htmlFor="contact-subject" className={labelClass}>
+                  Topic
+                </label>
+                <select
+                  id="contact-subject"
+                  name="subject"
+                  required
+                  value={formData.subject}
+                  onChange={handleChange}
+                  className={`${inputClass} cursor-pointer appearance-none`}
+                >
+                  <option value="" disabled>
+                    Select a topic...
+                  </option>
+                  <option value="Licensing">Commercial Licensing</option>
+                  <option value="Prints">Fine Art Prints</option>
+                  <option value="Commission">Commission / Drone Work</option>
+                  <option value="Support">Technical Support</option>
+                  <option value="Other">Other Inquiry</option>
+                </select>
+              </div>
+
+              <div>
+                <label htmlFor="contact-message" className={labelClass}>
+                  Message
+                </label>
+                <textarea
+                  id="contact-message"
+                  name="message"
+                  rows={5}
+                  required
+                  value={formData.message}
+                  onChange={handleChange}
+                  placeholder="How can we help you?"
+                  className={`${inputClass} resize-none`}
+                />
+              </div>
+
+              {errorMessage ? (
+                <div className="rounded-2xl border border-red-500/20 bg-red-500/10 px-4 py-3 text-sm text-red-300">
+                  {errorMessage}
+                </div>
+              ) : null}
+
+              <button
+                id={SUBMIT_ID}
+                name="submit-button"
+                type="submit"
+                disabled={status === "submitting"}
+                className="flex w-full items-center justify-center gap-3 rounded-xl bg-brand-700 py-4 text-lg font-bold text-paper shadow-lg transition-all hover:bg-brand-900 active:scale-[0.99] disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                {status === "submitting" ? (
+                  <span className="h-5 w-5 animate-spin rounded-full border-2 border-brand-900 border-t-transparent" />
+                ) : (
+                  <>
+                    <span>Send Message</span>
+                    <FaPaperPlane className="text-sm" aria-hidden="true" />
+                  </>
+                )}
+              </button>
+            </form>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/openeire-next/components/gallery/ProductMediaPreview.tsx
+++ b/openeire-next/components/gallery/ProductMediaPreview.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { FaSearchPlus, FaTimes } from "react-icons/fa";
+
+interface ProductMediaPreviewProps {
+  imageUrl?: string;
+  title: string;
+}
+
+export function ProductMediaPreview({
+  imageUrl,
+  title,
+}: ProductMediaPreviewProps) {
+  const [isOpen, setIsOpen] = useState(false);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setIsOpen(false);
+      }
+    };
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [isOpen]);
+
+  if (!imageUrl) {
+    return (
+      <div className="flex aspect-[4/3] min-h-[320px] w-full items-center justify-center bg-gray-900 px-8 text-center text-gray-500">
+        Preview image unavailable
+      </div>
+    );
+  }
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setIsOpen(true)}
+        className="group relative block text-left"
+        aria-label={`Open larger preview of ${title}`}
+      >
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src={imageUrl}
+          alt={title}
+          className="block h-auto max-h-[75vh] w-auto max-w-full shadow-lg"
+        />
+        <span className="absolute bottom-4 right-4 inline-flex items-center gap-2 rounded-full border border-white/10 bg-black/70 px-3 py-2 text-xs font-bold uppercase tracking-[0.16em] text-white opacity-0 backdrop-blur transition-opacity group-hover:opacity-100 group-focus-visible:opacity-100">
+          <FaSearchPlus aria-hidden="true" />
+          View
+        </span>
+      </button>
+
+      {isOpen ? (
+        <div
+          className="fixed inset-0 z-[90] flex items-center justify-center bg-black/90 p-4"
+          role="dialog"
+          aria-modal="true"
+          aria-label={`${title} image preview`}
+        >
+          <button
+            type="button"
+            onClick={() => setIsOpen(false)}
+            className="absolute right-4 top-4 rounded-full border border-white/15 bg-white/5 p-3 text-white transition hover:bg-white/10"
+            aria-label="Close image preview"
+          >
+            <FaTimes aria-hidden="true" />
+          </button>
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={imageUrl}
+            alt={title}
+            className="max-h-[90vh] max-w-[95vw] rounded-xl object-contain shadow-2xl"
+          />
+        </div>
+      ) : null}
+    </>
+  );
+}

--- a/openeire-next/components/layout/Footer.tsx
+++ b/openeire-next/components/layout/Footer.tsx
@@ -2,6 +2,7 @@ import Image from "next/image";
 import Link from "next/link";
 import type { ReactNode } from "react";
 import { FaInstagram, FaYoutube } from "react-icons/fa";
+import { FooterNewsletterSignup } from "@/components/newsletter/FooterNewsletterSignup";
 
 function FooterLink({ href, children }: { href: string; children: ReactNode }) {
   return (
@@ -122,21 +123,7 @@ export function Footer() {
             <p className="mb-4 text-sm text-brand-100/80">
               Join our community for exclusive discounts and new location drops.
             </p>
-            <form className="flex flex-col gap-3">
-              <input
-                id="newsletter-email"
-                name="email"
-                type="email"
-                placeholder="email@example.com"
-                className="w-full rounded-lg border border-paper bg-brand-800 px-4 py-3 text-white placeholder-paper/50 transition-all focus:outline-none focus:ring-1 focus:ring-accent"
-              />
-              <button
-                type="button"
-                className="w-full rounded-lg bg-accent px-4 py-3 font-bold text-brand-900 shadow-lg shadow-black/20 transition-colors hover:bg-accent-hover"
-              >
-                Subscribe
-              </button>
-            </form>
+            <FooterNewsletterSignup />
           </div>
         </div>
 

--- a/openeire-next/components/newsletter/FooterNewsletterSignup.tsx
+++ b/openeire-next/components/newsletter/FooterNewsletterSignup.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useEffect, useState, type FormEvent } from "react";
+import { newsletterSignup, getApiErrorMessage } from "@/lib/api/publicForms";
+import {
+  registerIubendaConsentForm,
+  submitIubendaConsentForm,
+} from "@/lib/iubendaConsent";
+import { useToast } from "@/components/ui/ToastProvider";
+
+const FORM_ID = "footer-newsletter-signup-form";
+const SUBMIT_ID = "footer-newsletter-submit";
+
+export function FooterNewsletterSignup() {
+  const [email, setEmail] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const { showToast } = useToast();
+
+  useEffect(() => {
+    return registerIubendaConsentForm({
+      formId: FORM_ID,
+      submitButtonId: SUBMIT_ID,
+      subject: { email: "email" },
+      preferences: { newsletter: "newsletter_consent" },
+    });
+  }, []);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setIsSubmitting(true);
+    setErrorMessage(null);
+
+    try {
+      await newsletterSignup({ email, source: "footer" });
+      submitIubendaConsentForm(FORM_ID);
+      setEmail("");
+      showToast("Thanks for joining the OpenEire list.", "success");
+    } catch (error) {
+      const message = getApiErrorMessage(
+        error,
+        "We could not subscribe that email. Please try again.",
+      );
+      setErrorMessage(message);
+      showToast(message, "error");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <form id={FORM_ID} className="flex flex-col gap-3" onSubmit={handleSubmit}>
+      <input type="hidden" name="newsletter_consent" value="true" readOnly />
+      <label htmlFor="footer-newsletter-email" className="sr-only">
+        Email address
+      </label>
+      <input
+        id="footer-newsletter-email"
+        name="email"
+        type="email"
+        value={email}
+        onChange={(event) => setEmail(event.target.value)}
+        placeholder="email@example.com"
+        required
+        autoComplete="email"
+        className="w-full rounded-lg border border-paper bg-brand-800 px-4 py-3 text-white placeholder-paper/50 transition-all focus:outline-none focus:ring-1 focus:ring-accent"
+      />
+      {errorMessage ? (
+        <p className="text-xs leading-5 text-red-200">{errorMessage}</p>
+      ) : null}
+      <button
+        id={SUBMIT_ID}
+        type="submit"
+        disabled={isSubmitting}
+        className="w-full rounded-lg bg-accent px-4 py-3 font-bold text-brand-900 shadow-lg shadow-black/20 transition-colors hover:bg-accent-hover disabled:cursor-not-allowed disabled:opacity-60"
+      >
+        {isSubmitting ? "Subscribing..." : "Subscribe"}
+      </button>
+    </form>
+  );
+}

--- a/openeire-next/components/newsletter/NewsletterSignupModal.tsx
+++ b/openeire-next/components/newsletter/NewsletterSignupModal.tsx
@@ -1,0 +1,315 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { useEffect, useMemo, useState, type FormEvent } from "react";
+import { FaCheckCircle, FaTimes } from "react-icons/fa";
+import { newsletterSignup, getApiErrorMessage } from "@/lib/api/publicForms";
+import {
+  registerIubendaConsentForm,
+  submitIubendaConsentForm,
+} from "@/lib/iubendaConsent";
+
+const DISMISSED_UNTIL_KEY = "openeire:newsletter-modal-dismissed-until";
+const SUBSCRIBED_KEY = "openeire:newsletter-modal-subscribed";
+const DISMISS_DURATION_MS = 14 * 24 * 60 * 60 * 1000;
+const WELCOME_CODE = "WELCOME10";
+const MODAL_FORM_ID = "newsletter-modal-signup-form";
+const MODAL_SUBMIT_ID = "newsletter-modal-submit";
+
+const BLOCKED_PATH_PREFIXES = [
+  "/bag",
+  "/checkout",
+  "/checkout-success",
+  "/login",
+  "/logout",
+  "/register",
+  "/profile",
+  "/real-estate",
+  "/request-password-reset",
+  "/password-reset/confirm",
+  "/verify-pending",
+  "/verify-email",
+  "/staff",
+  "/gallery-gate",
+  "/gallery/digital",
+  "/gallery/photo",
+  "/gallery/video",
+  "/403",
+  "/404",
+  "/500",
+];
+
+const shouldBlockModalForPath = (pathname: string): boolean =>
+  BLOCKED_PATH_PREFIXES.some(
+    (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`),
+  );
+
+const hasActiveDismissal = (): boolean => {
+  const dismissedUntil = Number(localStorage.getItem(DISMISSED_UNTIL_KEY));
+  return Number.isFinite(dismissedUntil) && dismissedUntil > Date.now();
+};
+
+const hasCompletedSignup = (): boolean =>
+  localStorage.getItem(SUBSCRIBED_KEY) === "1";
+
+export function NewsletterSignupModal() {
+  const pathname = usePathname();
+  const [isOpen, setIsOpen] = useState(false);
+  const [email, setEmail] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isSuccess, setIsSuccess] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const isEligibleRoute = useMemo(
+    () => !shouldBlockModalForPath(pathname),
+    [pathname],
+  );
+
+  const closeWithDismissal = () => {
+    localStorage.setItem(
+      DISMISSED_UNTIL_KEY,
+      String(Date.now() + DISMISS_DURATION_MS),
+    );
+    setIsOpen(false);
+  };
+
+  useEffect(() => {
+    if (!isOpen || isSuccess) return;
+
+    return registerIubendaConsentForm({
+      formId: MODAL_FORM_ID,
+      submitButtonId: MODAL_SUBMIT_ID,
+      subject: { email: "email" },
+      preferences: { newsletter: "newsletter_consent" },
+    });
+  }, [isOpen, isSuccess]);
+
+  useEffect(() => {
+    if (!isEligibleRoute) {
+      setIsOpen(false);
+      return;
+    }
+    if (hasActiveDismissal() || hasCompletedSignup()) return;
+
+    let didTrigger = false;
+    const openModal = () => {
+      if (didTrigger || hasActiveDismissal() || hasCompletedSignup()) return;
+      didTrigger = true;
+      setIsOpen(true);
+    };
+
+    const timeoutId = window.setTimeout(openModal, 10_000);
+    const handleScroll = () => {
+      const scrollableHeight =
+        document.documentElement.scrollHeight - window.innerHeight;
+      if (scrollableHeight <= 0) return;
+      if (window.scrollY / scrollableHeight >= 0.4) {
+        openModal();
+      }
+    };
+
+    window.addEventListener("scroll", handleScroll, { passive: true });
+    return () => {
+      window.clearTimeout(timeoutId);
+      window.removeEventListener("scroll", handleScroll);
+    };
+  }, [isEligibleRoute, pathname]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        closeWithDismissal();
+      }
+    };
+
+    const scrollY = window.scrollY;
+    const originalBodyOverflow = document.body.style.overflow;
+    const originalBodyPosition = document.body.style.position;
+    const originalBodyTop = document.body.style.top;
+    const originalBodyWidth = document.body.style.width;
+
+    document.body.style.overflow = "hidden";
+    document.body.style.position = "fixed";
+    document.body.style.top = `-${scrollY}px`;
+    document.body.style.width = "100%";
+    window.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      document.body.style.overflow = originalBodyOverflow;
+      document.body.style.position = originalBodyPosition;
+      document.body.style.top = originalBodyTop;
+      document.body.style.width = originalBodyWidth;
+      window.removeEventListener("keydown", handleKeyDown);
+      window.scrollTo({ top: scrollY, behavior: "auto" });
+    };
+  }, [isOpen]);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setIsSubmitting(true);
+    setErrorMessage(null);
+
+    try {
+      await newsletterSignup({ email, source: "newsletter_modal" });
+      submitIubendaConsentForm(MODAL_FORM_ID);
+      localStorage.setItem(SUBSCRIBED_KEY, "1");
+      localStorage.removeItem(DISMISSED_UNTIL_KEY);
+      setIsSuccess(true);
+      setEmail("");
+    } catch (error) {
+      setErrorMessage(
+        getApiErrorMessage(
+          error,
+          "We could not subscribe that email. Please try again.",
+        ),
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-[80] flex items-end justify-center p-4 sm:items-center sm:p-6"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="newsletter-signup-modal-title"
+    >
+      <button
+        type="button"
+        className="fixed inset-0 cursor-default bg-black/70 backdrop-blur-sm"
+        onClick={closeWithDismissal}
+        aria-label="Close newsletter signup"
+      />
+      <div className="relative z-10 w-full max-w-xl overflow-hidden rounded-[28px] border border-white/10 bg-[radial-gradient(circle_at_top,_rgba(245,197,24,0.08),_transparent_35%),linear-gradient(180deg,_rgba(17,24,39,0.98),_rgba(5,8,14,0.98))] shadow-[0_30px_80px_rgba(0,0,0,0.45)]">
+        <button
+          type="button"
+          onClick={closeWithDismissal}
+          aria-label="Close newsletter signup modal"
+          className="absolute right-4 top-4 rounded-full border border-white/10 bg-white/5 p-2 text-gray-300 transition-colors hover:border-white/20 hover:text-white"
+        >
+          <FaTimes aria-hidden="true" />
+        </button>
+
+        <div className="px-6 pb-6 pt-8 sm:px-10 sm:pb-10 sm:pt-10">
+          {isSuccess ? (
+            <div className="space-y-5">
+              <div className="inline-flex h-12 w-12 items-center justify-center rounded-full bg-brand-500/15 text-brand-500">
+                <FaCheckCircle className="text-xl" aria-hidden="true" />
+              </div>
+              <div className="space-y-3">
+                <h2
+                  id="newsletter-signup-modal-title"
+                  className="font-serif text-3xl font-bold text-white"
+                >
+                  You&apos;re in
+                </h2>
+                <p className="text-base leading-relaxed text-gray-300">
+                  Use code{" "}
+                  <span className="font-bold text-white">{WELCOME_CODE}</span>{" "}
+                  at checkout for 10% off your first art print.
+                </p>
+                <p className="text-sm leading-relaxed text-gray-400">
+                  If newsletter email delivery is configured, we&apos;ll also send
+                  the code to your inbox.
+                </p>
+                <p className="text-xs uppercase tracking-[0.22em] text-gray-500">
+                  Applies to art prints only. Does not apply to shipping,
+                  digital licences, commercial licences, or custom services.
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={() => setIsOpen(false)}
+                className="inline-flex rounded-full bg-brand-500 px-5 py-3 text-sm font-bold text-black transition-colors hover:bg-white"
+              >
+                Continue Browsing
+              </button>
+            </div>
+          ) : (
+            <div className="space-y-6">
+              <div className="space-y-4">
+                <p className="text-xs font-semibold uppercase tracking-[0.28em] text-accent">
+                  Collector Access
+                </p>
+                <h2
+                  id="newsletter-signup-modal-title"
+                  className="max-w-md font-serif text-3xl font-bold leading-tight text-white sm:text-4xl"
+                >
+                  Get 10% off your first art print
+                </h2>
+                <p className="max-w-lg text-sm leading-7 text-gray-300 sm:text-base">
+                  Join the OpenEire list for new aerial print releases,
+                  behind-the-scenes stories, and early access to collections.
+                </p>
+              </div>
+
+              <form
+                id={MODAL_FORM_ID}
+                onSubmit={handleSubmit}
+                className="space-y-4"
+              >
+                <input
+                  type="hidden"
+                  name="newsletter_consent"
+                  value="true"
+                  readOnly
+                />
+                <label htmlFor="newsletter-modal-email" className="block">
+                  <span className="mb-2 block text-xs font-bold uppercase tracking-[0.22em] text-gray-500">
+                    Email Address
+                  </span>
+                  <input
+                    id="newsletter-modal-email"
+                    name="email"
+                    type="email"
+                    value={email}
+                    onChange={(event) => setEmail(event.target.value)}
+                    placeholder="you@example.com"
+                    required
+                    autoComplete="email"
+                    className="w-full rounded-2xl border border-white/10 bg-black/30 px-4 py-3 text-white placeholder:text-gray-500 focus:border-brand-500 focus:outline-none focus:ring-1 focus:ring-brand-500"
+                  />
+                </label>
+
+                {errorMessage ? (
+                  <div className="rounded-2xl border border-red-500/20 bg-red-500/10 px-4 py-3 text-sm text-red-300">
+                    {errorMessage}
+                  </div>
+                ) : null}
+
+                <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+                  <button
+                    id={MODAL_SUBMIT_ID}
+                    type="submit"
+                    disabled={isSubmitting}
+                    className="inline-flex w-full items-center justify-center rounded-full bg-brand-500 px-5 py-3 text-sm font-bold text-black transition-colors hover:bg-white disabled:cursor-not-allowed disabled:opacity-60 sm:w-auto"
+                  >
+                    {isSubmitting ? "Joining..." : "Get my 10% code"}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={closeWithDismissal}
+                    className="inline-flex w-full items-center justify-center rounded-full border border-white/10 px-5 py-3 text-sm font-medium text-gray-300 transition-colors hover:border-white/20 hover:text-white sm:w-auto"
+                  >
+                    Maybe later
+                  </button>
+                </div>
+              </form>
+
+              <p className="text-xs leading-6 text-gray-500">
+                Applies to art prints only. Does not apply to shipping, digital
+                licences, commercial licences, or custom services.
+              </p>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/openeire-next/components/real-estate/RealEstateEnquiryForm.tsx
+++ b/openeire-next/components/real-estate/RealEstateEnquiryForm.tsx
@@ -1,0 +1,659 @@
+"use client";
+
+import {
+  useEffect,
+  useState,
+  type ChangeEvent,
+  type FormEvent,
+  type ReactNode,
+} from "react";
+import { FaCheckCircle, FaPaperPlane } from "react-icons/fa";
+import {
+  getApiErrorMessage,
+  submitRealEstateEnquiry,
+} from "@/lib/api/publicForms";
+import {
+  registerIubendaConsentForm,
+  submitIubendaConsentForm,
+} from "@/lib/iubendaConsent";
+import { useToast } from "@/components/ui/ToastProvider";
+import type {
+  AddOnKey,
+  ClientType,
+  HowHeard,
+  PackageType,
+  RealEstateEnquiryPayload,
+} from "@/types/publicForms";
+
+const FORM_ID = "real-estate-enquiry-form";
+const SUBMIT_ID = "real-estate-enquiry-submit";
+
+type RealEstateFormData = {
+  name: string;
+  email: string;
+  phone: string;
+  company_name: string;
+  client_type: "" | ClientType;
+  property_address: string;
+  eircode: string;
+  county: string;
+  property_type: string;
+  preferred_package: PackageType;
+  add_ons: AddOnKey[];
+  preferred_date: string;
+  how_heard: "" | HowHeard;
+  message: string;
+  consent_to_contact: boolean;
+};
+
+type FormErrors = Partial<Record<keyof RealEstateFormData | "submit", string>>;
+
+const initialFormData: RealEstateFormData = {
+  name: "",
+  email: "",
+  phone: "",
+  company_name: "",
+  client_type: "",
+  property_address: "",
+  eircode: "",
+  county: "",
+  property_type: "",
+  preferred_package: "not_sure",
+  add_ons: [],
+  preferred_date: "",
+  how_heard: "",
+  message: "",
+  consent_to_contact: false,
+};
+
+const clientTypeOptions = [
+  "estate_agent",
+  "developer",
+  "private_seller",
+  "landlord",
+  "other",
+] as const satisfies readonly ClientType[];
+
+const packageOptions = [
+  "essential",
+  "starter",
+  "pro",
+  "premium",
+  "custom",
+  "not_sure",
+] as const satisfies readonly PackageType[];
+
+const howHeardOptions = [
+  "google",
+  "instagram",
+  "facebook",
+  "linkedin",
+  "referral",
+  "estate_agent_colleague",
+  "openeire_website",
+  "other",
+  "not_sure",
+] as const satisfies readonly HowHeard[];
+
+const addOns: Array<{ key: AddOnKey; label: string; price: string }> = [
+  {
+    key: "additional_stills",
+    label: "Additional edited stills",
+    price: "EUR10 + VAT per image",
+  },
+  { key: "floor_plan", label: "Floor plan, 2D measured", price: "EUR75 + VAT" },
+  {
+    key: "rush_delivery",
+    label: "Rush same-day delivery, stills only",
+    price: "EUR75 + VAT",
+  },
+  {
+    key: "extended_drone_video",
+    label: "Extended drone video, up to 3 minutes, fully edited",
+    price: "EUR150 + VAT",
+  },
+  {
+    key: "additional_social_cuts",
+    label: "Additional social media cuts, extra formats or edits",
+    price: "EUR50 + VAT",
+  },
+  {
+    key: "travel_supplement",
+    label: "Travel supplement beyond 40 km from base",
+    price: "EUR0.50 + VAT per km",
+  },
+];
+
+const requiredFields: Array<keyof RealEstateFormData> = [
+  "name",
+  "email",
+  "phone",
+  "client_type",
+  "property_address",
+  "county",
+  "property_type",
+  "preferred_package",
+];
+
+const fieldLabels: Partial<Record<keyof RealEstateFormData, string>> = {
+  name: "Name",
+  email: "Email",
+  phone: "Phone",
+  client_type: "Client type",
+  property_address: "Property address",
+  county: "County",
+  property_type: "Property type",
+  preferred_package: "Preferred package",
+  consent_to_contact: "Consent to contact",
+};
+
+const inputClass =
+  "w-full rounded-xl border border-white/15 bg-black/60 px-4 py-3 text-white placeholder-gray-600 outline-none transition-all focus:border-[#16a34a] focus:ring-1 focus:ring-[#16a34a]";
+const labelClass =
+  "mb-2 block text-xs font-bold uppercase tracking-[0.22em] text-gray-500";
+
+const trimOrUndefined = (value: string): string | undefined => {
+  const trimmed = value.trim();
+  return trimmed ? trimmed : undefined;
+};
+
+const isOneOf = <T extends string>(
+  value: string,
+  options: readonly T[],
+): value is T => options.includes(value as T);
+
+function Field({
+  inputId,
+  label,
+  error,
+  children,
+}: {
+  inputId: string;
+  label: string;
+  error?: string;
+  children: ReactNode;
+}) {
+  return (
+    <div>
+      <label htmlFor={inputId} className={labelClass}>
+        {label}
+      </label>
+      {children}
+      {error ? <p className="mt-2 text-sm text-red-300">{error}</p> : null}
+    </div>
+  );
+}
+
+export function RealEstateEnquiryForm() {
+  const [formData, setFormData] = useState<RealEstateFormData>(initialFormData);
+  const [errors, setErrors] = useState<FormErrors>({});
+  const [status, setStatus] = useState<"idle" | "submitting" | "success">(
+    "idle",
+  );
+  const { showToast } = useToast();
+
+  useEffect(() => {
+    return registerIubendaConsentForm({
+      formId: FORM_ID,
+      submitButtonId: SUBMIT_ID,
+      subject: {
+        full_name: "name",
+        email: "email",
+      },
+      preferences: {
+        real_estate_enquiry: "consent_to_contact",
+      },
+    });
+  }, []);
+
+  const handleFieldChange = (
+    event: ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>,
+  ) => {
+    const { name, value } = event.target;
+    setFormData((current) => ({ ...current, [name]: value }));
+    setErrors((current) => ({ ...current, [name]: undefined, submit: undefined }));
+  };
+
+  const handleConsentChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setFormData((current) => ({
+      ...current,
+      consent_to_contact: event.target.checked,
+    }));
+    setErrors((current) => ({
+      ...current,
+      consent_to_contact: undefined,
+      submit: undefined,
+    }));
+  };
+
+  const toggleAddOn = (key: AddOnKey) => {
+    setFormData((current) => {
+      const exists = current.add_ons.includes(key);
+      return {
+        ...current,
+        add_ons: exists
+          ? current.add_ons.filter((item) => item !== key)
+          : [...current.add_ons, key],
+      };
+    });
+  };
+
+  const validateForm = (): FormErrors => {
+    const nextErrors: FormErrors = {};
+
+    for (const field of requiredFields) {
+      const value = formData[field];
+      if (typeof value === "string" && !value.trim()) {
+        nextErrors[field] = `${fieldLabels[field] ?? "This field"} is required.`;
+      }
+    }
+
+    if (formData.email && !/^\S+@\S+\.\S+$/.test(formData.email)) {
+      nextErrors.email = "Please enter a valid email address.";
+    }
+
+    if (!formData.consent_to_contact) {
+      nextErrors.consent_to_contact =
+        "Please confirm we can contact you about this enquiry.";
+    }
+
+    return nextErrors;
+  };
+
+  const buildPayload = (): RealEstateEnquiryPayload => {
+    const clientType = formData.client_type.trim();
+    const preferredPackage = formData.preferred_package.trim();
+    const howHeard = formData.how_heard.trim();
+
+    if (!isOneOf(clientType, clientTypeOptions)) {
+      throw new Error("Please choose a valid client type.");
+    }
+    if (!isOneOf(preferredPackage, packageOptions)) {
+      throw new Error("Please choose a valid package.");
+    }
+    if (howHeard && !isOneOf(howHeard, howHeardOptions)) {
+      throw new Error("Please choose a valid referral source.");
+    }
+
+    const companyName = trimOrUndefined(formData.company_name);
+    const eircode = trimOrUndefined(formData.eircode);
+    const preferredDate = trimOrUndefined(formData.preferred_date);
+    const message = trimOrUndefined(formData.message);
+    const howHeardValue: HowHeard | undefined = howHeard
+      ? (howHeard as HowHeard)
+      : undefined;
+
+    return {
+      name: formData.name.trim(),
+      email: formData.email.trim(),
+      phone: formData.phone.trim(),
+      client_type: clientType,
+      property_address: formData.property_address.trim(),
+      county: formData.county.trim(),
+      property_type: formData.property_type.trim(),
+      preferred_package: preferredPackage,
+      consent_to_contact: formData.consent_to_contact,
+      ...(companyName ? { company_name: companyName } : {}),
+      ...(eircode ? { eircode } : {}),
+      ...(formData.add_ons.length ? { add_ons: formData.add_ons } : {}),
+      ...(preferredDate ? { preferred_date: preferredDate } : {}),
+      ...(howHeardValue ? { how_heard: howHeardValue } : {}),
+      ...(message ? { message } : {}),
+    };
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const nextErrors = validateForm();
+    if (Object.keys(nextErrors).length > 0) {
+      setErrors(nextErrors);
+      return;
+    }
+
+    setStatus("submitting");
+    setErrors({});
+
+    try {
+      const payload = buildPayload();
+      await submitRealEstateEnquiry(payload);
+      submitIubendaConsentForm(FORM_ID);
+      setStatus("success");
+      setFormData(initialFormData);
+      showToast("Property enquiry sent successfully.", "success");
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : getApiErrorMessage(
+              error,
+              "We could not send the enquiry. Please try again or email studio@openeire.ie.",
+            );
+      setErrors({ submit: message });
+      setStatus("idle");
+      showToast(message, "error");
+    }
+  };
+
+  return (
+    <section id="enquiry" className="container mx-auto max-w-5xl px-4 py-20 lg:px-8">
+      <div className="rounded-[2rem] border border-white/10 bg-gray-900/80 p-6 shadow-2xl md:p-10">
+        {status === "success" ? (
+          <div className="flex min-h-[360px] flex-col items-center justify-center text-center">
+            <div className="mb-6 flex h-20 w-20 items-center justify-center rounded-full bg-[#16a34a]/15 text-[#16a34a]">
+              <FaCheckCircle className="text-4xl" aria-hidden="true" />
+            </div>
+            <h2 className="mb-4 font-serif text-3xl font-bold text-white">
+              Enquiry Sent
+            </h2>
+            <p className="max-w-xl text-gray-300">
+              Thanks for the details. OpenEire Studios will review the property
+              brief and come back to you with next steps.
+            </p>
+            <button
+              type="button"
+              onClick={() => setStatus("idle")}
+              className="mt-8 rounded-xl border border-white/20 px-6 py-3 font-bold text-white transition hover:bg-white/10"
+            >
+              Send another enquiry
+            </button>
+          </div>
+        ) : (
+          <>
+            <div className="mb-10">
+              <p className="mb-3 text-xs font-bold uppercase tracking-[0.26em] text-[#16a34a]">
+                Property shoot enquiry
+              </p>
+              <h2 className="font-serif text-3xl font-bold text-white md:text-4xl">
+                Tell us about the property
+              </h2>
+              <p className="mt-4 max-w-2xl text-gray-400">
+                Share the address, property type, preferred package, and any
+                access notes so we can scope the shoot safely and clearly.
+              </p>
+            </div>
+
+            <form id={FORM_ID} onSubmit={handleSubmit} className="space-y-6">
+              <div className="grid gap-5 md:grid-cols-2">
+                <Field inputId="real-estate-name" label="Name" error={errors.name}>
+                  <input
+                    id="real-estate-name"
+                    name="name"
+                    value={formData.name}
+                    onChange={handleFieldChange}
+                    className={inputClass}
+                    required
+                  />
+                </Field>
+                <Field
+                  inputId="real-estate-email"
+                  label="Email"
+                  error={errors.email}
+                >
+                  <input
+                    id="real-estate-email"
+                    name="email"
+                    type="email"
+                    value={formData.email}
+                    onChange={handleFieldChange}
+                    className={inputClass}
+                    required
+                  />
+                </Field>
+              </div>
+
+              <div className="grid gap-5 md:grid-cols-2">
+                <Field
+                  inputId="real-estate-phone"
+                  label="Phone"
+                  error={errors.phone}
+                >
+                  <input
+                    id="real-estate-phone"
+                    name="phone"
+                    type="tel"
+                    value={formData.phone}
+                    onChange={handleFieldChange}
+                    className={inputClass}
+                    required
+                  />
+                </Field>
+                <Field inputId="real-estate-company" label="Company / agency">
+                  <input
+                    id="real-estate-company"
+                    name="company_name"
+                    value={formData.company_name}
+                    onChange={handleFieldChange}
+                    className={inputClass}
+                  />
+                </Field>
+              </div>
+
+              <div className="grid gap-5 md:grid-cols-2">
+                <Field
+                  inputId="real-estate-client-type"
+                  label="Client type"
+                  error={errors.client_type}
+                >
+                  <select
+                    id="real-estate-client-type"
+                    name="client_type"
+                    value={formData.client_type}
+                    onChange={handleFieldChange}
+                    className={inputClass}
+                    required
+                  >
+                    <option value="">Select...</option>
+                    <option value="estate_agent">Estate agent</option>
+                    <option value="developer">Developer</option>
+                    <option value="private_seller">Private seller</option>
+                    <option value="landlord">Landlord</option>
+                    <option value="other">Other</option>
+                  </select>
+                </Field>
+                <Field
+                  inputId="real-estate-package"
+                  label="Preferred package"
+                  error={errors.preferred_package}
+                >
+                  <select
+                    id="real-estate-package"
+                    name="preferred_package"
+                    value={formData.preferred_package}
+                    onChange={handleFieldChange}
+                    className={inputClass}
+                    required
+                  >
+                    <option value="not_sure">Not sure yet</option>
+                    <option value="essential">Essential</option>
+                    <option value="starter">Starter</option>
+                    <option value="pro">Pro</option>
+                    <option value="premium">Premium</option>
+                    <option value="custom">Custom</option>
+                  </select>
+                </Field>
+              </div>
+
+              <Field
+                inputId="real-estate-address"
+                label="Property address"
+                error={errors.property_address}
+              >
+                <input
+                  id="real-estate-address"
+                  name="property_address"
+                  value={formData.property_address}
+                  onChange={handleFieldChange}
+                  className={inputClass}
+                  required
+                />
+              </Field>
+
+              <div className="grid gap-5 md:grid-cols-3">
+                <Field inputId="real-estate-eircode" label="Eircode">
+                  <input
+                    id="real-estate-eircode"
+                    name="eircode"
+                    value={formData.eircode}
+                    onChange={handleFieldChange}
+                    className={inputClass}
+                  />
+                </Field>
+                <Field
+                  inputId="real-estate-county"
+                  label="County"
+                  error={errors.county}
+                >
+                  <input
+                    id="real-estate-county"
+                    name="county"
+                    value={formData.county}
+                    onChange={handleFieldChange}
+                    className={inputClass}
+                    required
+                  />
+                </Field>
+                <Field
+                  inputId="real-estate-property-type"
+                  label="Property type"
+                  error={errors.property_type}
+                >
+                  <input
+                    id="real-estate-property-type"
+                    name="property_type"
+                    value={formData.property_type}
+                    onChange={handleFieldChange}
+                    className={inputClass}
+                    required
+                  />
+                </Field>
+              </div>
+
+              <div>
+                <p className={labelClass}>Optional add-ons</p>
+                <div className="grid gap-3 md:grid-cols-2">
+                  {addOns.map((item) => (
+                    <label
+                      key={item.key}
+                      className="flex items-start gap-3 rounded-2xl border border-white/10 bg-black/40 p-4 text-sm text-gray-300"
+                    >
+                      <input
+                        type="checkbox"
+                        checked={formData.add_ons.includes(item.key)}
+                        onChange={() => toggleAddOn(item.key)}
+                        className="mt-1 h-4 w-4 rounded border-white/30 bg-black text-[#16a34a] focus:ring-[#16a34a]"
+                      />
+                      <span>
+                        <span className="block font-bold text-white">
+                          {item.label}
+                        </span>
+                        <span className="mt-1 block text-gray-400">
+                          {item.price}
+                        </span>
+                      </span>
+                    </label>
+                  ))}
+                </div>
+              </div>
+
+              <div className="grid gap-5 md:grid-cols-2">
+                <Field inputId="real-estate-date" label="Preferred date">
+                  <input
+                    id="real-estate-date"
+                    name="preferred_date"
+                    type="date"
+                    value={formData.preferred_date}
+                    onChange={handleFieldChange}
+                    className={inputClass}
+                  />
+                </Field>
+                <Field
+                  inputId="real-estate-how-heard"
+                  label="How did you hear about us?"
+                >
+                  <select
+                    id="real-estate-how-heard"
+                    name="how_heard"
+                    value={formData.how_heard}
+                    onChange={handleFieldChange}
+                    className={inputClass}
+                  >
+                    <option value="">Select...</option>
+                    <option value="google">Google</option>
+                    <option value="instagram">Instagram</option>
+                    <option value="facebook">Facebook</option>
+                    <option value="linkedin">LinkedIn</option>
+                    <option value="referral">Referral</option>
+                    <option value="estate_agent_colleague">
+                      Estate agent colleague
+                    </option>
+                    <option value="openeire_website">OpenEire website</option>
+                    <option value="other">Other</option>
+                    <option value="not_sure">Not sure</option>
+                  </select>
+                </Field>
+              </div>
+
+              <Field
+                inputId="real-estate-message"
+                label="Message / access notes / special requirements"
+              >
+                <textarea
+                  id="real-estate-message"
+                  name="message"
+                  rows={5}
+                  value={formData.message}
+                  onChange={handleFieldChange}
+                  className={`${inputClass} resize-none`}
+                />
+              </Field>
+
+              <div>
+                <label className="flex items-start gap-3 rounded-2xl border border-white/10 bg-gray-950 p-4 text-sm text-gray-300">
+                  <input
+                    type="checkbox"
+                    checked={formData.consent_to_contact}
+                    onChange={handleConsentChange}
+                    className="mt-1 h-4 w-4 rounded border-white/30 bg-black text-[#16a34a] focus:ring-[#16a34a]"
+                    required
+                  />
+                  <span>
+                    I consent to OpenEire Studios contacting me about this
+                    property media enquiry.
+                  </span>
+                </label>
+                {errors.consent_to_contact ? (
+                  <p className="mt-2 text-sm text-red-300">
+                    {errors.consent_to_contact}
+                  </p>
+                ) : null}
+              </div>
+
+              {errors.submit ? (
+                <div className="rounded-2xl border border-red-500/20 bg-red-500/10 px-4 py-3 text-sm text-red-300">
+                  {errors.submit}
+                </div>
+              ) : null}
+
+              <button
+                id={SUBMIT_ID}
+                name="submit-button"
+                type="submit"
+                disabled={status === "submitting"}
+                className="flex w-full items-center justify-center gap-3 rounded-2xl bg-[#16a34a] px-6 py-4 font-bold text-white shadow-lg shadow-[#16a34a]/20 transition hover:bg-[#15803d] disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {status === "submitting" ? (
+                  <span className="h-5 w-5 animate-spin rounded-full border-2 border-brand-900 border-t-transparent" />
+                ) : (
+                  <>
+                    Send property enquiry
+                    <FaPaperPlane aria-hidden="true" />
+                  </>
+                )}
+              </button>
+            </form>
+          </>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/openeire-next/components/share/ShareControls.tsx
+++ b/openeire-next/components/share/ShareControls.tsx
@@ -1,0 +1,81 @@
+"use client";
+
+import { useState } from "react";
+import { FaFacebookF, FaLinkedinIn, FaLink, FaShareAlt } from "react-icons/fa";
+
+interface ShareControlsProps {
+  title: string;
+  url: string;
+}
+
+export function ShareControls({ title, url }: ShareControlsProps) {
+  const [copyLabel, setCopyLabel] = useState("Copy link");
+  const encodedUrl = encodeURIComponent(url);
+  const encodedTitle = encodeURIComponent(title);
+
+  const handleNativeShare = async () => {
+    if (!navigator.share) {
+      await handleCopy();
+      return;
+    }
+
+    try {
+      await navigator.share({ title, url });
+    } catch {
+      // Users can cancel native share sheets; no UI error needed.
+    }
+  };
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopyLabel("Copied");
+      window.setTimeout(() => setCopyLabel("Copy link"), 1800);
+    } catch {
+      setCopyLabel("Copy failed");
+      window.setTimeout(() => setCopyLabel("Copy link"), 1800);
+    }
+  };
+
+  return (
+    <div className="mt-6 flex flex-wrap items-center gap-3 text-xs uppercase tracking-[0.18em] text-gray-500">
+      <span>Share</span>
+      <button
+        type="button"
+        onClick={handleNativeShare}
+        className="inline-flex items-center gap-2 rounded-full border border-white/10 px-3 py-2 text-gray-300 transition-colors hover:border-brand-500/40 hover:text-brand-500"
+      >
+        <FaShareAlt aria-hidden="true" />
+        Share
+      </button>
+      <button
+        type="button"
+        onClick={handleCopy}
+        className="inline-flex items-center gap-2 rounded-full border border-white/10 px-3 py-2 text-gray-300 transition-colors hover:border-brand-500/40 hover:text-brand-500"
+      >
+        <FaLink aria-hidden="true" />
+        {copyLabel}
+      </button>
+      <a
+        href={`https://www.facebook.com/sharer/sharer.php?u=${encodedUrl}`}
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label="Share on Facebook"
+        className="inline-flex items-center gap-2 rounded-full border border-white/10 px-3 py-2 text-gray-300 transition-colors hover:border-brand-500/40 hover:text-brand-500"
+      >
+        <FaFacebookF aria-hidden="true" />
+        Facebook
+      </a>
+      <a
+        href={`https://www.linkedin.com/sharing/share-offsite/?url=${encodedUrl}&title=${encodedTitle}`}
+        target="_blank"
+        rel="noopener noreferrer"
+        aria-label="Share on LinkedIn"
+        className="inline-flex items-center gap-2 rounded-full border border-white/10 px-3 py-2 text-gray-300 transition-colors hover:border-brand-500/40 hover:text-brand-500"
+      >
+        <FaLinkedinIn aria-hidden="true" />
+        LinkedIn
+      </a>
+    </div>
+  );
+}

--- a/openeire-next/components/ui/ToastProvider.tsx
+++ b/openeire-next/components/ui/ToastProvider.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+  type ReactNode,
+} from "react";
+
+type ToastType = "success" | "error" | "info";
+
+interface Toast {
+  id: number;
+  type: ToastType;
+  message: string;
+}
+
+interface ToastContextValue {
+  showToast: (message: string, type?: ToastType) => void;
+}
+
+const ToastContext = createContext<ToastContextValue | null>(null);
+
+export function ToastProvider({ children }: { children: ReactNode }) {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+
+  const showToast = useCallback((message: string, type: ToastType = "info") => {
+    const id = Date.now() + Math.random();
+    setToasts((current) => [...current, { id, type, message }]);
+    window.setTimeout(() => {
+      setToasts((current) => current.filter((toast) => toast.id !== id));
+    }, 5000);
+  }, []);
+
+  const value = useMemo(() => ({ showToast }), [showToast]);
+
+  return (
+    <ToastContext.Provider value={value}>
+      {children}
+      <div
+        aria-live="polite"
+        aria-atomic="true"
+        className="fixed bottom-28 left-4 right-4 z-[70] flex flex-col items-stretch gap-3 sm:left-auto sm:right-6 sm:w-96"
+      >
+        {toasts.map((toast) => (
+          <div
+            key={toast.id}
+            className={[
+              "rounded-2xl border px-4 py-3 text-sm shadow-2xl backdrop-blur",
+              toast.type === "success"
+                ? "border-brand-500/30 bg-brand-900/95 text-brand-50"
+                : toast.type === "error"
+                  ? "border-red-500/30 bg-red-950/95 text-red-100"
+                  : "border-white/15 bg-gray-950/95 text-white",
+            ].join(" ")}
+          >
+            {toast.message}
+          </div>
+        ))}
+      </div>
+    </ToastContext.Provider>
+  );
+}
+
+export const useToast = () => {
+  const context = useContext(ToastContext);
+  if (!context) {
+    throw new Error("useToast must be used within ToastProvider.");
+  }
+  return context;
+};

--- a/openeire-next/lib/api/publicForms.ts
+++ b/openeire-next/lib/api/publicForms.ts
@@ -1,0 +1,64 @@
+import { api, isApiError } from "@/lib/api/client";
+import type {
+  ContactData,
+  NewsletterSignupPayload,
+  RealEstateEnquiryPayload,
+} from "@/types/publicForms";
+
+export const getApiErrorMessage = (
+  error: unknown,
+  fallback = "Something went wrong. Please try again.",
+): string => {
+  const payload = isApiError(error) ? error.response?.data : error;
+
+  if (typeof payload === "string" && payload.trim()) {
+    return payload.trim();
+  }
+
+  if (!payload || typeof payload !== "object") {
+    return fallback;
+  }
+
+  const record = payload as Record<string, unknown>;
+  for (const key of ["detail", "message", "error"]) {
+    const value = record[key];
+    if (typeof value === "string" && value.trim()) {
+      return value.trim();
+    }
+  }
+
+  const fieldMessage = Object.entries(record)
+    .map(([field, value]) => {
+      if (Array.isArray(value)) {
+        const message = value.filter(Boolean).join(" ");
+        return message ? `${field}: ${message}` : null;
+      }
+      if (typeof value === "string" && value.trim()) {
+        return `${field}: ${value.trim()}`;
+      }
+      return null;
+    })
+    .find(Boolean);
+
+  return fieldMessage ?? fallback;
+};
+
+export const sendContactMessage = async (payload: ContactData) => {
+  const response = await api.post("home/contact/", payload);
+  return response.data;
+};
+
+export const newsletterSignup = async (payload: NewsletterSignupPayload) => {
+  const response = await api.post<{ email: string }>(
+    "home/newsletter-signup/",
+    payload,
+  );
+  return response.data;
+};
+
+export const submitRealEstateEnquiry = async (
+  payload: RealEstateEnquiryPayload,
+) => {
+  const response = await api.post("real-estate/enquiries/", payload);
+  return response.data;
+};

--- a/openeire-next/lib/iubendaConsent.ts
+++ b/openeire-next/lib/iubendaConsent.ts
@@ -1,0 +1,160 @@
+"use client";
+
+type SubjectFieldMap = Partial<{
+  id: string;
+  email: string;
+  first_name: string;
+  last_name: string;
+  full_name: string;
+}>;
+
+type PreferenceFieldMap = Record<string, string>;
+
+export interface IubendaConsentFormConfig {
+  formId: string;
+  submitButtonId: string;
+  subject: SubjectFieldMap;
+  preferences?: PreferenceFieldMap;
+  legalNoticeIdentifiers?: string[];
+}
+
+interface RegisteredFormEntry {
+  formElement: HTMLElement;
+  config: IubendaConsentFormConfig;
+}
+
+declare global {
+  interface Window {
+    _iub?: {
+      cons_instructions?: Array<
+        [string, Record<string, unknown>, Record<string, unknown>?]
+      >;
+    };
+  }
+}
+
+const CONSENT_SCRIPT_SRC = "https://cdn.iubenda.com/cons/iubenda_cons.js";
+const DEFAULT_LEGAL_NOTICE_IDENTIFIERS = ["privacy_policy", "cookie_policy"];
+const registeredForms = new Map<string, RegisteredFormEntry>();
+
+const getSafeEnvValue = (value: string | undefined): string | null => {
+  const trimmedValue = value?.trim();
+  if (!trimmedValue || trimmedValue === "undefined" || trimmedValue === "null") {
+    return null;
+  }
+  return trimmedValue;
+};
+
+const publicApiKey = getSafeEnvValue(
+  process.env.NEXT_PUBLIC_IUBENDA_CONSENT_PUBLIC_API_KEY,
+);
+
+const isConsentDatabaseEnabled = Boolean(publicApiKey);
+
+const ensureConsentInstructionQueue = () => {
+  window._iub = window._iub || {};
+  window._iub.cons_instructions = window._iub.cons_instructions || [];
+  return window._iub.cons_instructions;
+};
+
+const buildFieldMap = (
+  subject: SubjectFieldMap,
+  preferences?: PreferenceFieldMap,
+) => {
+  const map: { subject: SubjectFieldMap; preferences?: PreferenceFieldMap } = {
+    subject,
+  };
+  if (preferences && Object.keys(preferences).length > 0) {
+    map.preferences = preferences;
+  }
+  return map;
+};
+
+const getLegalNotices = (legalNoticeIdentifiers: string[]) =>
+  legalNoticeIdentifiers.map((identifier) => ({ identifier }));
+
+export const bootstrapIubendaConsentDatabase = () => {
+  if (!isConsentDatabaseEnabled || !publicApiKey || typeof window === "undefined") {
+    return;
+  }
+
+  const queue = ensureConsentInstructionQueue();
+  const hasInitInstruction = queue.some(([instruction]) => instruction === "init");
+
+  if (!hasInitInstruction) {
+    queue.push([
+      "init",
+      {
+        api_key: publicApiKey,
+        sendFromLocalStorageAtLoad: false,
+      },
+    ]);
+  }
+
+  if (document.querySelector(`script[src="${CONSENT_SCRIPT_SRC}"]`)) {
+    return;
+  }
+
+  const script = document.createElement("script");
+  script.src = CONSENT_SCRIPT_SRC;
+  script.async = true;
+  script.type = "text/javascript";
+  document.head.appendChild(script);
+};
+
+export const registerIubendaConsentForm = (
+  config: IubendaConsentFormConfig,
+) => {
+  if (!isConsentDatabaseEnabled || typeof window === "undefined") {
+    return () => undefined;
+  }
+
+  bootstrapIubendaConsentDatabase();
+
+  const formElement = document.getElementById(config.formId);
+  const submitElement = document.getElementById(config.submitButtonId);
+
+  if (!formElement || !submitElement) {
+    return () => undefined;
+  }
+
+  registeredForms.set(config.formId, { formElement, config });
+
+  return () => {
+    const latestEntry = registeredForms.get(config.formId);
+    if (latestEntry?.formElement === formElement) {
+      registeredForms.delete(config.formId);
+    }
+  };
+};
+
+export const submitIubendaConsentForm = (formId: string) => {
+  if (!isConsentDatabaseEnabled || typeof window === "undefined") {
+    return;
+  }
+
+  bootstrapIubendaConsentDatabase();
+
+  const entry = registeredForms.get(formId);
+  if (!entry) return;
+
+  const currentFormElement = document.getElementById(formId) ?? entry.formElement;
+  const queue = ensureConsentInstructionQueue();
+
+  queue.push([
+    "submit",
+    {
+      form: {
+        selector: currentFormElement,
+        map: buildFieldMap(entry.config.subject, entry.config.preferences),
+      },
+      consent: {
+        legal_notices: getLegalNotices(
+          entry.config.legalNoticeIdentifiers ??
+            DEFAULT_LEGAL_NOTICE_IDENTIFIERS,
+        ),
+      },
+      writeOnLocalStorage: false,
+    },
+  ]);
+};

--- a/openeire-next/types/publicForms.ts
+++ b/openeire-next/types/publicForms.ts
@@ -1,0 +1,64 @@
+export interface ContactData {
+  name: string;
+  email: string;
+  subject: string;
+  message: string;
+}
+
+export type NewsletterSignupPayload = {
+  email: string;
+  first_name?: string;
+  source?: string;
+};
+
+export type ClientType =
+  | "estate_agent"
+  | "developer"
+  | "private_seller"
+  | "landlord"
+  | "other";
+
+export type PackageType =
+  | "essential"
+  | "starter"
+  | "pro"
+  | "premium"
+  | "custom"
+  | "not_sure";
+
+export type HowHeard =
+  | "google"
+  | "instagram"
+  | "facebook"
+  | "linkedin"
+  | "referral"
+  | "estate_agent_colleague"
+  | "openeire_website"
+  | "other"
+  | "not_sure";
+
+export type AddOnKey =
+  | "additional_stills"
+  | "floor_plan"
+  | "rush_delivery"
+  | "extended_drone_video"
+  | "additional_social_cuts"
+  | "travel_supplement";
+
+export interface RealEstateEnquiryPayload {
+  name: string;
+  email: string;
+  phone: string;
+  company_name?: string;
+  client_type: ClientType;
+  property_address: string;
+  eircode?: string;
+  county: string;
+  property_type: string;
+  preferred_package: PackageType;
+  add_ons?: AddOnKey[];
+  preferred_date?: string;
+  how_heard?: HowHeard;
+  message?: string;
+  consent_to_contact: boolean;
+}


### PR DESCRIPTION
## Summary

This PR adds iubenda cookie consent integration, replaces the physical product image with a reusable media preview component, adds social sharing controls, introduces a real estate enquiry form, and extracts the newsletter signup into a dedicated component.

## Why

Implements cookie consent compliance (iubenda), improves media handling on product pages, adds sharing functionality, and provides a dedicated enquiry flow for real estate shoots. Also extracts reusable components for maintainability.

## Screenshots / Demo

- [x] Not needed
- [ ] Added (attach screenshots / short Loom link)

## Changes

- Backend:
  -
- Frontend:
  - Add iubenda consent script in root layout
  - Replace direct `<img>` with `ProductMediaPreview` component on physical product pages
  - Add `ShareControls` component to physical product pages
  - Add `RealEstateEnquiryForm` component with anchor-based CTA
  - Extract `FooterNewsletterSignup` component from Footer
- Infra/Config:
  - Add `/contact` route to sitemap
  - Add CSS fix for iubenda preferences button positioning

## Testing

- [x] Django tests pass locally
- [x] React build passes locally
- [x] Manual smoke test done

### Manual smoke test checklist (quick)

- [x] No console errors
- [x] Forms submit correctly (success + validation errors)
- [x] API errors handled (loading/error states)
- [x] Mobile layout checked
- [x] Auth/permissions verified (if relevant)

## Risk & Rollback

Risk level: Low

Rollback plan:

- [x] Revert PR
- [ ] Feature flag off
- [ ] Hotfix path described:

## Notes for Reviewer (Codex/Copilot)

Focus review on:

- [x] Security (auth, permissions, file uploads, CSRF/CORS)
- [x] Performance (N+1 queries, heavy renders, unnecessary requests)
- [x] Maintainability (naming, structure, duplicated logic)