### PR TITLE
Migrate gallery access and digital listing

### DIFF
--- a/openeire-next/app/footage/page.tsx
+++ b/openeire-next/app/footage/page.tsx
@@ -184,7 +184,10 @@ export default function FootagePage() {
         description="Browse premium aerial footage captured in Ireland for campaigns, productions, editorial projects, and creative use. This page is built for buyers who need to discover the right drone footage first, then move into licensing when the asset is right."
         image={PUBLIC_IMAGES.irelandGallery}
         actions={[
-          { href: "/gallery/digital", label: "Browse Available Footage" },
+          {
+            href: "/gallery-gate?next=/gallery/digital",
+            label: "Browse Available Footage",
+          },
           {
             href: "/licensing",
             label: "Review Licensing Options",
@@ -305,7 +308,10 @@ export default function FootagePage() {
         title="Find footage before you license"
         description="Start with the available footage library, then move into commercial or editorial licensing once the right asset is clear."
         actions={[
-          { href: "/gallery/digital", label: "Browse Footage" },
+          {
+            href: "/gallery-gate?next=/gallery/digital",
+            label: "Browse Footage",
+          },
           {
             href: "/contact",
             label: "Ask About a Footage Brief",

--- a/openeire-next/app/gallery-gate/page.tsx
+++ b/openeire-next/app/gallery-gate/page.tsx
@@ -1,0 +1,30 @@
+import type { Metadata } from "next";
+import { Suspense } from "react";
+import { GalleryGateClient } from "@/components/gallery/GalleryGateClient";
+
+export const metadata: Metadata = {
+  title: "Private Collection Access | OpenÉire Studios",
+  description:
+    "Request access, sign in with the same email, and unlock the private OpenÉire Studios digital collection.",
+  alternates: {
+    canonical: "/gallery-gate",
+  },
+  robots: {
+    index: false,
+    follow: false,
+  },
+};
+
+export default function GalleryGatePage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="page-top-offset flex min-h-screen items-center justify-center bg-brand-900 px-4 pb-16 text-white">
+          <div className="h-12 w-12 animate-spin rounded-full border-2 border-accent border-t-transparent" />
+        </div>
+      }
+    >
+      <GalleryGateClient />
+    </Suspense>
+  );
+}

--- a/openeire-next/app/gallery/digital/page.tsx
+++ b/openeire-next/app/gallery/digital/page.tsx
@@ -1,4 +1,5 @@
-import { GalleryAccessRequired } from "@/components/gallery/GalleryAccessRequired";
+import { Suspense } from "react";
+import { DigitalGalleryClient } from "@/components/gallery/DigitalGalleryClient";
 
 export const metadata = {
   title: "Private Gallery | OpenÉire Studios",
@@ -6,5 +7,16 @@ export const metadata = {
 };
 
 export default function DigitalGalleryPage() {
-  return <GalleryAccessRequired title="Private digital gallery" />;
+  return (
+    <Suspense
+      fallback={
+        <div className="page-top-offset flex min-h-screen items-center justify-center bg-black px-4 pb-24 text-center text-white">
+          <div className="h-12 w-12 animate-spin rounded-full border-2 border-accent border-t-transparent" />
+          <span className="sr-only">Loading private gallery</span>
+        </div>
+      }
+    >
+      <DigitalGalleryClient />
+    </Suspense>
+  );
 }

--- a/openeire-next/app/gallery/photo/[id]/page.tsx
+++ b/openeire-next/app/gallery/photo/[id]/page.tsx
@@ -1,4 +1,4 @@
-import { GalleryAccessRequired } from "@/components/gallery/GalleryAccessRequired";
+import { PrivateGalleryAccessShell } from "@/components/gallery/PrivateGalleryAccessShell";
 
 export const metadata = {
   title: "Private Photo | OpenÉire Studios",
@@ -6,5 +6,10 @@ export const metadata = {
 };
 
 export default function PhotoDetailGatePage() {
-  return <GalleryAccessRequired title="Private photo access required" />;
+  return (
+    <PrivateGalleryAccessShell
+      title="Private photo"
+      pendingTitle="Private photo details pending migration"
+    />
+  );
 }

--- a/openeire-next/app/gallery/photo/page.tsx
+++ b/openeire-next/app/gallery/photo/page.tsx
@@ -1,4 +1,4 @@
-import { GalleryAccessRequired } from "@/components/gallery/GalleryAccessRequired";
+import { PrivateGalleryAccessShell } from "@/components/gallery/PrivateGalleryAccessShell";
 
 export const metadata = {
   title: "Private Photo Gallery | OpenÉire Studios",
@@ -6,5 +6,10 @@ export const metadata = {
 };
 
 export default function PhotoGalleryPage() {
-  return <GalleryAccessRequired title="Private photo gallery" />;
+  return (
+    <PrivateGalleryAccessShell
+      title="Private photo gallery"
+      pendingTitle="Private photo gallery pending migration"
+    />
+  );
 }

--- a/openeire-next/app/gallery/video/[id]/page.tsx
+++ b/openeire-next/app/gallery/video/[id]/page.tsx
@@ -1,4 +1,4 @@
-import { GalleryAccessRequired } from "@/components/gallery/GalleryAccessRequired";
+import { PrivateGalleryAccessShell } from "@/components/gallery/PrivateGalleryAccessShell";
 
 export const metadata = {
   title: "Private Video | OpenÉire Studios",
@@ -6,5 +6,10 @@ export const metadata = {
 };
 
 export default function VideoDetailGatePage() {
-  return <GalleryAccessRequired title="Private video access required" />;
+  return (
+    <PrivateGalleryAccessShell
+      title="Private video"
+      pendingTitle="Private video details pending migration"
+    />
+  );
 }

--- a/openeire-next/app/gallery/video/page.tsx
+++ b/openeire-next/app/gallery/video/page.tsx
@@ -1,4 +1,4 @@
-import { GalleryAccessRequired } from "@/components/gallery/GalleryAccessRequired";
+import { PrivateGalleryAccessShell } from "@/components/gallery/PrivateGalleryAccessShell";
 
 export const metadata = {
   title: "Private Video Gallery | OpenÉire Studios",
@@ -6,5 +6,10 @@ export const metadata = {
 };
 
 export default function VideoGalleryPage() {
-  return <GalleryAccessRequired title="Private video gallery" />;
+  return (
+    <PrivateGalleryAccessShell
+      title="Private video gallery"
+      pendingTitle="Private video gallery pending migration"
+    />
+  );
 }

--- a/openeire-next/app/licensing/page.tsx
+++ b/openeire-next/app/licensing/page.tsx
@@ -131,7 +131,7 @@ export default function LicensingPage() {
         image={PUBLIC_IMAGES.irelandGallery}
         actions={[
           {
-            href: "/gallery/digital",
+            href: "/gallery-gate?next=/gallery/digital",
             label: "Browse Footage & Choose Your Asset",
           },
           { href: "/contact", label: "Speak to the Studio", variant: "secondary" },
@@ -197,7 +197,7 @@ export default function LicensingPage() {
         description="Start with the footage library, then open the asset page to share your usage details and get the right scope confirmed."
         actions={[
           {
-            href: "/gallery/digital",
+            href: "/gallery-gate?next=/gallery/digital",
             label: "Browse Footage & Choose Your Asset",
           },
           { href: "/contact", label: "Contact the Studio", variant: "secondary" },

--- a/openeire-next/components/gallery/DigitalGalleryCard.tsx
+++ b/openeire-next/components/gallery/DigitalGalleryCard.tsx
@@ -1,0 +1,89 @@
+/* eslint-disable @next/next/no-img-element */
+import Link from "next/link";
+import { FaCamera, FaExpand, FaImage, FaVideo } from "react-icons/fa";
+import { formatEuro, getStartingPrice } from "@/lib/gallery/format";
+import { resolveMediaUrl } from "@/lib/media";
+import type { PublicGalleryItem } from "@/types/gallery";
+
+const getDigitalItemHref = (item: PublicGalleryItem): string =>
+  item.product_type === "video"
+    ? `/gallery/video/${item.id}`
+    : `/gallery/photo/${item.id}`;
+
+const getDigitalItemLabel = (item: PublicGalleryItem): string =>
+  item.product_type === "video" ? "Video" : "Photo";
+
+export function DigitalGalleryCard({ item }: { item: PublicGalleryItem }) {
+  const imageUrl = resolveMediaUrl(item.thumbnail_image || item.preview_image);
+  const startingPrice = getStartingPrice(item);
+  const displayPrice =
+    startingPrice === undefined || startingPrice === null || startingPrice === ""
+      ? null
+      : formatEuro(startingPrice);
+  const label = getDigitalItemLabel(item);
+  const href = getDigitalItemHref(item);
+  const Icon = item.product_type === "video" ? FaVideo : FaImage;
+
+  return (
+    <article className="group relative flex h-full w-full flex-col overflow-hidden rounded-2xl border border-white/10 bg-black shadow-sm transition-all duration-500 hover:-translate-y-1 hover:shadow-2xl">
+      <Link
+        href={href}
+        prefetch={false}
+        className="relative block aspect-[4/3] w-full overflow-hidden bg-gray-900"
+      >
+        {imageUrl ? (
+          <img
+            src={imageUrl}
+            alt={item.title}
+            loading="lazy"
+            decoding="async"
+            className="absolute inset-0 z-10 h-full w-full object-cover transition-transform duration-700 group-hover:scale-105"
+          />
+        ) : (
+          <div className="absolute inset-0 z-10 flex items-center justify-center bg-gray-950 text-gray-600">
+            <FaCamera className="text-4xl" aria-hidden="true" />
+          </div>
+        )}
+
+        <div className="absolute right-3 top-3 z-20">
+          <span className="flex items-center rounded-full bg-accent px-3 py-1 text-[10px] font-bold uppercase tracking-widest text-brand-900 shadow-md backdrop-blur-md">
+            <Icon className="mr-1 text-[8px]" /> {label}
+          </span>
+        </div>
+
+        <div className="absolute bottom-0 left-0 z-20 flex w-full translate-y-full items-end justify-between bg-gradient-to-t from-black via-black/80 to-transparent p-4 transition-transform duration-300 ease-out group-hover:translate-y-0">
+          <div className="text-white">
+            <p className="text-[10px] font-bold uppercase tracking-wider opacity-80">
+              Personal use
+            </p>
+            <span className="font-serif text-lg font-bold">
+              {displayPrice ? `€${displayPrice}` : "View details"}
+            </span>
+          </div>
+          <span
+            className="flex h-10 w-10 items-center justify-center rounded-full bg-white text-brand-900 shadow-lg transition-all group-hover:scale-110 group-hover:bg-accent"
+            aria-hidden="true"
+          >
+            <FaExpand className="text-sm" />
+          </span>
+        </div>
+      </Link>
+
+      <div className="flex flex-1 flex-col p-5">
+        <Link href={href} prefetch={false}>
+          <h2 className="mb-1 min-h-[3.5rem] font-serif text-lg font-bold leading-tight text-white transition-colors hover:text-accent">
+            {item.title}
+          </h2>
+        </Link>
+        <div className="mt-auto flex min-h-[2rem] items-center justify-between gap-3 pt-2">
+          <p className="text-xs font-bold uppercase tracking-wider text-gray-500">
+            {item.collection || "Private collection"}
+          </p>
+          <p className="text-[10px] font-bold uppercase tracking-[0.2em] text-gray-600">
+            {label}
+          </p>
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/openeire-next/components/gallery/DigitalGalleryClient.tsx
+++ b/openeire-next/components/gallery/DigitalGalleryClient.tsx
@@ -1,0 +1,296 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { useCallback, useEffect, useState } from "react";
+import type { IconType } from "react-icons";
+import { FaImage, FaVideo } from "react-icons/fa";
+import { useAuth } from "@/components/auth/AuthProvider";
+import { DigitalGalleryCard } from "@/components/gallery/DigitalGalleryCard";
+import { GalleryHero } from "@/components/gallery/GalleryHero";
+import { GalleryToolbar } from "@/components/gallery/GalleryToolbar";
+import { getProtectedDigitalGalleryItems } from "@/lib/api/gallery";
+import {
+  getCollectionLabel,
+  isGalleryCollectionAvailable,
+} from "@/lib/gallery/collections";
+import type {
+  DigitalGalleryFilter,
+  PaginatedResponse,
+  PublicGalleryItem,
+} from "@/types/gallery";
+
+type GalleryLoadState = "idle" | "loading" | "success" | "error";
+
+const digitalFilters: Array<{
+  value: DigitalGalleryFilter;
+  label: string;
+  icon?: IconType;
+}> = [
+  { value: "all", label: "All digital" },
+  { value: "photo", label: "Photos", icon: FaImage },
+  { value: "video", label: "Videos", icon: FaVideo },
+];
+
+const getSafeDigitalFilter = (
+  value: string | null,
+): DigitalGalleryFilter =>
+  value === "photo" || value === "video" ? value : "all";
+
+const buildGateHref = (pathname: string | null): string =>
+  `/gallery-gate?next=${encodeURIComponent(pathname || "/gallery/digital")}`;
+
+const getApiErrorMessage = (error: unknown): string => {
+  if (error instanceof Error && error.message.trim()) {
+    return error.message;
+  }
+  return "The private gallery could not be loaded right now. Please try again shortly.";
+};
+
+export function DigitalGalleryClient() {
+  const pathname = usePathname();
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const { isLoading: isAuthLoading, user } = useAuth();
+  const [galleryPage, setGalleryPage] =
+    useState<PaginatedResponse<PublicGalleryItem> | null>(null);
+  const [loadState, setLoadState] = useState<GalleryLoadState>("idle");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const hasGalleryAccess = Boolean(user?.can_access_gallery);
+  const collection = searchParams.get("collection")?.trim() || "all";
+  const search = searchParams.get("search")?.trim() || "";
+  const sort = searchParams.get("sort")?.trim() || "date_desc";
+  const page = searchParams.get("page") || undefined;
+  const itemType = getSafeDigitalFilter(searchParams.get("itemType"));
+  const collectionLabel = getCollectionLabel(collection);
+  const isCollectionComingSoon = !isGalleryCollectionAvailable(collection);
+  const gateHref = buildGateHref(pathname);
+
+  useEffect(() => {
+    if (!isAuthLoading && !hasGalleryAccess) {
+      router.replace(gateHref);
+    }
+  }, [gateHref, hasGalleryAccess, isAuthLoading, router]);
+
+  useEffect(() => {
+    if (isAuthLoading || !hasGalleryAccess || isCollectionComingSoon) {
+      setGalleryPage(
+        isCollectionComingSoon
+          ? { count: 0, next: null, previous: null, results: [] }
+          : null,
+      );
+      setLoadState(isCollectionComingSoon ? "success" : "idle");
+      return;
+    }
+
+    const controller = new AbortController();
+    setLoadState("loading");
+    setErrorMessage(null);
+
+    getProtectedDigitalGalleryItems({
+      collection,
+      search,
+      sort,
+      page,
+      itemType,
+      signal: controller.signal,
+    })
+      .then((response) => {
+        if (controller.signal.aborted) return;
+        setGalleryPage(response);
+        setLoadState("success");
+      })
+      .catch((error) => {
+        if (controller.signal.aborted) return;
+        setGalleryPage(null);
+        setErrorMessage(getApiErrorMessage(error));
+        setLoadState("error");
+      });
+
+    return () => {
+      controller.abort();
+    };
+  }, [
+    collection,
+    hasGalleryAccess,
+    isAuthLoading,
+    isCollectionComingSoon,
+    itemType,
+    page,
+    search,
+    sort,
+  ]);
+
+  const buildFilterHref = useCallback(
+    (nextItemType: DigitalGalleryFilter): string => {
+      const params = new URLSearchParams(searchParams.toString());
+      if (nextItemType === "all") {
+        params.delete("itemType");
+      } else {
+        params.set("itemType", nextItemType);
+      }
+      params.delete("page");
+      const query = params.toString();
+      return query ? `/gallery/digital?${query}` : "/gallery/digital";
+    },
+    [searchParams],
+  );
+
+  if (isAuthLoading) {
+    return (
+      <div className="page-top-offset flex min-h-screen items-center justify-center bg-black px-4 pb-24 text-center text-white">
+        <div className="h-12 w-12 animate-spin rounded-full border-2 border-accent border-t-transparent" />
+        <span className="sr-only">Checking gallery access</span>
+      </div>
+    );
+  }
+
+  if (!hasGalleryAccess) {
+    return (
+      <div className="page-top-offset flex min-h-screen items-center justify-center bg-black px-4 pb-24 text-center text-white">
+        <div className="max-w-md rounded-2xl border border-white/10 bg-gray-900/50 p-8 shadow-2xl">
+          <div className="mx-auto mb-5 h-10 w-10 animate-spin rounded-full border-2 border-accent border-t-transparent" />
+          <p className="text-xs font-bold uppercase tracking-[0.28em] text-accent">
+            Redirecting
+          </p>
+          <h1 className="mt-3 font-serif text-2xl font-bold">
+            Private gallery
+          </h1>
+          <p className="mt-3 text-sm leading-relaxed text-gray-400">
+            Taking you to the private collection access flow.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  const items = galleryPage?.results ?? [];
+  const showFilterState = Boolean(
+    search || itemType !== "all" || (collection && collection !== "all"),
+  );
+
+  return (
+    <div className="page-top-offset min-h-screen bg-black pb-20 text-white">
+      <GalleryHero activeCollection={collection} galleryPath="/gallery/digital" />
+
+      <div className="container mx-auto mb-4 mt-2 px-4 lg:hidden lg:px-8">
+        <div className="rounded-[24px] border border-white/10 bg-white/5 px-4 py-4 shadow-[0_18px_50px_rgba(0,0,0,0.28)] backdrop-blur-xl">
+          <div className="text-[11px] font-semibold uppercase tracking-[0.26em] text-gray-400">
+            Private digital archive
+          </div>
+          <h2 className="mt-2 font-serif text-lg font-bold text-white">
+            Browse licensed photos and footage for personal use.
+          </h2>
+          <p className="mt-2 text-sm leading-relaxed text-gray-300">
+            Use search and filters to find protected digital images and videos.
+            Detail pages are private and never prefetched.
+          </p>
+        </div>
+      </div>
+
+      <GalleryToolbar
+        search={search}
+        sort={sort}
+        collection={collection}
+        actionPath="/gallery/digital"
+      />
+
+      <div
+        id="gallery-grid"
+        className="container relative z-10 mx-auto px-4 lg:px-8"
+      >
+        <div className="mb-8 flex flex-wrap items-center gap-3">
+          {digitalFilters.map((filter) => {
+            const isActive = filter.value === itemType;
+            const Icon = filter.icon;
+            return (
+              <Link
+                key={filter.value}
+                href={buildFilterHref(filter.value)}
+                scroll={false}
+                className={`inline-flex items-center gap-2 rounded-full border px-4 py-2 text-xs font-bold uppercase tracking-[0.2em] transition-colors ${
+                  isActive
+                    ? "border-accent bg-accent text-brand-900"
+                    : "border-white/10 bg-white/5 text-gray-400 hover:border-white/25 hover:text-white"
+                }`}
+              >
+                {Icon ? <Icon className="text-[11px]" aria-hidden="true" /> : null}
+                {filter.label}
+              </Link>
+            );
+          })}
+        </div>
+
+        {showFilterState ? (
+          <div className="mb-8 flex flex-wrap items-center gap-3 text-sm text-gray-400">
+            <span className="rounded-full border border-white/10 bg-white/5 px-4 py-2">
+              {collection !== "all" ? collectionLabel : "All collections"}
+            </span>
+            {itemType !== "all" ? (
+              <span className="rounded-full border border-white/10 bg-white/5 px-4 py-2">
+                Type: {itemType === "photo" ? "Photos" : "Videos"}
+              </span>
+            ) : null}
+            {search ? (
+              <span className="rounded-full border border-white/10 bg-white/5 px-4 py-2">
+                Search: {search}
+              </span>
+            ) : null}
+            <Link href="/gallery/digital" className="text-accent hover:underline">
+              Clear filters
+            </Link>
+          </div>
+        ) : null}
+
+        {loadState === "loading" ? (
+          <div className="py-20 text-center">
+            <div className="mx-auto h-12 w-12 animate-spin rounded-full border-2 border-accent border-t-transparent" />
+            <p className="mt-4 text-sm uppercase tracking-[0.24em] text-gray-500">
+              Loading private gallery
+            </p>
+          </div>
+        ) : loadState === "error" ? (
+          <div className="py-20 text-center">
+            <h2 className="font-serif text-2xl font-bold text-white">
+              Private gallery unavailable right now.
+            </h2>
+            <p className="mx-auto mt-3 max-w-xl text-gray-400">
+              {errorMessage}
+            </p>
+          </div>
+        ) : items.length > 0 ? (
+          <div className="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+            {items.map((item) => (
+              <DigitalGalleryCard key={`${item.product_type}-${item.id}`} item={item} />
+            ))}
+          </div>
+        ) : (
+          <div className="py-20 text-center">
+            {isCollectionComingSoon ? (
+              <>
+                <h2 className="font-serif text-2xl font-bold text-white">
+                  {collectionLabel} is coming soon!
+                </h2>
+                <p className="mt-3 text-gray-400">
+                  We&apos;re curating this private collection now. Check back
+                  soon for new releases.
+                </p>
+              </>
+            ) : (
+              <>
+                <h2 className="font-serif text-2xl font-bold text-white">
+                  No private media found.
+                </h2>
+                <p className="mt-3 text-gray-400">
+                  Try clearing filters or checking back as new licensed visuals
+                  are added.
+                </p>
+              </>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/openeire-next/components/gallery/GalleryAccessRequired.tsx
+++ b/openeire-next/components/gallery/GalleryAccessRequired.tsx
@@ -18,7 +18,7 @@ export function GalleryAccessRequired({
         </p>
         <div className="mt-8 flex flex-col justify-center gap-3 sm:flex-row">
           <Link
-            href="/gallery-gate"
+            href="/gallery-gate?next=/gallery/digital"
             className="rounded-full bg-brand-700 px-6 py-3 text-sm font-bold text-paper transition-colors hover:bg-brand-900"
           >
             Request Access

--- a/openeire-next/components/gallery/GalleryGateClient.tsx
+++ b/openeire-next/components/gallery/GalleryGateClient.tsx
@@ -1,0 +1,504 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
+import { useEffect, useMemo, useState, type FormEvent } from "react";
+import { useAuth } from "@/components/auth/AuthProvider";
+import { useToast } from "@/components/ui/ToastProvider";
+import { requestGalleryAccess, verifyGalleryAccess } from "@/lib/api/galleryAccess";
+import { normalizeAuthErrorMessage } from "@/lib/api/auth";
+import { getSafeReturnPath } from "@/lib/auth/redirects";
+import {
+  clearGalleryAccessIntent,
+  getPendingGalleryCode,
+  getPendingGalleryRedirect,
+  getRequestedGalleryEmail,
+  setPendingGalleryCode,
+  setPendingGalleryRedirect,
+  setRequestedGalleryEmail,
+} from "@/lib/gallery/accessIntent";
+
+type GateState =
+  | "loggedOutStart"
+  | "loggedOutRequested"
+  | "readyToVerify"
+  | "emailMismatch"
+  | "alreadyApproved";
+
+const normalizeEmail = (value: string): string => value.trim().toLowerCase();
+
+const getSafeGalleryRedirect = (value: string | null | undefined) => {
+  const safePath = getSafeReturnPath(value, "/gallery/digital");
+  const [safePathname] = safePath.split(/[?#]/);
+  return safePath.startsWith("/gallery") && safePathname !== "/gallery-gate"
+    ? safePath
+    : "/gallery/digital";
+};
+
+export function GalleryGateClient() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const { isAuthenticated, isLoading, user, refreshUser } = useAuth();
+  const { showToast } = useToast();
+  const [requestEmail, setRequestEmail] = useState("");
+  const [requestedEmail, setRequestedEmailState] = useState("");
+  const [code, setCode] = useState("");
+  const [isRequestingCode, setIsRequestingCode] = useState(false);
+  const [isVerifyingCode, setIsVerifyingCode] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const accountEmail = normalizeEmail(user?.email ?? "");
+  const hasGalleryAccess = Boolean(user?.can_access_gallery);
+
+  const pendingRedirect = useMemo(() => {
+    const nextParam = searchParams.get("next");
+    const storedRedirect = getPendingGalleryRedirect();
+    return getSafeGalleryRedirect(nextParam || storedRedirect);
+  }, [searchParams]);
+
+  const emailsMatch =
+    Boolean(requestedEmail) &&
+    Boolean(accountEmail) &&
+    requestedEmail === accountEmail;
+
+  useEffect(() => {
+    localStorage.removeItem("gallery_access");
+    setCode(getPendingGalleryCode());
+    const storedRequestedEmail = getRequestedGalleryEmail();
+    setRequestedEmailState(storedRequestedEmail);
+    setRequestEmail(storedRequestedEmail || accountEmail);
+  }, [accountEmail]);
+
+  useEffect(() => {
+    setPendingGalleryRedirect(pendingRedirect);
+  }, [pendingRedirect]);
+
+  useEffect(() => {
+    if (!hasGalleryAccess) return;
+    clearGalleryAccessIntent();
+    router.replace(pendingRedirect || "/gallery/digital");
+  }, [hasGalleryAccess, pendingRedirect, router]);
+
+  const gateState: GateState = useMemo(() => {
+    if (hasGalleryAccess) return "alreadyApproved";
+    if (!isAuthenticated && !requestedEmail) return "loggedOutStart";
+    if (!isAuthenticated && requestedEmail) return "loggedOutRequested";
+    if (isAuthenticated && requestedEmail && !emailsMatch) {
+      return "emailMismatch";
+    }
+    return "readyToVerify";
+  }, [emailsMatch, hasGalleryAccess, isAuthenticated, requestedEmail]);
+
+  const handleRequestAccess = async (emailOverride?: string) => {
+    const emailToUse = normalizeEmail(emailOverride ?? requestEmail);
+    if (!emailToUse) {
+      setErrorMessage("Enter the email address you want to use for private gallery access.");
+      return;
+    }
+
+    setIsRequestingCode(true);
+    setErrorMessage(null);
+    try {
+      await requestGalleryAccess({ email: emailToUse });
+      setRequestedGalleryEmail(emailToUse);
+      setRequestedEmailState(emailToUse);
+      setRequestEmail(emailToUse);
+      setPendingGalleryRedirect(pendingRedirect);
+      showToast("Access code sent. Check your inbox for the next step.", "success");
+    } catch (error) {
+      const message = normalizeAuthErrorMessage(
+        error,
+        "Unable to send access code right now. Please try again later.",
+      );
+      setErrorMessage(message);
+      showToast(message, "error");
+    } finally {
+      setIsRequestingCode(false);
+    }
+  };
+
+  const handleStartOver = () => {
+    clearGalleryAccessIntent();
+    setRequestedEmailState("");
+    setCode("");
+    setRequestEmail(accountEmail || "");
+    setErrorMessage(null);
+    showToast("You can request access with a different email now.", "success");
+  };
+
+  const handleVerifyCode = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const normalizedCode = code.trim().toUpperCase();
+    if (!normalizedCode) {
+      setErrorMessage("Enter the access code from your email.");
+      return;
+    }
+
+    if (!isAuthenticated) {
+      setPendingGalleryCode(normalizedCode);
+      setPendingGalleryRedirect(pendingRedirect);
+      showToast("Sign in with the same email you used to request access.", "info");
+      router.push(
+        `/login?next=${encodeURIComponent("/gallery-gate")}${
+          requestedEmail ? `&email=${encodeURIComponent(requestedEmail)}` : ""
+        }`,
+      );
+      return;
+    }
+
+    if (gateState === "emailMismatch") {
+      setErrorMessage(
+        "This signed-in email does not match the email where your code was sent.",
+      );
+      return;
+    }
+
+    setIsVerifyingCode(true);
+    setErrorMessage(null);
+    try {
+      const response = await verifyGalleryAccess({ access_code: normalizedCode });
+      if (response.valid) {
+        const refreshedUser = await refreshUser();
+        clearGalleryAccessIntent();
+        showToast("Private gallery unlocked.", "success");
+        router.replace(
+          refreshedUser?.can_access_gallery ? pendingRedirect : "/profile",
+        );
+      }
+    } catch (error) {
+      const message = normalizeAuthErrorMessage(
+        error,
+        "Invalid or expired code.",
+      );
+      setErrorMessage(message);
+      showToast(message, "error");
+    } finally {
+      setIsVerifyingCode(false);
+    }
+  };
+
+  const loginHref = `/login?next=${encodeURIComponent("/gallery-gate")}${
+    requestedEmail || requestEmail
+      ? `&email=${encodeURIComponent(requestedEmail || requestEmail)}`
+      : ""
+  }`;
+  const registerHref = `/register?next=${encodeURIComponent("/gallery-gate")}${
+    requestedEmail || requestEmail
+      ? `&email=${encodeURIComponent(requestedEmail || requestEmail)}`
+      : ""
+  }`;
+
+  const renderPrimaryPanel = () => {
+    if (isLoading) {
+      return (
+        <div className="space-y-5 text-center">
+          <div className="mx-auto h-10 w-10 animate-spin rounded-full border-2 border-brand-700 border-t-transparent" />
+          <div>
+            <p className="text-sm font-semibold uppercase tracking-[0.18em] text-brand-700">
+              Checking Access
+            </p>
+            <h2 className="mt-2 font-serif text-2xl font-bold text-brand-900">
+              Looking up your private gallery status
+            </h2>
+            <p className="mt-3 text-sm leading-relaxed text-gray-600">
+              We&apos;ll send you straight to the gallery if this account is already
+              unlocked.
+            </p>
+          </div>
+        </div>
+      );
+    }
+
+    if (gateState === "alreadyApproved") {
+      return (
+        <div className="space-y-5">
+          <div className="rounded-xl border border-emerald-200 bg-emerald-50 p-5">
+            <p className="text-sm font-semibold uppercase tracking-[0.18em] text-emerald-700">
+              Access Ready
+            </p>
+            <h2 className="mt-2 font-serif text-2xl font-bold text-brand-900">
+              Your private gallery is unlocked
+            </h2>
+            <p className="mt-3 text-sm leading-relaxed text-gray-600">
+              Redirecting you to the private digital collection now.
+            </p>
+          </div>
+          <div className="mx-auto h-10 w-10 animate-spin rounded-full border-2 border-brand-700 border-t-transparent" />
+        </div>
+      );
+    }
+
+    if (gateState === "emailMismatch") {
+      return (
+        <div className="space-y-5">
+          <div className="rounded-xl border border-amber-200 bg-amber-50 p-5">
+            <p className="text-sm font-semibold uppercase tracking-[0.18em] text-amber-700">
+              Email Check
+            </p>
+            <h2 className="mt-2 font-serif text-2xl font-bold text-brand-900">
+              Sign in with the same email
+            </h2>
+            <p className="mt-3 text-sm leading-relaxed text-gray-600">
+              Your code was requested for{" "}
+              <span className="font-semibold text-brand-900">{requestedEmail}</span>
+              , but you are currently signed in as{" "}
+              <span className="font-semibold text-brand-900">{accountEmail}</span>.
+            </p>
+          </div>
+
+          <button
+            onClick={() => handleRequestAccess(accountEmail)}
+            disabled={isRequestingCode}
+            className="w-full rounded-lg bg-brand-900 py-4 font-bold text-white shadow-lg transition-all hover:bg-brand-800 hover:shadow-xl disabled:cursor-not-allowed disabled:opacity-70"
+          >
+            {isRequestingCode ? "Sending Fresh Code..." : "Request a New Code for This Account"}
+          </button>
+
+          <Link
+            href="/logout"
+            className="block w-full rounded-lg border border-brand-200 px-6 py-4 text-center text-sm font-bold text-brand-700 transition-colors hover:bg-brand-50 hover:text-brand-900"
+          >
+            Switch Account
+          </Link>
+        </div>
+      );
+    }
+
+    if (gateState === "loggedOutRequested") {
+      return (
+        <div className="space-y-5">
+          <div className="rounded-xl border border-brand-200 bg-brand-50/70 p-5">
+            <p className="text-sm font-semibold uppercase tracking-[0.18em] text-brand-700">
+              Continue Your Access Request
+            </p>
+            <h2 className="mt-2 font-serif text-2xl font-bold text-brand-900">
+              Use the same email to keep going
+            </h2>
+            <p className="mt-3 text-sm leading-relaxed text-gray-600">
+              You&apos;re continuing a gallery access request for{" "}
+              <span className="font-semibold text-brand-900">{requestedEmail}</span>.
+              Sign in or create your account with this same email, then return
+              here to unlock the gallery.
+            </p>
+          </div>
+
+          <div className="grid gap-3 sm:grid-cols-2">
+            <Link
+              href={loginHref}
+              className="rounded-lg bg-brand-900 px-6 py-4 text-center text-sm font-bold text-white shadow-lg transition-all hover:bg-brand-800"
+            >
+              Sign In
+            </Link>
+            <Link
+              href={registerHref}
+              className="rounded-lg border border-brand-200 px-6 py-4 text-center text-sm font-bold text-brand-700 transition-colors hover:bg-brand-50 hover:text-brand-900"
+            >
+              Create Account
+            </Link>
+          </div>
+
+          <button
+            onClick={() => handleRequestAccess(requestedEmail)}
+            disabled={isRequestingCode}
+            className="w-full rounded-lg border border-brand-200 px-6 py-4 text-sm font-bold text-brand-700 transition-colors hover:bg-brand-50 hover:text-brand-900 disabled:cursor-not-allowed disabled:opacity-70"
+          >
+            {isRequestingCode ? "Sending Fresh Code..." : "Send a Fresh Code"}
+          </button>
+
+          <button
+            onClick={handleStartOver}
+            type="button"
+            className="w-full text-sm font-semibold text-gray-500 underline-offset-4 transition-colors hover:text-brand-900 hover:underline"
+          >
+            Use a different email
+          </button>
+        </div>
+      );
+    }
+
+    if (gateState === "readyToVerify") {
+      return (
+        <div className="space-y-6">
+          <div className="rounded-xl border border-brand-200 bg-brand-50/70 p-5">
+            <p className="text-sm font-semibold uppercase tracking-[0.18em] text-brand-700">
+              Final Step
+            </p>
+            <h2 className="mt-2 font-serif text-2xl font-bold text-brand-900">
+              Enter your access code
+            </h2>
+            <p className="mt-3 text-sm leading-relaxed text-gray-600">
+              {requestedEmail
+                ? `Use the code sent to ${requestedEmail} to unlock the private digital gallery.`
+                : `Request a code for ${accountEmail} and then enter it here to unlock the private digital gallery.`}
+            </p>
+          </div>
+
+          <button
+            onClick={() => handleRequestAccess(requestedEmail || accountEmail)}
+            disabled={isRequestingCode}
+            className="w-full rounded-lg border border-brand-200 px-6 py-4 text-sm font-bold text-brand-700 transition-colors hover:bg-brand-50 hover:text-brand-900 disabled:cursor-not-allowed disabled:opacity-70"
+          >
+            {isRequestingCode
+              ? "Sending Fresh Code..."
+              : requestedEmail
+                ? "Send a Fresh Code"
+                : "Request Access Code"}
+          </button>
+
+          {requestedEmail ? (
+            <button
+              onClick={handleStartOver}
+              type="button"
+              className="w-full text-sm font-semibold text-gray-500 underline-offset-4 transition-colors hover:text-brand-900 hover:underline"
+            >
+              Use a different email
+            </button>
+          ) : null}
+
+          <form onSubmit={handleVerifyCode} className="space-y-5">
+            <input
+              type="text"
+              placeholder="A1B2-C3D4"
+              value={code}
+              onChange={(event) => setCode(event.target.value)}
+              className="w-full rounded-lg border border-gray-200 bg-gray-50 p-4 text-center font-mono text-base uppercase tracking-[0.2em] text-brand-900 outline-none transition-all placeholder-gray-300 focus:border-transparent focus:ring-2 focus:ring-accent sm:text-lg sm:tracking-[0.3em]"
+              maxLength={9}
+            />
+            <button
+              type="submit"
+              disabled={isVerifyingCode}
+              className="w-full rounded-lg bg-brand-900 py-4 font-bold text-white shadow-lg transition-all hover:bg-brand-800 hover:shadow-xl disabled:cursor-not-allowed disabled:opacity-70"
+            >
+              {isVerifyingCode ? "Verifying..." : "Verify Code"}
+            </button>
+          </form>
+        </div>
+      );
+    }
+
+    return (
+      <div className="space-y-6">
+        <div className="rounded-xl border border-brand-200 bg-brand-50/70 p-5">
+          <p className="text-sm font-semibold uppercase tracking-[0.18em] text-brand-700">
+            Private Access
+          </p>
+          <h2 className="mt-2 font-serif text-2xl font-bold text-brand-900">
+            Request your access code
+          </h2>
+          <p className="mt-3 text-sm leading-relaxed text-gray-600">
+            Use the email you plan to use for your account. You&apos;ll sign in
+            or create that account next, then enter your emailed code to unlock
+            the gallery.
+          </p>
+        </div>
+
+        <form
+          onSubmit={(event) => {
+            event.preventDefault();
+            void handleRequestAccess();
+          }}
+          className="space-y-4"
+        >
+          <input
+            type="email"
+            placeholder="creators@studio.com"
+            value={requestEmail}
+            onChange={(event) => setRequestEmail(event.target.value)}
+            className="w-full rounded-lg border border-gray-200 bg-gray-50 p-4 text-sm text-brand-900 outline-none focus:ring-2 focus:ring-accent"
+          />
+          <button
+            type="submit"
+            disabled={isRequestingCode}
+            className="w-full rounded-lg bg-brand-900 py-4 font-bold text-white shadow-lg transition-all hover:bg-brand-800 hover:shadow-xl disabled:cursor-not-allowed disabled:opacity-70"
+          >
+            {isRequestingCode ? "Sending Code..." : "Request Access Code"}
+          </button>
+        </form>
+
+        <div className="grid gap-3 sm:grid-cols-2">
+          <Link
+            href={loginHref}
+            className="rounded-lg border border-brand-200 px-6 py-4 text-center text-sm font-bold text-brand-700 transition-colors hover:bg-brand-50 hover:text-brand-900"
+          >
+            Sign In
+          </Link>
+          <Link
+            href={registerHref}
+            className="rounded-lg border border-brand-200 px-6 py-4 text-center text-sm font-bold text-brand-700 transition-colors hover:bg-brand-50 hover:text-brand-900"
+          >
+            Create Account
+          </Link>
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <div className="page-top-offset relative flex min-h-screen items-center justify-center overflow-x-hidden bg-brand-900 px-4 pb-16 text-white">
+      <div className="pointer-events-none absolute inset-0 opacity-5">
+        <svg width="100%" height="100%" aria-hidden="true">
+          <pattern
+            id="gate-grid"
+            width="40"
+            height="40"
+            patternUnits="userSpaceOnUse"
+          >
+            <path
+              d="M 40 0 L 0 0 0 40"
+              fill="none"
+              stroke="white"
+              strokeWidth="0.5"
+            />
+          </pattern>
+          <rect width="100%" height="100%" fill="url(#gate-grid)" />
+        </svg>
+      </div>
+
+      <div className="relative z-10 grid w-full max-w-5xl items-center gap-10 md:grid-cols-2 lg:gap-20">
+        <div className="space-y-8 text-center md:text-left">
+          <span className="inline-block rounded-full border border-accent/30 px-3 py-1 text-xs font-bold uppercase tracking-[0.2em] text-accent">
+            Members Only
+          </span>
+          <h1 className="font-serif text-4xl font-bold leading-tight text-white sm:text-5xl lg:text-6xl">
+            Private <br />
+            <span className="bg-gradient-to-r from-brand-100 to-accent bg-clip-text text-transparent">
+              Collection
+            </span>
+          </h1>
+          <div className="space-y-3 text-brand-100/85">
+            <p className="text-base leading-relaxed sm:text-lg">
+              Unlock our private digital gallery in three simple steps.
+            </p>
+            <ol className="space-y-3 text-sm leading-relaxed sm:text-base">
+              <li>1. Request your access code.</li>
+              <li>2. Sign in or create an account with the same email.</li>
+              <li>3. Enter the code to unlock the gallery.</li>
+            </ol>
+          </div>
+          <div className="mx-auto h-1 w-24 rounded bg-accent opacity-80 md:mx-0" />
+          <Link
+            href="/"
+            className="inline-block text-sm text-brand-100 underline decoration-white/30 transition-all hover:text-white hover:decoration-white"
+          >
+            &larr; Return to Home
+          </Link>
+        </div>
+
+        <div className="w-full rounded-2xl border border-white/10 bg-white p-6 text-brand-900 shadow-2xl transition-all hover:scale-[1.01] sm:p-8 lg:p-10">
+          {requestedEmail && gateState !== "alreadyApproved" ? (
+            <div className="mb-6 rounded-xl border border-brand-100 bg-brand-50 px-4 py-3 text-sm text-brand-900">
+              Using <span className="font-semibold">{requestedEmail}</span> for
+              gallery access
+            </div>
+          ) : null}
+          {errorMessage ? (
+            <div className="mb-6 rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+              {errorMessage}
+            </div>
+          ) : null}
+          {renderPrimaryPanel()}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/openeire-next/components/gallery/GalleryHero.tsx
+++ b/openeire-next/components/gallery/GalleryHero.tsx
@@ -13,8 +13,10 @@ const normalizeCollection = (value?: string | null): string =>
 
 export function GalleryHero({
   activeCollection,
+  galleryPath = "/gallery/physical",
 }: {
   activeCollection?: string | null;
+  galleryPath?: string;
 }) {
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -38,9 +40,9 @@ export function GalleryHero({
       }
 
       const query = params.toString();
-      return query ? `/gallery/physical?${query}` : "/gallery/physical";
+      return query ? `${galleryPath}?${query}` : galleryPath;
     },
-    [searchParams],
+    [galleryPath, searchParams],
   );
 
   const selectCollection = useCallback(

--- a/openeire-next/components/gallery/GalleryToolbar.tsx
+++ b/openeire-next/components/gallery/GalleryToolbar.tsx
@@ -10,15 +10,17 @@ export function GalleryToolbar({
   search,
   sort,
   collection,
+  actionPath = "/gallery/physical",
 }: {
   search?: string;
   sort?: string;
   collection?: string;
+  actionPath?: string;
 }) {
   return (
     <div className="container mx-auto mb-8 px-4 sm:mb-10 lg:mb-12 lg:px-8">
       <form
-        action="/gallery/physical"
+        action={actionPath}
         className="rounded-[28px] border border-white/10 bg-white/5 px-4 py-4 shadow-[0_24px_80px_rgba(0,0,0,0.38)] backdrop-blur-xl sm:px-5 sm:py-5"
       >
         <input type="hidden" name="collection" value={collection ?? ""} />

--- a/openeire-next/components/gallery/PrivateGalleryAccessShell.tsx
+++ b/openeire-next/components/gallery/PrivateGalleryAccessShell.tsx
@@ -1,0 +1,86 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname, useRouter } from "next/navigation";
+import { useEffect } from "react";
+import { FaCheckCircle } from "react-icons/fa";
+import { useAuth } from "@/components/auth/AuthProvider";
+
+export function PrivateGalleryAccessShell({
+  title,
+  pendingTitle = "Private gallery content pending migration",
+}: {
+  title: string;
+  pendingTitle?: string;
+}) {
+  const pathname = usePathname();
+  const router = useRouter();
+  const { isLoading, user } = useAuth();
+  const hasGalleryAccess = Boolean(user?.can_access_gallery);
+  const gateHref = `/gallery-gate?next=${encodeURIComponent(pathname || "/gallery/digital")}`;
+
+  useEffect(() => {
+    if (!isLoading && !hasGalleryAccess) {
+      router.replace(gateHref);
+    }
+  }, [gateHref, hasGalleryAccess, isLoading, router]);
+
+  if (isLoading) {
+    return (
+      <div className="page-top-offset flex min-h-screen items-center justify-center bg-black px-4 pb-24 text-center text-white">
+        <div className="h-12 w-12 animate-spin rounded-full border-2 border-accent border-t-transparent" />
+        <span className="sr-only">Checking gallery access</span>
+      </div>
+    );
+  }
+
+  if (!hasGalleryAccess) {
+    return (
+      <div className="page-top-offset flex min-h-screen items-center justify-center bg-black px-4 pb-24 text-center text-white">
+        <div className="max-w-md rounded-2xl border border-white/10 bg-gray-900/50 p-8 shadow-2xl">
+          <div className="mx-auto mb-5 h-10 w-10 animate-spin rounded-full border-2 border-accent border-t-transparent" />
+          <p className="text-xs font-bold uppercase tracking-[0.28em] text-accent">
+            Redirecting
+          </p>
+          <h1 className="mt-3 font-serif text-2xl font-bold">{title}</h1>
+          <p className="mt-3 text-sm leading-relaxed text-gray-400">
+            Taking you to the private collection access flow.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="page-top-offset flex min-h-screen items-center justify-center bg-black px-4 pb-24 text-center text-white">
+      <div className="max-w-2xl rounded-2xl border border-brand-500/25 bg-gray-900/70 p-8 shadow-2xl">
+        <div className="mx-auto mb-5 flex h-14 w-14 items-center justify-center rounded-full bg-brand-500 text-paper">
+          <FaCheckCircle aria-hidden="true" />
+        </div>
+        <p className="mb-3 text-xs font-bold uppercase tracking-[0.28em] text-accent">
+          Access granted
+        </p>
+        <h1 className="font-serif text-3xl font-bold">{pendingTitle}</h1>
+        <p className="mt-4 text-sm leading-relaxed text-gray-400">
+          Your account is authorised for the private digital gallery. The
+          interactive private listing is still being migrated into Next.js, so
+          this page no longer asks you to request access again.
+        </p>
+        <div className="mt-8 flex flex-col justify-center gap-3 sm:flex-row">
+          <Link
+            href="/profile"
+            className="rounded-full bg-brand-700 px-6 py-3 text-sm font-bold text-paper transition-colors hover:bg-brand-900"
+          >
+            View Account
+          </Link>
+          <Link
+            href="/gallery/physical"
+            className="rounded-full border border-white/20 px-6 py-3 text-sm font-bold text-white transition-colors hover:bg-white/10"
+          >
+            Browse Prints
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/openeire-next/components/home/HomeSections.tsx
+++ b/openeire-next/components/home/HomeSections.tsx
@@ -24,7 +24,7 @@ const services = [
     title: "4K Stock Footage",
     description:
       "Cinematic aerial stock footage from Ireland and beyond, ready for documentary, brand, editorial, and commercial licensing work.",
-    link: "/gallery/digital",
+    link: "/gallery-gate?next=/gallery/digital",
     cta: "Browse Clips",
     icon: <FaVideo className="h-10 w-10 text-paper" />,
   },
@@ -94,7 +94,7 @@ export function HomeHeroSection() {
             </Link>
 
             <Link
-              href="/gallery/digital"
+              href="/gallery-gate?next=/gallery/digital"
               className="w-full max-w-xs rounded-full border border-white/20 bg-black/20 px-8 py-4 font-medium text-white backdrop-blur-sm transition-all hover:border-white hover:bg-white/30 sm:w-auto"
             >
               Browse Footage

--- a/openeire-next/components/layout/Footer.tsx
+++ b/openeire-next/components/layout/Footer.tsx
@@ -96,7 +96,7 @@ export function Footer() {
             <ul className="space-y-3 text-sm">
               <FooterLink href="/art-prints">Art Prints</FooterLink>
               <FooterLink href="/licensing">Licensing</FooterLink>
-              <FooterLink href="/gallery/digital">Stock Footage</FooterLink>
+              <FooterLink href="/gallery-gate?next=/gallery/digital">Stock Footage</FooterLink>
               <FooterLink href="/real-estate">Services</FooterLink>
               <FooterLink href="/blog">Journal</FooterLink>
               <FooterLink href="/about">Our Story</FooterLink>

--- a/openeire-next/components/profile/GalleryAccessPanel.tsx
+++ b/openeire-next/components/profile/GalleryAccessPanel.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import Link from "next/link";
+import { FaCheckCircle, FaLock } from "react-icons/fa";
+import type { UserProfile } from "@/types/auth";
+
+export function GalleryAccessPanel({ user }: { user: UserProfile }) {
+  const hasAccess = Boolean(user.can_access_gallery);
+
+  return (
+    <section aria-labelledby="gallery-access-heading">
+      <div className="mb-8 border-b border-white/10 pb-4">
+        <h3
+          id="gallery-access-heading"
+          className="font-serif text-3xl font-bold text-white"
+        >
+          Gallery Access
+        </h3>
+        <p className="mt-2 max-w-2xl text-sm text-gray-400">
+          Your account access to the private digital photo and video collection.
+        </p>
+      </div>
+
+      <div
+        className={`rounded-2xl border p-6 md:p-8 ${
+          hasAccess
+            ? "border-brand-500/30 bg-brand-500/10"
+            : "border-white/10 bg-black/30"
+        }`}
+      >
+        <div className="flex flex-col gap-5 sm:flex-row sm:items-start">
+          <div
+            className={`flex h-12 w-12 shrink-0 items-center justify-center rounded-full ${
+              hasAccess ? "bg-brand-500 text-paper" : "bg-white/10 text-gray-400"
+            }`}
+          >
+            {hasAccess ? (
+              <FaCheckCircle aria-hidden="true" />
+            ) : (
+              <FaLock aria-hidden="true" />
+            )}
+          </div>
+          <div className="min-w-0 flex-1">
+            <p className="text-xs font-bold uppercase tracking-[0.25em] text-accent">
+              {hasAccess ? "Access granted" : "Access not granted"}
+            </p>
+            <h4 className="mt-2 font-serif text-2xl font-bold text-white">
+              {hasAccess
+                ? "Private gallery unlocked"
+                : "Request or verify gallery access"}
+            </h4>
+            <p className="mt-3 text-sm leading-relaxed text-gray-400">
+              {hasAccess
+                ? "This account can access the private digital gallery. Backend permissions remain the source of truth for protected media."
+                : "Request an access code, then verify it while signed in with the same email address."}
+            </p>
+            <div className="mt-6 flex flex-col gap-3 sm:flex-row">
+              <Link
+                href={hasAccess ? "/gallery/digital" : "/gallery-gate?next=/gallery/digital"}
+                className="inline-flex justify-center rounded-lg bg-brand-500 px-5 py-3 text-sm font-bold text-paper transition-colors hover:bg-brand-700"
+              >
+                {hasAccess ? "Open Private Gallery" : "Request / Verify Access"}
+              </Link>
+              {!hasAccess ? (
+                <Link
+                  href="/gallery/physical"
+                  className="inline-flex justify-center rounded-lg border border-white/15 px-5 py-3 text-sm font-bold text-gray-300 transition-colors hover:border-white/30 hover:text-white"
+                >
+                  Browse Public Prints
+                </Link>
+              ) : null}
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/openeire-next/components/profile/ProfilePageClient.tsx
+++ b/openeire-next/components/profile/ProfilePageClient.tsx
@@ -14,6 +14,7 @@ import {
 import { useAuth } from "@/components/auth/AuthProvider";
 import { AccountSecurityPanel } from "@/components/profile/AccountSecurityPanel";
 import { DigitalEntitlementsSection } from "@/components/profile/DigitalEntitlementsSection";
+import { GalleryAccessPanel } from "@/components/profile/GalleryAccessPanel";
 import { OrderHistorySection } from "@/components/profile/OrderHistorySection";
 import { ProfileEditForm } from "@/components/profile/ProfileEditForm";
 import { useToast } from "@/components/ui/ToastProvider";
@@ -73,9 +74,9 @@ const accountSections: Array<{
   {
     id: "gallery",
     label: "Gallery Access",
-    description: "Future home for private gallery access status.",
+    description: "View and manage private gallery access status.",
     icon: FaImages,
-    available: false,
+    available: true,
   },
 ];
 
@@ -319,6 +320,10 @@ export function ProfilePageClient() {
 
               {activeSection === "licences" ? (
                 <DigitalEntitlementsSection mode="licences" />
+              ) : null}
+
+              {activeSection === "gallery" ? (
+                <GalleryAccessPanel user={user} />
               ) : null}
             </div>
           </main>

--- a/openeire-next/lib/api/gallery.ts
+++ b/openeire-next/lib/api/gallery.ts
@@ -1,6 +1,7 @@
 import { api, isApiError } from "@/lib/api/client";
 import type {
   PaginatedResponse,
+  DigitalGalleryFilter,
   PublicGalleryItem,
   PublicGalleryType,
   PublicPhysicalProductDetail,
@@ -51,6 +52,39 @@ export const getPublicGalleryItems = async (
   });
 
   return asGalleryPage(response.data);
+};
+
+export const getProtectedDigitalGalleryItems = async (
+  query: Omit<GalleryQuery, "type"> & {
+    itemType?: DigitalGalleryFilter;
+    signal?: AbortSignal;
+  } = {},
+): Promise<PaginatedResponse<PublicGalleryItem>> => {
+  const response = await api.get<
+    PublicGalleryItem[] | PaginatedResponse<PublicGalleryItem>
+  >("gallery/", {
+    params: {
+      type: "digital",
+      collection:
+        !query.collection || query.collection === "all"
+          ? undefined
+          : query.collection,
+      search: query.search,
+      sort: query.sort ?? "date_desc",
+      page: query.page,
+    },
+    cache: "no-store",
+    signal: query.signal,
+    retryOnAuthRefresh: true,
+  });
+
+  const page = asGalleryPage(response.data);
+  if (!query.itemType || query.itemType === "all") return page;
+
+  return {
+    ...page,
+    results: page.results.filter((item) => item.product_type === query.itemType),
+  };
 };
 
 export const getPublicPhysicalProduct = async (

--- a/openeire-next/lib/api/galleryAccess.ts
+++ b/openeire-next/lib/api/galleryAccess.ts
@@ -1,0 +1,28 @@
+import { api } from "@/lib/api/client";
+import type {
+  GalleryAccessRequestPayload,
+  GalleryAccessRequestResponse,
+  GalleryAccessVerifyPayload,
+  GalleryAccessVerifyResponse,
+} from "@/types/galleryAccess";
+
+export const requestGalleryAccess = async (
+  payload: GalleryAccessRequestPayload,
+): Promise<GalleryAccessRequestResponse> => {
+  const response = await api.post<GalleryAccessRequestResponse>(
+    "gallery-request/",
+    payload,
+  );
+  return response.data;
+};
+
+export const verifyGalleryAccess = async (
+  payload: GalleryAccessVerifyPayload,
+): Promise<GalleryAccessVerifyResponse> => {
+  const response = await api.post<GalleryAccessVerifyResponse>(
+    "gallery-verify/",
+    payload,
+    { retryOnAuthRefresh: true },
+  );
+  return response.data;
+};

--- a/openeire-next/lib/gallery/accessIntent.ts
+++ b/openeire-next/lib/gallery/accessIntent.ts
@@ -1,0 +1,51 @@
+const REQUESTED_EMAIL_KEY = "galleryRequestedEmail";
+const PENDING_CODE_KEY = "pendingGalleryAccessCode";
+const REDIRECT_KEY = "pendingGalleryRedirect";
+
+const isBrowser = () => typeof window !== "undefined";
+
+const normalizeEmail = (value?: string | null): string =>
+  (value ?? "").trim().toLowerCase();
+
+export const getRequestedGalleryEmail = (): string => {
+  if (!isBrowser()) return "";
+  return normalizeEmail(sessionStorage.getItem(REQUESTED_EMAIL_KEY));
+};
+
+export const setRequestedGalleryEmail = (email: string): void => {
+  if (!isBrowser()) return;
+  const normalized = normalizeEmail(email);
+  if (!normalized) return;
+  sessionStorage.setItem(REQUESTED_EMAIL_KEY, normalized);
+};
+
+export const getPendingGalleryCode = (): string => {
+  if (!isBrowser()) return "";
+  return (sessionStorage.getItem(PENDING_CODE_KEY) ?? "").trim().toUpperCase();
+};
+
+export const setPendingGalleryCode = (code: string): void => {
+  if (!isBrowser()) return;
+  const normalized = code.trim().toUpperCase();
+  if (!normalized) return;
+  sessionStorage.setItem(PENDING_CODE_KEY, normalized);
+};
+
+export const getPendingGalleryRedirect = (): string => {
+  if (!isBrowser()) return "";
+  const value = sessionStorage.getItem(REDIRECT_KEY) ?? "";
+  return value.startsWith("/") && !value.startsWith("//") ? value : "";
+};
+
+export const setPendingGalleryRedirect = (path: string): void => {
+  if (!isBrowser()) return;
+  if (!path.startsWith("/") || path.startsWith("//")) return;
+  sessionStorage.setItem(REDIRECT_KEY, path);
+};
+
+export const clearGalleryAccessIntent = (): void => {
+  if (!isBrowser()) return;
+  sessionStorage.removeItem(REQUESTED_EMAIL_KEY);
+  sessionStorage.removeItem(PENDING_CODE_KEY);
+  sessionStorage.removeItem(REDIRECT_KEY);
+};

--- a/openeire-next/types/gallery.ts
+++ b/openeire-next/types/gallery.ts
@@ -1,5 +1,6 @@
 export type GalleryProductType = "physical" | "photo" | "video";
 export type PublicGalleryType = "physical" | "all";
+export type DigitalGalleryFilter = "all" | "photo" | "video";
 
 export interface PaginatedResponse<T> {
   count: number;

--- a/openeire-next/types/galleryAccess.ts
+++ b/openeire-next/types/galleryAccess.ts
@@ -1,0 +1,17 @@
+export interface GalleryAccessRequestPayload {
+  email: string;
+}
+
+export interface GalleryAccessRequestResponse {
+  message: string;
+}
+
+export interface GalleryAccessVerifyPayload {
+  access_code: string;
+}
+
+export interface GalleryAccessVerifyResponse {
+  message: string;
+  expires_at?: string | null;
+  valid?: boolean;
+}


### PR DESCRIPTION
## Summary

Migrates the private gallery access flow and `/gallery/digital` listing into `openeire-next`. Approved users can now enter the private digital gallery, while users without access are routed through the gallery gate request/verify flow.

## Why

This closes the remaining gallery migration gap after the profile/customer area work: private gallery access status now connects to an actual protected digital gallery listing instead of a pending placeholder.

## Screenshots / Demo

- [ ] Not needed
- [ ] Added (attach screenshots / short Loom link)

## Changes

- Backend:
  - No backend changes.
  - Existing endpoints/contracts preserved: `POST /api/gallery-request/`, `POST /api/gallery-verify/`, `GET /api/auth/profile/`, `GET /api/gallery/?type=digital`.

- Frontend:
  - Added `/gallery-gate` request/verify flow with safe internal redirect handling.
  - Added Profile → Gallery Access status panel.
  - Updated protected gallery CTAs to route through `/gallery-gate?next=/gallery/digital`.
  - Replaced `/gallery/digital` placeholder with a client-side protected digital gallery listing.
  - Added digital Photo/Video cards and type filtering.
  - Reused gallery hero/search/sort styling from the art prints gallery.
  - Disabled prefetching for protected digital detail links.
  - Kept private gallery pages `noindex`.
  - Auto-redirects already-approved users from gallery gate to the safe next path.

- Infra/Config:
  - No infra/config changes.

## Testing

- [ ] Django tests pass locally
- [x] React build passes locally
- [x] Manual smoke test done

### Manual smoke test checklist (quick)

- [ ] No console errors
- [ ] Forms submit correctly (success + validation errors)
- [x] API errors handled (loading/error states)
- [ ] Mobile layout checked
- [x] Auth/permissions verified (if relevant)

Validated with:

```
npm.cmd run lint
npm.cmd run build
npm.cmd audit
npm.cmd audit --omit=dev
```

Notes:
- Initial sandboxed build hit the known Windows `spawn EPERM`; rerun with approved escalation passed.
- `npm.cmd audit` and `npm.cmd audit --omit=dev` both reported 0 vulnerabilities.

## Risk & Rollback

Risk level: Medium

Rollback plan:

- [x] Revert PR
- [ ] Feature flag off
- [ ] Hotfix path described:

Primary risk is auth/access flow UX around the migrated private gallery. Backend permissions remain the source of truth, private items are client-fetched only after confirmed profile access, and protected links are not prefetched.

## Notes for Reviewer (Codex/Copilot)

Focus review on:

- [x] Security (auth, permissions, file uploads, CSRF/CORS)
- [x] Performance (N+1 queries, heavy renders, unnecessary requests)
- [x] Maintainability (naming, structure, duplicated logic)

Specific review areas:
- Safe redirect validation in `GalleryGateClient`.
- `can_access_gallery` profile-state handling.
- `cache: "no-store"` on protected digital gallery fetches.
- No private gallery data in server HTML, metadata, sitemap, or JSON-LD.
- No protected detail page prefetching.