### PR TITLE
Migrate protected digital gallery detail pages

### DIFF
--- a/openeire-next/app/gallery/photo/[id]/page.tsx
+++ b/openeire-next/app/gallery/photo/[id]/page.tsx
@@ -1,15 +1,28 @@
-import { PrivateGalleryAccessShell } from "@/components/gallery/PrivateGalleryAccessShell";
+import { Suspense } from "react";
+import { DigitalGalleryDetailClient } from "@/components/gallery/DigitalGalleryDetailClient";
 
 export const metadata = {
   title: "Private Photo | OpenÉire Studios",
   robots: { index: false, follow: false },
 };
 
-export default function PhotoDetailGatePage() {
+export default async function PhotoDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+
   return (
-    <PrivateGalleryAccessShell
-      title="Private photo"
-      pendingTitle="Private photo details pending migration"
-    />
+    <Suspense
+      fallback={
+        <div className="page-top-offset flex min-h-screen items-center justify-center bg-black px-4 pb-24 text-center text-white">
+          <div className="h-12 w-12 animate-spin rounded-full border-2 border-accent border-t-transparent" />
+          <span className="sr-only">Loading private photo</span>
+        </div>
+      }
+    >
+      <DigitalGalleryDetailClient id={id} type="photo" />
+    </Suspense>
   );
 }

--- a/openeire-next/app/gallery/video/[id]/page.tsx
+++ b/openeire-next/app/gallery/video/[id]/page.tsx
@@ -1,15 +1,28 @@
-import { PrivateGalleryAccessShell } from "@/components/gallery/PrivateGalleryAccessShell";
+import { Suspense } from "react";
+import { DigitalGalleryDetailClient } from "@/components/gallery/DigitalGalleryDetailClient";
 
 export const metadata = {
   title: "Private Video | OpenÉire Studios",
   robots: { index: false, follow: false },
 };
 
-export default function VideoDetailGatePage() {
+export default async function VideoDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+
   return (
-    <PrivateGalleryAccessShell
-      title="Private video"
-      pendingTitle="Private video details pending migration"
-    />
+    <Suspense
+      fallback={
+        <div className="page-top-offset flex min-h-screen items-center justify-center bg-black px-4 pb-24 text-center text-white">
+          <div className="h-12 w-12 animate-spin rounded-full border-2 border-accent border-t-transparent" />
+          <span className="sr-only">Loading private video</span>
+        </div>
+      }
+    >
+      <DigitalGalleryDetailClient id={id} type="video" />
+    </Suspense>
   );
 }

--- a/openeire-next/components/gallery/CommercialLicenceRequestModal.tsx
+++ b/openeire-next/components/gallery/CommercialLicenceRequestModal.tsx
@@ -1,0 +1,465 @@
+"use client";
+
+import {
+  useEffect,
+  useMemo,
+  useState,
+  type ChangeEvent,
+  type FormEvent,
+  type ReactNode,
+} from "react";
+import { FaTimes } from "react-icons/fa";
+import { useAuth } from "@/components/auth/AuthProvider";
+import { useToast } from "@/components/ui/ToastProvider";
+import { normalizeAuthErrorMessage } from "@/lib/api/auth";
+import { submitLicenseRequest } from "@/lib/api/licenseRequests";
+import type {
+  LicenceAssetType,
+  LicenseRequestPayload,
+} from "@/types/licenseRequests";
+
+type LicenseRequestFormData = Omit<
+  LicenseRequestPayload,
+  "asset_id" | "asset_type"
+>;
+
+interface CommercialLicenceRequestModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  assetId: number;
+  assetType: LicenceAssetType;
+  assetTitle: string;
+}
+
+const getInitialFormData = (): LicenseRequestFormData => ({
+  client_name: "",
+  company: "",
+  email: "",
+  project_type: "COMMERCIAL",
+  duration: "1_YEAR",
+  territory: "IRELAND",
+  permitted_media: "WEB_SOCIAL",
+  reach_caps: "",
+  exclusivity: "NON_EXCLUSIVE",
+  message: "",
+});
+
+const getUserDisplayName = (
+  user: ReturnType<typeof useAuth>["user"],
+): string => {
+  const fullName = [user?.first_name, user?.last_name]
+    .filter(Boolean)
+    .join(" ")
+    .trim();
+  return fullName || user?.username || "";
+};
+
+export function CommercialLicenceRequestModal({
+  isOpen,
+  onClose,
+  assetId,
+  assetType,
+  assetTitle,
+}: CommercialLicenceRequestModalProps) {
+  const { isAuthenticated, user } = useAuth();
+  const { showToast } = useToast();
+  const [formData, setFormData] = useState<LicenseRequestFormData>(
+    getInitialFormData,
+  );
+  const [agreements, setAgreements] = useState({ merch: false, ai: false });
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const shouldLockEmail = Boolean(isAuthenticated && user?.email);
+  const canSubmit = agreements.merch && agreements.ai && !isSubmitting;
+
+  const accountEmailMessage = useMemo(() => {
+    if (!shouldLockEmail || !user?.email) return null;
+    return `Signed-in licence requests use your account email: ${user.email}`;
+  }, [shouldLockEmail, user?.email]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    setFormData({
+      ...getInitialFormData(),
+      client_name: getUserDisplayName(user),
+      email: user?.email ?? "",
+    });
+    setAgreements({ merch: false, ai: false });
+    setIsSubmitting(false);
+    setErrorMessage(null);
+  }, [isOpen, user]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const scrollY = window.scrollY;
+    const originalBodyOverflow = document.body.style.overflow;
+    const originalBodyPosition = document.body.style.position;
+    const originalBodyTop = document.body.style.top;
+    const originalBodyWidth = document.body.style.width;
+
+    document.body.style.overflow = "hidden";
+    document.body.style.position = "fixed";
+    document.body.style.top = `-${scrollY}px`;
+    document.body.style.width = "100%";
+
+    return () => {
+      document.body.style.overflow = originalBodyOverflow;
+      document.body.style.position = originalBodyPosition;
+      document.body.style.top = originalBodyTop;
+      document.body.style.width = originalBodyWidth;
+      window.scrollTo({ top: scrollY, behavior: "auto" });
+    };
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape" && !isSubmitting) {
+        onClose();
+      }
+    };
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [isOpen, isSubmitting, onClose]);
+
+  if (!isOpen) return null;
+
+  const handleFieldChange = (
+    event: ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>,
+  ) => {
+    const { name, value } = event.target;
+    setFormData((current) => ({ ...current, [name]: value }));
+  };
+
+  const handleAgreementChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const { name, checked } = event.target;
+    setAgreements((current) => ({ ...current, [name]: checked }));
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setErrorMessage(null);
+
+    if (!agreements.merch || !agreements.ai) {
+      setErrorMessage("Please confirm the licence terms before submitting.");
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      await submitLicenseRequest({
+        ...formData,
+        client_name: formData.client_name.trim(),
+        company: formData.company?.trim(),
+        email: formData.email.trim(),
+        reach_caps: formData.reach_caps?.trim(),
+        message: formData.message?.trim(),
+        asset_id: assetId,
+        asset_type: assetType,
+      });
+      showToast(
+        "Licence request submitted. We will be in touch shortly with a custom quote.",
+        "success",
+      );
+      onClose();
+    } catch (error) {
+      setErrorMessage(
+        normalizeAuthErrorMessage(
+          error,
+          "Could not submit your licence request. Please review the form and try again.",
+        ),
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div
+      className="fixed inset-0 z-[90] flex items-center justify-center p-4 sm:p-6"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="commercial-licence-modal-title"
+      aria-describedby="commercial-licence-modal-description"
+    >
+      <button
+        type="button"
+        className="fixed inset-0 cursor-default bg-black/80 backdrop-blur-sm"
+        aria-label="Close commercial licence request"
+        onClick={() => {
+          if (!isSubmitting) onClose();
+        }}
+      />
+
+      <div className="relative flex max-h-[calc(100dvh-2rem)] w-full max-w-2xl flex-col overflow-hidden rounded-2xl border border-white/10 bg-gray-900 shadow-2xl">
+        <div className="flex items-start justify-between gap-4 border-b border-white/10 bg-gray-900 p-6">
+          <div>
+            <h2
+              id="commercial-licence-modal-title"
+              className="font-serif text-xl font-bold text-white"
+            >
+              Request Commercial Licence
+            </h2>
+            <p
+              id="commercial-licence-modal-description"
+              className="mt-1 text-xs uppercase tracking-widest text-gray-400"
+            >
+              For: {assetTitle}
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={isSubmitting}
+            className="shrink-0 rounded-full p-2 text-gray-400 transition-colors hover:bg-white/10 hover:text-white disabled:cursor-not-allowed disabled:opacity-50"
+            aria-label="Close commercial licence request"
+          >
+            <FaTimes aria-hidden="true" />
+          </button>
+        </div>
+
+        <form
+          onSubmit={handleSubmit}
+          className="space-y-5 overflow-y-auto overscroll-contain p-6"
+        >
+          {errorMessage ? (
+            <div className="rounded-xl border border-red-500/30 bg-red-950/40 px-4 py-3 text-sm text-red-100">
+              {errorMessage}
+            </div>
+          ) : null}
+
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            <Field label="Full Name" inputId="licence-client-name" required>
+              <input
+                id="licence-client-name"
+                required
+                type="text"
+                name="client_name"
+                value={formData.client_name}
+                onChange={handleFieldChange}
+                className="w-full rounded-lg border border-white/20 bg-black p-3 text-white outline-none focus:border-accent"
+              />
+            </Field>
+            <Field label="Company / Agency" inputId="licence-company">
+              <input
+                id="licence-company"
+                type="text"
+                name="company"
+                value={formData.company}
+                onChange={handleFieldChange}
+                className="w-full rounded-lg border border-white/20 bg-black p-3 text-white outline-none focus:border-accent"
+              />
+            </Field>
+          </div>
+
+          <Field label="Email Address" inputId="licence-email" required>
+            <input
+              id="licence-email"
+              required
+              type="email"
+              name="email"
+              value={formData.email}
+              onChange={handleFieldChange}
+              readOnly={shouldLockEmail}
+              aria-readonly={shouldLockEmail}
+              className={[
+                "w-full rounded-lg border border-white/20 bg-black p-3 text-white outline-none focus:border-accent",
+                shouldLockEmail ? "cursor-not-allowed opacity-80" : "",
+              ].join(" ")}
+            />
+            {accountEmailMessage ? (
+              <p className="mt-2 text-xs text-gray-500">
+                {accountEmailMessage}
+              </p>
+            ) : null}
+          </Field>
+
+          <div className="border-t border-white/10 pt-4">
+            <h3 className="text-sm font-bold text-white">
+              Licence Schedule Details
+            </h3>
+          </div>
+
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+            <Field label="Project Type" inputId="licence-project-type" required>
+              <select
+                id="licence-project-type"
+                name="project_type"
+                value={formData.project_type}
+                onChange={handleFieldChange}
+                className="w-full appearance-none rounded-lg border border-white/20 bg-black p-3 text-white outline-none focus:border-accent"
+              >
+                <option value="REAL_ESTATE">Real Estate / Property</option>
+                <option value="CORPORATE">Corporate / B2B</option>
+                <option value="EDITORIAL">Editorial / Documentary</option>
+                <option value="COMMERCIAL">Commercial / Advertising</option>
+                <option value="OTHER">Other</option>
+              </select>
+            </Field>
+            <Field label="Permitted Media" inputId="licence-permitted-media" required>
+              <select
+                id="licence-permitted-media"
+                name="permitted_media"
+                value={formData.permitted_media}
+                onChange={handleFieldChange}
+                className="w-full appearance-none rounded-lg border border-white/20 bg-black p-3 text-white outline-none focus:border-accent"
+              >
+                <option value="WEB_SOCIAL">Web & Organic Social Only</option>
+                <option value="PAID_DIGITAL">Paid Digital Ads</option>
+                <option value="PRINT_BROCHURE">Print & Brochure</option>
+                <option value="BROADCAST">TV / Broadcast / Cinema</option>
+                <option value="ALL_MEDIA">All Media</option>
+              </select>
+            </Field>
+          </div>
+
+          <div className="grid grid-cols-1 gap-4 md:grid-cols-3">
+            <Field label="Territory" inputId="licence-territory" required>
+              <select
+                id="licence-territory"
+                name="territory"
+                value={formData.territory}
+                onChange={handleFieldChange}
+                className="w-full appearance-none rounded-lg border border-white/20 bg-black p-3 text-white outline-none focus:border-accent"
+              >
+                <option value="IRELAND">Ireland Only</option>
+                <option value="EU">EU / UK</option>
+                <option value="US_NA">US / North America</option>
+                <option value="SOUTH_AMERICA">South America</option>
+                <option value="ASIA">Asia</option>
+                <option value="AFRICA">Africa</option>
+                <option value="OCEANIA">Oceania</option>
+                <option value="WORLDWIDE">Worldwide</option>
+              </select>
+            </Field>
+            <Field label="Duration" inputId="licence-duration" required>
+              <select
+                id="licence-duration"
+                name="duration"
+                value={formData.duration}
+                onChange={handleFieldChange}
+                className="w-full appearance-none rounded-lg border border-white/20 bg-black p-3 text-white outline-none focus:border-accent"
+              >
+                <option value="1_MONTH">1 Month</option>
+                <option value="3_MONTHS">3 Months</option>
+                <option value="6_MONTHS">6 Months</option>
+                <option value="1_YEAR">1 Year</option>
+                <option value="2_YEARS">2 Years</option>
+                <option value="5_YEARS">5 Years</option>
+                <option value="PERPETUAL">Perpetual</option>
+                <option value="OTHER">Other</option>
+              </select>
+            </Field>
+            <Field label="Exclusivity" inputId="licence-exclusivity" required>
+              <select
+                id="licence-exclusivity"
+                name="exclusivity"
+                value={formData.exclusivity}
+                onChange={handleFieldChange}
+                className="w-full appearance-none rounded-lg border border-white/20 bg-black p-3 text-white outline-none focus:border-accent"
+              >
+                <option value="NON_EXCLUSIVE">Non-Exclusive</option>
+                <option value="CATEGORY">Category Exclusive</option>
+                <option value="FULL">Fully Exclusive</option>
+              </select>
+            </Field>
+          </div>
+
+          <Field label="Additional Details" inputId="licence-message">
+            <textarea
+              id="licence-message"
+              name="message"
+              value={formData.message}
+              onChange={handleFieldChange}
+              rows={3}
+              maxLength={2000}
+              placeholder="Include reach caps if applicable, such as audience size, ad spend, or print run limits..."
+              className="w-full resize-none rounded-lg border border-white/20 bg-black p-3 text-white outline-none focus:border-accent"
+            />
+          </Field>
+
+          <div className="space-y-3 rounded-xl border border-white/10 bg-white/5 p-4">
+            <p className="text-xs font-bold uppercase tracking-widest text-gray-400">
+              Required Legal Affirmations
+            </p>
+            <label className="flex cursor-pointer items-start gap-3">
+              <input
+                type="checkbox"
+                name="merch"
+                checked={agreements.merch}
+                onChange={handleAgreementChange}
+                className="mt-1 h-4 w-4 rounded border-gray-600 bg-black text-accent focus:ring-accent"
+              />
+              <span className="text-xs leading-relaxed text-gray-300">
+                I understand this is a digital licence, not a transfer of
+                ownership. This licence prohibits using the asset as the primary
+                value component of merchandise or Print-on-Demand products for
+                resale.
+              </span>
+            </label>
+            <label className="flex cursor-pointer items-start gap-3">
+              <input
+                type="checkbox"
+                name="ai"
+                checked={agreements.ai}
+                onChange={handleAgreementChange}
+                className="mt-1 h-4 w-4 rounded border-gray-600 bg-black text-accent focus:ring-accent"
+              />
+              <span className="text-xs leading-relaxed text-gray-300">
+                I agree not to use, upload, or embed the asset for AI/ML
+                training, dataset creation, generative model fine-tuning, or NFT
+                minting.
+              </span>
+            </label>
+          </div>
+
+          <div className="border-t border-white/10 pt-4">
+            <button
+              type="submit"
+              disabled={!canSubmit}
+              className={[
+                "w-full rounded-xl py-4 text-lg font-bold transition-all shadow-lg",
+                canSubmit
+                  ? "bg-white text-black hover:bg-gray-200 active:scale-[0.98]"
+                  : "cursor-not-allowed bg-gray-700 text-gray-400",
+              ].join(" ")}
+            >
+              {isSubmitting ? "Submitting..." : "Submit Licence Request"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+function Field({
+  children,
+  inputId,
+  label,
+  required = false,
+}: {
+  children: ReactNode;
+  inputId: string;
+  label: string;
+  required?: boolean;
+}) {
+  return (
+    <div>
+      <label
+        htmlFor={inputId}
+        className="mb-2 block text-xs uppercase tracking-widest text-gray-500"
+      >
+        {label}
+        {required ? " *" : ""}
+      </label>
+      {children}
+    </div>
+  );
+}

--- a/openeire-next/components/gallery/DigitalGalleryDetailClient.tsx
+++ b/openeire-next/components/gallery/DigitalGalleryDetailClient.tsx
@@ -1,0 +1,441 @@
+"use client";
+
+/* eslint-disable @next/next/no-img-element */
+import Link from "next/link";
+import { usePathname, useRouter } from "next/navigation";
+import { useEffect, useMemo, useState } from "react";
+import {
+  FaArrowLeft,
+  FaCalendarAlt,
+  FaFileContract,
+  FaImage,
+  FaShoppingBag,
+  FaVideo,
+} from "react-icons/fa";
+import { useAuth } from "@/components/auth/AuthProvider";
+import { CommercialLicenceRequestModal } from "@/components/gallery/CommercialLicenceRequestModal";
+import { DigitalGalleryCard } from "@/components/gallery/DigitalGalleryCard";
+import { ProductMediaPreview } from "@/components/gallery/ProductMediaPreview";
+import { SpecBox } from "@/components/gallery/SpecBox";
+import { isApiError } from "@/lib/api/client";
+import { getProtectedDigitalDetail } from "@/lib/api/gallery";
+import { formatEuro, getStartingPrice, splitTags } from "@/lib/gallery/format";
+import { resolveMediaUrl } from "@/lib/media";
+import type { ProtectedDigitalDetail } from "@/types/gallery";
+
+type DetailKind = "photo" | "video";
+type DetailLoadState = "idle" | "loading" | "success" | "notFound" | "error";
+
+const buildGateHref = (pathname: string | null): string =>
+  `/gallery-gate?next=${encodeURIComponent(pathname || "/gallery/digital")}`;
+
+const formatDate = (value?: string | null): string | null => {
+  if (!value) return null;
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return null;
+  return new Intl.DateTimeFormat("en-IE", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+  }).format(parsed);
+};
+
+const formatDuration = (value?: number | string | null): string => {
+  if (value === undefined || value === null || value === "") return "N/A";
+  const seconds = Number(value);
+  if (!Number.isFinite(seconds) || seconds <= 0) return String(value);
+
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = Math.round(seconds % 60);
+  if (minutes <= 0) return `${remainingSeconds}s`;
+  return `${minutes}:${String(remainingSeconds).padStart(2, "0")}`;
+};
+
+const getLoadErrorMessage = (error: unknown): string => {
+  if (isApiError(error)) {
+    if (error.response?.status === 404) {
+      return "not-found";
+    }
+    if (error.response?.status === 401 || error.response?.status === 403) {
+      return "access-denied";
+    }
+  }
+  return "This private asset could not be loaded right now. Please try again shortly.";
+};
+
+function VideoPreview({
+  posterUrl,
+  title,
+  videoUrl,
+}: {
+  posterUrl?: string;
+  title: string;
+  videoUrl?: string;
+}) {
+  if (!videoUrl) {
+    return (
+      <div className="relative flex aspect-video min-h-80 w-full items-center justify-center overflow-hidden bg-gray-900 px-8 text-center text-gray-500">
+        {posterUrl ? (
+          <img
+            src={posterUrl}
+            alt={title}
+            className="absolute inset-0 h-full w-full object-cover opacity-35 blur-sm"
+          />
+        ) : null}
+        <div className="relative z-10 flex flex-col items-center gap-3">
+          <FaVideo className="text-4xl" aria-hidden="true" />
+          <p>Video preview unavailable</p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <video
+      src={videoUrl}
+      poster={posterUrl}
+      controls
+      preload="metadata"
+      playsInline
+      className="block h-auto max-h-[75vh] w-auto max-w-full bg-black shadow-lg"
+    >
+      <track kind="captions" />
+    </video>
+  );
+}
+
+export function DigitalGalleryDetailClient({
+  id,
+  type,
+}: {
+  id: string;
+  type: DetailKind;
+}) {
+  const pathname = usePathname();
+  const router = useRouter();
+  const { isLoading: isAuthLoading, user } = useAuth();
+  const [detail, setDetail] = useState<ProtectedDigitalDetail | null>(null);
+  const [loadState, setLoadState] = useState<DetailLoadState>("idle");
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [isLicenceModalOpen, setIsLicenceModalOpen] = useState(false);
+
+  const hasGalleryAccess = Boolean(user?.can_access_gallery);
+  const gateHref = buildGateHref(pathname);
+
+  useEffect(() => {
+    if (!isAuthLoading && !hasGalleryAccess) {
+      router.replace(gateHref);
+    }
+  }, [gateHref, hasGalleryAccess, isAuthLoading, router]);
+
+  useEffect(() => {
+    if (isAuthLoading || !hasGalleryAccess) {
+      setDetail(null);
+      setLoadState("idle");
+      return;
+    }
+
+    const controller = new AbortController();
+    setLoadState("loading");
+    setErrorMessage(null);
+
+    getProtectedDigitalDetail(type, id, { signal: controller.signal })
+      .then((payload) => {
+        if (controller.signal.aborted) return;
+        setDetail(payload);
+        setLoadState("success");
+      })
+      .catch((error) => {
+        if (controller.signal.aborted) return;
+        const message = getLoadErrorMessage(error);
+        if (message === "access-denied") {
+          router.replace(gateHref);
+          return;
+        }
+        setDetail(null);
+        setLoadState(message === "not-found" ? "notFound" : "error");
+        setErrorMessage(message === "not-found" ? null : message);
+      });
+
+    return () => {
+      controller.abort();
+    };
+  }, [gateHref, hasGalleryAccess, id, isAuthLoading, router, type]);
+
+  const media = useMemo(() => {
+    if (!detail) return { imageUrl: undefined, videoUrl: undefined };
+    return {
+      imageUrl: resolveMediaUrl(detail.preview_image || detail.thumbnail_image),
+      videoUrl:
+        detail.product_type === "video"
+          ? resolveMediaUrl(detail.preview_video_url)
+          : undefined,
+    };
+  }, [detail]);
+
+  if (isAuthLoading) {
+    return (
+      <div className="page-top-offset flex min-h-screen items-center justify-center bg-black px-4 pb-24 text-center text-white">
+        <div className="h-12 w-12 animate-spin rounded-full border-2 border-accent border-t-transparent" />
+        <span className="sr-only">Checking gallery access</span>
+      </div>
+    );
+  }
+
+  if (!hasGalleryAccess) {
+    return (
+      <div className="page-top-offset flex min-h-screen items-center justify-center bg-black px-4 pb-24 text-center text-white">
+        <div className="max-w-md rounded-2xl border border-white/10 bg-gray-900/50 p-8 shadow-2xl">
+          <div className="mx-auto mb-5 h-10 w-10 animate-spin rounded-full border-2 border-accent border-t-transparent" />
+          <p className="text-xs font-bold uppercase tracking-[0.28em] text-accent">
+            Redirecting
+          </p>
+          <h1 className="mt-3 font-serif text-2xl font-bold">
+            Private {type}
+          </h1>
+          <p className="mt-3 text-sm leading-relaxed text-gray-400">
+            Taking you to the private collection access flow.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  if (loadState === "loading" || loadState === "idle") {
+    return (
+      <div className="page-top-offset flex min-h-screen items-center justify-center bg-black px-4 pb-24 text-center text-white">
+        <div className="h-12 w-12 animate-spin rounded-full border-2 border-accent border-t-transparent" />
+        <span className="sr-only">Loading private asset</span>
+      </div>
+    );
+  }
+
+  if (loadState === "notFound") {
+    return (
+      <div className="page-top-offset flex min-h-screen items-center justify-center bg-black px-4 pb-24 text-center text-white">
+        <div className="max-w-xl rounded-2xl border border-white/10 bg-gray-900/50 p-8">
+          <h1 className="font-serif text-3xl font-bold">
+            Private asset not found.
+          </h1>
+          <p className="mt-4 text-gray-400">
+            It may have been removed from the private collection.
+          </p>
+          <Link
+            href="/gallery/digital"
+            className="mt-8 inline-flex items-center justify-center rounded-full border border-white/20 px-6 py-3 text-sm font-semibold text-white transition-colors hover:bg-white/10"
+          >
+            Back to Private Gallery
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  if (loadState === "error" || !detail) {
+    return (
+      <div className="page-top-offset flex min-h-screen items-center justify-center bg-black px-4 pb-24 text-center text-white">
+        <div className="max-w-xl rounded-2xl border border-white/10 bg-gray-900/50 p-8">
+          <h1 className="font-serif text-3xl font-bold">
+            This private asset is unavailable right now.
+          </h1>
+          <p className="mt-4 text-gray-400">{errorMessage}</p>
+          <Link
+            href="/gallery/digital"
+            className="mt-8 inline-flex items-center justify-center rounded-full border border-white/20 px-6 py-3 text-sm font-semibold text-white transition-colors hover:bg-white/10"
+          >
+            Back to Private Gallery
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  const isVideo = detail.product_type === "video";
+  const displayPrice = formatEuro(getStartingPrice(detail));
+  const tags = splitTags(detail.tags);
+  const capturedDate = formatDate(detail.created_at);
+  const relatedProducts = detail.related_products ?? [];
+  const legalTermsHref = "https://openeire.ie/licensing/terms";
+
+  return (
+    <div className="page-top-offset min-h-screen overflow-x-hidden bg-black pb-20 font-sans text-white selection:bg-accent selection:text-black">
+      <div className="container mx-auto px-4 lg:px-8">
+        <nav className="mb-8 flex flex-wrap items-center gap-2 text-xs uppercase tracking-widest text-gray-500">
+          <Link
+            href="/gallery/digital"
+            className="inline-flex items-center gap-2 transition-colors hover:text-accent"
+          >
+            <FaArrowLeft aria-hidden="true" />
+            Private Gallery
+          </Link>
+          <span>/</span>
+          <span className="text-gray-400">{isVideo ? "Video" : "Photo"}</span>
+          <span>/</span>
+          <span className="max-w-50 truncate text-white">{detail.title}</span>
+        </nav>
+
+        <div className="grid grid-cols-1 gap-12 lg:grid-cols-12 lg:gap-20">
+          <div className="lg:col-span-8">
+            <div className="sticky top-32">
+              <div className="relative mx-auto w-fit overflow-hidden rounded-xl border border-white/10 bg-black shadow-2xl">
+                {isVideo ? (
+                  <VideoPreview
+                    posterUrl={media.imageUrl}
+                    title={detail.title}
+                    videoUrl={media.videoUrl}
+                  />
+                ) : (
+                  <ProductMediaPreview
+                    imageUrl={media.imageUrl}
+                    title={detail.title}
+                  />
+                )}
+              </div>
+
+              <div className="mt-8 grid grid-cols-2 gap-px overflow-hidden rounded-lg border border-white/10 bg-white/10 md:grid-cols-4">
+                <SpecBox
+                  label="Resolution"
+                  value={isVideo ? detail.resolution || "High Res" : "High Res"}
+                />
+                <SpecBox
+                  label="Format"
+                  value={isVideo ? "Video Preview" : "Fine Art / JPEG"}
+                />
+                <SpecBox
+                  label="Frame Rate"
+                  value={isVideo ? detail.frame_rate || "N/A" : "N/A"}
+                />
+                <SpecBox
+                  label="Duration"
+                  value={isVideo ? formatDuration(detail.duration) : "N/A"}
+                />
+              </div>
+            </div>
+          </div>
+
+          <div className="lg:col-span-4">
+            <div className="rounded-2xl border border-white/10 bg-gray-900/50 p-6 backdrop-blur-sm md:p-8">
+              <div className="mb-4 inline-flex items-center gap-2 rounded-full border border-accent/20 bg-accent px-3 py-1 text-[10px] font-bold uppercase tracking-[0.22em] text-brand-900">
+                {isVideo ? <FaVideo aria-hidden="true" /> : <FaImage aria-hidden="true" />}
+                {isVideo ? "Video" : "Photo"}
+              </div>
+
+              <h1 className="mb-4 font-serif text-3xl font-bold leading-tight text-white md:text-4xl">
+                {detail.title}
+              </h1>
+
+              {detail.description ? (
+                <p className="mb-8 border-l-2 border-accent pl-4 text-sm leading-relaxed text-gray-400">
+                  {detail.description}
+                </p>
+              ) : null}
+
+              <div className="space-y-4 border-y border-white/10 py-6">
+                <div className="flex items-center justify-between gap-4">
+                  <span className="text-sm text-gray-400">Personal use</span>
+                  <span className="font-serif text-3xl font-bold text-white">
+                    {"\u20AC"}
+                    {displayPrice}
+                  </span>
+                </div>
+                <p className="text-xs leading-relaxed text-gray-500">
+                  Buy this {isVideo ? "video" : "photo"} for personal use.
+                  Commercial usage requires a separate rights-managed licence
+                  request.
+                </p>
+              </div>
+
+              <div className="mt-6 grid gap-3">
+                <button
+                  type="button"
+                  disabled
+                  title="Personal-use cart and checkout will be enabled when the Next checkout migration lands."
+                  className="inline-flex cursor-not-allowed items-center justify-center gap-2 rounded-xl bg-brand-700/60 px-5 py-4 text-sm font-bold text-paper opacity-75"
+                >
+                  <FaShoppingBag aria-hidden="true" />
+                  Add to Cart
+                </button>
+                <p className="-mt-1 text-center text-[11px] leading-relaxed text-gray-500">
+                  Personal-use checkout for digital downloads is pending the
+                  checkout migration.
+                </p>
+
+                <button
+                  type="button"
+                  onClick={() => setIsLicenceModalOpen(true)}
+                  className="inline-flex items-center justify-center gap-2 rounded-xl border-2 border-white/20 px-5 py-4 text-sm font-bold text-white transition-all hover:bg-white hover:text-black active:scale-[0.98]"
+                >
+                  <FaFileContract aria-hidden="true" />
+                  Request Commercial Licence
+                </button>
+
+                <a
+                  href={legalTermsHref}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-center text-xs font-semibold text-gray-500 underline-offset-4 transition-colors hover:text-gray-300 hover:underline"
+                >
+                  View licence terms
+                </a>
+              </div>
+
+              <div className="mt-6 space-y-3 text-sm text-gray-500">
+                {detail.collection ? (
+                  <p>
+                    <span className="font-semibold uppercase tracking-[0.16em] text-gray-400">
+                      Collection:
+                    </span>{" "}
+                    {detail.collection}
+                  </p>
+                ) : null}
+                {capturedDate ? (
+                  <p className="flex items-center gap-2">
+                    <FaCalendarAlt aria-hidden="true" />
+                    Added {capturedDate}
+                  </p>
+                ) : null}
+              </div>
+            </div>
+
+            {tags.length ? (
+              <div className="mt-6 flex flex-wrap gap-2">
+                {tags.slice(0, 12).map((tag) => (
+                  <span
+                    key={tag}
+                    className="rounded-full border border-white/10 bg-white/5 px-3 py-1 text-xs text-gray-400"
+                  >
+                    #{tag}
+                  </span>
+                ))}
+              </div>
+            ) : null}
+          </div>
+        </div>
+
+        {relatedProducts.length ? (
+          <section className="mt-20">
+            <h2 className="mb-8 font-serif text-2xl font-bold text-white">
+              Related Private {isVideo ? "Videos" : "Photos"}
+            </h2>
+            <div className="grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-4">
+              {relatedProducts.map((related) => (
+                <DigitalGalleryCard
+                  key={`${related.product_type}-${related.id}`}
+                  item={related}
+                />
+              ))}
+            </div>
+          </section>
+        ) : null}
+
+        <CommercialLicenceRequestModal
+          isOpen={isLicenceModalOpen}
+          onClose={() => setIsLicenceModalOpen(false)}
+          assetId={detail.id}
+          assetType={detail.product_type}
+          assetTitle={detail.title}
+        />
+      </div>
+    </div>
+  );
+}

--- a/openeire-next/lib/api/gallery.ts
+++ b/openeire-next/lib/api/gallery.ts
@@ -2,6 +2,9 @@ import { api, isApiError } from "@/lib/api/client";
 import type {
   PaginatedResponse,
   DigitalGalleryFilter,
+  ProtectedDigitalDetail,
+  ProtectedPhotoDetail,
+  ProtectedVideoDetail,
   PublicGalleryItem,
   PublicGalleryType,
   PublicPhysicalProductDetail,
@@ -86,6 +89,39 @@ export const getProtectedDigitalGalleryItems = async (
     results: page.results.filter((item) => item.product_type === query.itemType),
   };
 };
+
+export const getProtectedDigitalPhoto = async (
+  id: string | number,
+  options: { signal?: AbortSignal } = {},
+): Promise<ProtectedPhotoDetail> => {
+  const response = await api.get<ProtectedPhotoDetail>(`photos/${id}/`, {
+    cache: "no-store",
+    signal: options.signal,
+    retryOnAuthRefresh: true,
+  });
+  return response.data;
+};
+
+export const getProtectedDigitalVideo = async (
+  id: string | number,
+  options: { signal?: AbortSignal } = {},
+): Promise<ProtectedVideoDetail> => {
+  const response = await api.get<ProtectedVideoDetail>(`videos/${id}/`, {
+    cache: "no-store",
+    signal: options.signal,
+    retryOnAuthRefresh: true,
+  });
+  return response.data;
+};
+
+export const getProtectedDigitalDetail = async (
+  type: "photo" | "video",
+  id: string | number,
+  options: { signal?: AbortSignal } = {},
+): Promise<ProtectedDigitalDetail> =>
+  type === "video"
+    ? getProtectedDigitalVideo(id, options)
+    : getProtectedDigitalPhoto(id, options);
 
 export const getPublicPhysicalProduct = async (
   id: string | number,

--- a/openeire-next/lib/api/licenseRequests.ts
+++ b/openeire-next/lib/api/licenseRequests.ts
@@ -1,0 +1,16 @@
+import { api } from "@/lib/api/client";
+import type {
+  LicenseRequestPayload,
+  LicenseRequestResponse,
+} from "@/types/licenseRequests";
+
+export const submitLicenseRequest = async (
+  payload: LicenseRequestPayload,
+): Promise<LicenseRequestResponse> => {
+  const response = await api.post<LicenseRequestResponse>(
+    "license-requests/",
+    payload,
+    { retryOnAuthRefresh: true },
+  );
+  return response.data;
+};

--- a/openeire-next/types/gallery.ts
+++ b/openeire-next/types/gallery.ts
@@ -48,3 +48,31 @@ export interface PublicPhysicalProductDetail extends PublicGalleryItem {
   review_count?: number | null;
   related_products?: PublicGalleryItem[];
 }
+
+export interface ProtectedPhotoDetail extends PublicGalleryItem {
+  product_type: "photo";
+  description?: string | null;
+  tags?: string | null;
+  created_at?: string | null;
+  variants?: ProductVariant[];
+  average_rating?: number | string | null;
+  review_count?: number | null;
+  related_products?: PublicGalleryItem[];
+}
+
+export interface ProtectedVideoDetail extends PublicGalleryItem {
+  product_type: "video";
+  description?: string | null;
+  tags?: string | null;
+  created_at?: string | null;
+  duration?: number | string | null;
+  resolution?: string | null;
+  frame_rate?: string | null;
+  average_rating?: number | string | null;
+  review_count?: number | null;
+  related_products?: PublicGalleryItem[];
+}
+
+export type ProtectedDigitalDetail =
+  | ProtectedPhotoDetail
+  | ProtectedVideoDetail;

--- a/openeire-next/types/licenseRequests.ts
+++ b/openeire-next/types/licenseRequests.ts
@@ -1,0 +1,57 @@
+export type LicenceAssetType = "photo" | "video";
+
+export type LicenceProjectType =
+  | "REAL_ESTATE"
+  | "CORPORATE"
+  | "EDITORIAL"
+  | "COMMERCIAL"
+  | "OTHER";
+
+export type LicenceDuration =
+  | "1_MONTH"
+  | "3_MONTHS"
+  | "6_MONTHS"
+  | "1_YEAR"
+  | "2_YEARS"
+  | "5_YEARS"
+  | "PERPETUAL"
+  | "OTHER";
+
+export type LicenceTerritory =
+  | "IRELAND"
+  | "EU"
+  | "US_NA"
+  | "SOUTH_AMERICA"
+  | "ASIA"
+  | "AFRICA"
+  | "OCEANIA"
+  | "WORLDWIDE";
+
+export type LicencePermittedMedia =
+  | "WEB_SOCIAL"
+  | "PAID_DIGITAL"
+  | "PRINT_BROCHURE"
+  | "BROADCAST"
+  | "ALL_MEDIA";
+
+export type LicenceExclusivity = "NON_EXCLUSIVE" | "CATEGORY" | "FULL";
+
+export interface LicenseRequestPayload {
+  asset_type: LicenceAssetType;
+  asset_id: number;
+  client_name: string;
+  company?: string;
+  email: string;
+  project_type: LicenceProjectType;
+  duration: LicenceDuration;
+  territory: LicenceTerritory;
+  permitted_media: LicencePermittedMedia;
+  exclusivity: LicenceExclusivity;
+  reach_caps?: string;
+  message?: string;
+}
+
+export interface LicenseRequestResponse {
+  id?: number;
+  message?: string;
+}


### PR DESCRIPTION
## Summary

Migrates protected digital photo/video detail pages into `openeire-next` and fixes the digital detail CTA hierarchy. Approved gallery users can now view private photo/video detail pages client-side, request commercial licences from the asset page, and see a clear pending state for personal-use checkout until cart/checkout is migrated.

## Why

This completes the next step after the private digital gallery listing migration. The previous detail routes were placeholder gates, and the migrated CTA area incorrectly sent commercial licence enquiries to `/contact` while promoting licensing terms as a main button.

## Screenshots / Demo

- [ ] Not needed
- [ ] Added (attach screenshots / short Loom link)

## Changes

- Backend:
  - No backend changes.
  - Reuses existing `license-requests/` endpoint and payload contract.

- Frontend:
  - Added protected `/gallery/photo/[id]` and `/gallery/video/[id]` detail rendering.
  - Added client-side private asset fetching with `cache: "no-store"` and auth-refresh retry.
  - Added typed protected digital detail API helpers and types.
  - Added `CommercialLicenceRequestModal` for rights-managed licence requests.
  - Updated digital detail CTA hierarchy:
    - Primary: disabled `Add to Cart` pending checkout migration.
    - Secondary: `Request Commercial Licence` opens modal.
    - Tertiary: small `View licence terms` link to current production EULA route.
  - Kept protected asset data out of SSR/page source and metadata.

- Infra/Config:
  - No infra/config changes.

## Testing

- [ ] Django tests pass locally
- [x] React build passes locally
- [ ] Manual smoke test done

### Manual smoke test checklist (quick)

- [ ] No console errors
- [ ] Forms submit correctly (success + validation errors)
- [ ] API errors handled (loading/error states)
- [ ] Mobile layout checked
- [ ] Auth/permissions verified (if relevant)

Validation run:

- `npm.cmd run lint` passed.
- `npm.cmd run build` passed.
- `npm.cmd audit` passed, `0 vulnerabilities`.
- `npm.cmd audit --omit=dev` passed, `0 vulnerabilities`.
- `npm.cmd ls axios plain-crypto-js` returned empty tree, confirming neither package is installed.

## Risk & Rollback

Risk level: Medium

Rollback plan:

- [x] Revert PR
- [ ] Feature flag off
- [ ] Hotfix path described:

The main risk is around protected detail-page auth/access behaviour and licence request submission UX. Rollback is straightforward because this PR is isolated to Next gallery detail pages and a new modal/API helper.

## Notes for Reviewer (Codex/Copilot)

Focus review on:

- [x] Security (auth, permissions, file uploads, CSRF/CORS)
- [x] Performance (N+1 queries, heavy renders, unnecessary requests)
- [x] Maintainability (naming, structure, duplicated logic)

Please specifically check:

- Private photo/video detail data is only fetched client-side after auth/gallery access is confirmed.
- Protected media/master URLs are not exposed in SSR, metadata, sitemap, or JSON-LD.
- Commercial licence request payload matches the existing Vite/backend contract.
- Disabled Add to Cart state is acceptable until cart/checkout migration lands.