### PR TITLE
Add saved stories and blog like support

### DIFF
--- a/openeire-next/app/blog/[slug]/page.tsx
+++ b/openeire-next/app/blog/[slug]/page.tsx
@@ -2,6 +2,7 @@
 import type { Metadata } from "next";
 import Link from "next/link";
 import { notFound } from "next/navigation";
+import { BlogLikeButton } from "@/components/blog/BlogLikeButton";
 import { JsonLd } from "@/components/JsonLd";
 import { getPublishedBlogPostBySlug } from "@/lib/api/blog";
 import { formatBlogDisplayDate } from "@/lib/blog/dates";
@@ -12,7 +13,6 @@ import { sanitizeRichHtml } from "@/lib/sanitizeRichHtml";
 import {
   FaArrowLeft,
   FaCalendar,
-  FaRegHeart,
   FaUser,
 } from "react-icons/fa";
 
@@ -218,10 +218,11 @@ export default async function BlogDetailPage({
         </article>
 
         <div className="mt-16 flex flex-col items-center border-t border-white/10 pt-8">
-          <div className="mb-8 flex items-center gap-3 rounded-full border border-white/10 bg-white/5 px-8 py-4 text-lg font-bold text-gray-400">
-            <FaRegHeart />
-            <span>{post.likes_count} Likes</span>
-          </div>
+          <BlogLikeButton
+            slug={post.slug}
+            initialHasLiked={post.has_liked}
+            initialLikesCount={post.likes_count}
+          />
 
           <div className="text-center">
             <p className="mb-4 text-xs font-bold uppercase tracking-widest text-gray-500">
@@ -295,8 +296,8 @@ export default async function BlogDetailPage({
             Discussion
           </h2>
           <p className="text-sm leading-relaxed text-gray-400">
-            Comments and authenticated likes remain available in the current
-            React app. This server-rendered migration preserves article content,
+            Comments remain available in the current React app while this
+            server-rendered migration preserves article content, saved stories,
             sharing, and related-post discovery first.
           </p>
         </div>

--- a/openeire-next/app/blog/page.tsx
+++ b/openeire-next/app/blog/page.tsx
@@ -119,7 +119,7 @@ export default async function BlogPage({
         />
       ) : null}
 
-      <div className="container mx-auto px-4 lg:px-8">
+      <div className="container mx-auto px-4 pt-8 md:pt-10 lg:px-8">
         <div className="mb-16 text-center">
           <h1 className="mb-6 font-serif text-5xl font-bold tracking-tight md:text-7xl">
             The Journal

--- a/openeire-next/components/blog/BlogLikeButton.tsx
+++ b/openeire-next/components/blog/BlogLikeButton.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { FaHeart, FaRegHeart } from "react-icons/fa";
+import { useAuth } from "@/components/auth/AuthProvider";
+import { useToast } from "@/components/ui/ToastProvider";
+import { normalizeAuthErrorMessage } from "@/lib/api/auth";
+import { getBlogPostLikeState, toggleBlogLike } from "@/lib/api/blog";
+
+interface BlogLikeButtonProps {
+  initialHasLiked?: boolean;
+  initialLikesCount: number;
+  slug: string;
+}
+
+const formatLikeLabel = (count: number) =>
+  `${count} ${count === 1 ? "Like" : "Likes"}`;
+
+export function BlogLikeButton({
+  initialHasLiked = false,
+  initialLikesCount,
+  slug,
+}: BlogLikeButtonProps) {
+  const { isAuthenticated, isLoading: isAuthLoading } = useAuth();
+  const { showToast } = useToast();
+  const [hasLiked, setHasLiked] = useState(initialHasLiked);
+  const [likesCount, setLikesCount] = useState(initialLikesCount);
+  const [isPending, setIsPending] = useState(false);
+
+  useEffect(() => {
+    if (isAuthLoading || !isAuthenticated) {
+      setHasLiked(false);
+      setLikesCount(initialLikesCount);
+      return;
+    }
+
+    let isMounted = true;
+
+    getBlogPostLikeState(slug)
+      .then((state) => {
+        if (!isMounted) return;
+        setHasLiked(state.liked);
+        setLikesCount(state.likes_count);
+      })
+      .catch(() => {
+        if (!isMounted) return;
+        setHasLiked(initialHasLiked);
+        setLikesCount(initialLikesCount);
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, [initialHasLiked, initialLikesCount, isAuthenticated, isAuthLoading, slug]);
+
+  const handleToggleLike = async () => {
+    if (isAuthLoading || isPending) return;
+
+    if (!isAuthenticated) {
+      showToast("Please log in to save stories.", "error");
+      return;
+    }
+
+    const previousLiked = hasLiked;
+    const previousCount = likesCount;
+    const optimisticLiked = !previousLiked;
+
+    setIsPending(true);
+    setHasLiked(optimisticLiked);
+    setLikesCount((current) =>
+      Math.max(0, current + (optimisticLiked ? 1 : -1)),
+    );
+
+    try {
+      const result = await toggleBlogLike(slug);
+      setHasLiked(result.liked);
+      setLikesCount(result.likes_count);
+      showToast(
+        result.liked
+          ? "Story saved to your account."
+          : "Story removed from saved stories.",
+        "success",
+      );
+    } catch (error) {
+      setHasLiked(previousLiked);
+      setLikesCount(previousCount);
+      showToast(
+        normalizeAuthErrorMessage(
+          error,
+          "Could not update your saved stories. Please try again.",
+        ),
+        "error",
+      );
+    } finally {
+      setIsPending(false);
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleToggleLike}
+      disabled={isAuthLoading || isPending}
+      aria-pressed={hasLiked}
+      className={[
+        "mb-8 flex items-center gap-3 rounded-full border px-8 py-4 text-lg font-bold transition-all active:scale-95 disabled:cursor-not-allowed disabled:opacity-70",
+        hasLiked
+          ? "border-red-500/50 bg-red-500/20 text-red-500"
+          : "border-white/10 bg-white/5 text-gray-400 hover:border-white/30 hover:text-white",
+      ].join(" ")}
+    >
+      {hasLiked ? <FaHeart aria-hidden="true" /> : <FaRegHeart aria-hidden="true" />}
+      <span>{isPending ? "Updating..." : formatLikeLabel(likesCount)}</span>
+    </button>
+  );
+}

--- a/openeire-next/components/profile/ProfilePageClient.tsx
+++ b/openeire-next/components/profile/ProfilePageClient.tsx
@@ -3,6 +3,7 @@
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import {
+  FaBookmark,
   FaHistory,
   FaIdBadge,
   FaImages,
@@ -17,6 +18,7 @@ import { DigitalEntitlementsSection } from "@/components/profile/DigitalEntitlem
 import { GalleryAccessPanel } from "@/components/profile/GalleryAccessPanel";
 import { OrderHistorySection } from "@/components/profile/OrderHistorySection";
 import { ProfileEditForm } from "@/components/profile/ProfileEditForm";
+import { SavedStoriesSection } from "@/components/profile/SavedStoriesSection";
 import { useToast } from "@/components/ui/ToastProvider";
 import { normalizeAuthErrorMessage } from "@/lib/api/auth";
 import type { UserProfile } from "@/types/auth";
@@ -27,6 +29,7 @@ type AccountSection =
   | "orders"
   | "downloads"
   | "licences"
+  | "saved"
   | "gallery";
 
 const accountSections: Array<{
@@ -69,6 +72,13 @@ const accountSections: Array<{
     label: "Licences",
     description: "Download personal licence PDFs for digital purchases.",
     icon: FaIdBadge,
+    available: true,
+  },
+  {
+    id: "saved",
+    label: "Saved Stories",
+    description: "Revisit journal articles you have liked.",
+    icon: FaBookmark,
     available: true,
   },
   {
@@ -320,6 +330,10 @@ export function ProfilePageClient() {
 
               {activeSection === "licences" ? (
                 <DigitalEntitlementsSection mode="licences" />
+              ) : null}
+
+              {activeSection === "saved" ? (
+                <SavedStoriesSection />
               ) : null}
 
               {activeSection === "gallery" ? (

--- a/openeire-next/components/profile/SavedStoriesSection.tsx
+++ b/openeire-next/components/profile/SavedStoriesSection.tsx
@@ -1,0 +1,258 @@
+"use client";
+
+/* eslint-disable @next/next/no-img-element */
+import Link from "next/link";
+import { useCallback, useEffect, useState } from "react";
+import { FaArrowRight, FaHeart, FaRegHeart } from "react-icons/fa";
+import { useToast } from "@/components/ui/ToastProvider";
+import { normalizeAuthErrorMessage } from "@/lib/api/auth";
+import { getLikedBlogPosts, toggleBlogLike } from "@/lib/api/blog";
+import { resolveMediaUrl } from "@/lib/media";
+import type { BlogPostListItem } from "@/types/blog";
+
+const dateFormatter = new Intl.DateTimeFormat("en-IE", {
+  day: "2-digit",
+  month: "2-digit",
+  year: "numeric",
+});
+
+const formatDate = (value?: string | null) => {
+  if (!value) return "Date unavailable";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "Date unavailable";
+  return dateFormatter.format(date);
+};
+
+function LoadingState() {
+  return (
+    <div className="space-y-6" aria-live="polite" aria-busy="true">
+      <div className="h-8 w-56 rounded bg-white/10" />
+      <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+        {[0, 1].map((item) => (
+          <div
+            key={item}
+            className="overflow-hidden rounded-xl border border-white/10 bg-black"
+          >
+            <div className="h-48 bg-white/10" />
+            <div className="space-y-4 p-5">
+              <div className="h-5 w-3/4 rounded bg-white/10" />
+              <div className="h-4 w-full rounded bg-white/10" />
+              <div className="h-4 w-1/2 rounded bg-white/10" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function EmptyState() {
+  return (
+    <div className="rounded-2xl border border-white/10 bg-black/30 px-6 py-16 text-center">
+      <div className="mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full bg-gray-800 text-gray-600">
+        <FaHeart className="text-2xl" aria-hidden="true" />
+      </div>
+      <h3 className="font-serif text-2xl font-bold text-white">
+        You haven&apos;t saved any stories yet.
+      </h3>
+      <p className="mx-auto mt-2 max-w-md text-sm text-gray-500">
+        Browse the journal and save aerial stories, location notes, and studio
+        updates you want to revisit.
+      </p>
+      <Link
+        href="/blog"
+        className="mt-6 inline-flex items-center justify-center rounded-full border border-white/20 px-6 py-3 text-sm font-bold uppercase tracking-wider text-white transition-colors hover:bg-white hover:text-black"
+      >
+        Browse Journal
+      </Link>
+    </div>
+  );
+}
+
+function ErrorState({
+  message,
+  onRetry,
+}: {
+  message: string;
+  onRetry: () => void;
+}) {
+  return (
+    <div className="rounded-2xl border border-red-500/20 bg-red-950/30 px-6 py-10 text-center">
+      <h3 className="font-serif text-2xl font-bold text-white">
+        Saved stories could not be loaded.
+      </h3>
+      <p className="mx-auto mt-2 max-w-md text-sm text-red-100/80">
+        {message}
+      </p>
+      <button
+        type="button"
+        onClick={onRetry}
+        className="mt-6 rounded-full border border-white/20 px-6 py-3 text-sm font-bold uppercase tracking-wider text-white transition-colors hover:bg-white hover:text-black"
+      >
+        Try Again
+      </button>
+    </div>
+  );
+}
+
+function SavedStoryCard({
+  isRemoving,
+  onRemove,
+  post,
+}: {
+  isRemoving: boolean;
+  onRemove: (post: BlogPostListItem) => void;
+  post: BlogPostListItem;
+}) {
+  const imageUrl = resolveMediaUrl(post.featured_image);
+
+  return (
+    <article className="group flex flex-col overflow-hidden rounded-xl border border-white/10 bg-black transition-all hover:-translate-y-1 hover:border-accent/50">
+      <Link href={`/blog/${post.slug}`} className="block">
+        <div className="relative h-48 w-full overflow-hidden bg-gray-900">
+          {imageUrl ? (
+            <img
+              src={imageUrl}
+              alt={post.title}
+              className="h-full w-full object-cover opacity-80 transition-all duration-500 group-hover:scale-105 group-hover:opacity-100"
+            />
+          ) : (
+            <div className="flex h-full w-full items-center justify-center bg-gray-900 text-xs font-bold uppercase tracking-widest text-gray-600">
+              OpenÉire Journal
+            </div>
+          )}
+          <div className="absolute right-3 top-3 rounded-full bg-black/70 p-2 text-red-500 backdrop-blur-md">
+            <FaHeart aria-hidden="true" />
+          </div>
+        </div>
+      </Link>
+
+      <div className="flex flex-1 flex-col p-5">
+        <Link href={`/blog/${post.slug}`} className="block">
+          <h3 className="line-clamp-2 text-lg font-bold text-white transition-colors group-hover:text-accent">
+            {post.title}
+          </h3>
+          <p className="mt-2 line-clamp-2 text-sm text-gray-500">
+            {post.excerpt}
+          </p>
+        </Link>
+
+        <div className="mt-auto flex flex-col gap-4 pt-5 sm:flex-row sm:items-center sm:justify-between">
+          <Link
+            href={`/blog/${post.slug}`}
+            className="inline-flex items-center gap-2 text-xs font-bold uppercase tracking-wider text-gray-400 transition-colors hover:text-white"
+          >
+            <span>{formatDate(post.created_at)}</span>
+            <span aria-hidden="true">/</span>
+            Read Story
+            <FaArrowRight aria-hidden="true" />
+          </Link>
+
+          <button
+            type="button"
+            onClick={() => onRemove(post)}
+            disabled={isRemoving}
+            className="inline-flex items-center justify-center gap-2 rounded-full border border-white/15 px-4 py-2 text-xs font-bold uppercase tracking-wider text-gray-300 transition-colors hover:border-red-400/50 hover:text-red-200 disabled:cursor-not-allowed disabled:opacity-50"
+            aria-label={`Remove ${post.title} from saved stories`}
+          >
+            <FaRegHeart aria-hidden="true" />
+            {isRemoving ? "Removing..." : "Remove"}
+          </button>
+        </div>
+      </div>
+    </article>
+  );
+}
+
+export function SavedStoriesSection() {
+  const { showToast } = useToast();
+  const [posts, setPosts] = useState<BlogPostListItem[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [pendingSlugs, setPendingSlugs] = useState<Set<string>>(() => new Set());
+
+  const loadSavedStories = useCallback(async () => {
+    setIsLoading(true);
+    setErrorMessage(null);
+
+    try {
+      const response = await getLikedBlogPosts();
+      setPosts(response.results);
+    } catch (error) {
+      setErrorMessage(
+        normalizeAuthErrorMessage(
+          error,
+          "Could not load your saved stories. Please try again shortly.",
+        ),
+      );
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadSavedStories();
+  }, [loadSavedStories]);
+
+  const handleRemove = async (post: BlogPostListItem) => {
+    if (pendingSlugs.has(post.slug)) return;
+
+    setPendingSlugs((current) => new Set(current).add(post.slug));
+    try {
+      const result = await toggleBlogLike(post.slug);
+      if (!result.liked) {
+        setPosts((current) => current.filter((item) => item.slug !== post.slug));
+        showToast("Story removed from saved stories.", "success");
+      } else {
+        showToast("This story is still saved.", "info");
+      }
+    } catch (error) {
+      showToast(
+        normalizeAuthErrorMessage(
+          error,
+          "Could not update your saved stories. Please try again.",
+        ),
+        "error",
+      );
+    } finally {
+      setPendingSlugs((current) => {
+        const next = new Set(current);
+        next.delete(post.slug);
+        return next;
+      });
+    }
+  };
+
+  if (isLoading) return <LoadingState />;
+  if (errorMessage) {
+    return <ErrorState message={errorMessage} onRetry={loadSavedStories} />;
+  }
+  if (posts.length === 0) return <EmptyState />;
+
+  return (
+    <section aria-labelledby="saved-stories-heading">
+      <div className="mb-8 border-b border-white/10 pb-4">
+        <h2
+          id="saved-stories-heading"
+          className="font-serif text-3xl font-bold text-white"
+        >
+          Saved Stories
+        </h2>
+        <p className="mt-2 text-sm text-gray-500">
+          Articles you have saved from the OpenÉire Studios journal.
+        </p>
+      </div>
+
+      <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+        {posts.map((post) => (
+          <SavedStoryCard
+            key={post.id}
+            post={post}
+            isRemoving={pendingSlugs.has(post.slug)}
+            onRemove={handleRemove}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/openeire-next/lib/api/blog.ts
+++ b/openeire-next/lib/api/blog.ts
@@ -1,5 +1,6 @@
 import { api, isApiError } from "@/lib/api/client";
 import type {
+  BlogLikeResponse,
   BlogPostDetail,
   BlogPostListItem,
   PaginatedResponse,
@@ -56,4 +57,41 @@ export const getPublishedBlogPostBySlug = async (
     }
     throw error;
   }
+};
+
+export const getLikedBlogPosts = async (): Promise<
+  PaginatedResponse<BlogPostListItem>
+> => {
+  const response = await api.get<PaginatedResponse<BlogPostListItem>>(
+    "blog/liked/",
+    {
+      cache: "no-store",
+      retryOnAuthRefresh: true,
+    },
+  );
+  return response.data;
+};
+
+export const getBlogPostLikeState = async (
+  slug: string,
+): Promise<BlogLikeResponse> => {
+  const response = await api.get<BlogPostDetail>(`blog/${slug}/`, {
+    cache: "no-store",
+    retryOnAuthRefresh: true,
+  });
+  return {
+    liked: Boolean(response.data.has_liked),
+    likes_count: response.data.likes_count,
+  };
+};
+
+export const toggleBlogLike = async (
+  slug: string,
+): Promise<BlogLikeResponse> => {
+  const response = await api.post<BlogLikeResponse>(
+    `blog/${slug}/like/`,
+    undefined,
+    { retryOnAuthRefresh: true },
+  );
+  return response.data;
 };

--- a/openeire-next/types/blog.ts
+++ b/openeire-next/types/blog.ts
@@ -21,6 +21,11 @@ export interface BlogPostListItem {
   has_liked?: boolean;
 }
 
+export interface BlogLikeResponse {
+  liked: boolean;
+  likes_count: number;
+}
+
 export interface RelatedBlogPost {
   title: string;
   slug: string;


### PR DESCRIPTION
## Summary

Adds the Saved Stories account section and restores interactive blog like/save behaviour in `openeire-next`. Also adjusts the `/blog` page spacing so the main Journal heading clears the fixed navbar.

## Why

The migrated profile area was missing the existing Vite Saved Stories section, and migrated blog detail pages displayed likes as a static counter instead of allowing authenticated users to save stories.

## Screenshots / Demo

- [ ] Not needed
- [ ] Added (attach screenshots / short Loom link)

## Changes

- Backend:
  - No backend changes.
  - Reuses existing `GET /api/blog/liked/` and `POST /api/blog/:slug/like/`.

- Frontend:
  - Added typed blog like response and liked-post API helpers.
  - Added `Saved Stories` tab to the protected profile shell.
  - Added saved-story loading, empty, error, card, and remove states.
  - Added `BlogLikeButton` client component for article pages.
  - Blog like button handles logged-out users, optimistic updates, backend sync, and safe error toasts.
  - Added extra top spacing to `/blog` so the page heading is not covered by the navbar.

- Infra/Config:
  - No infra/config changes.

## Testing

- [ ] Django tests pass locally
- [x] React build passes locally
- [ ] Manual smoke test done

### Manual smoke test checklist (quick)

- [ ] No console errors
- [ ] Forms submit correctly (success + validation errors)
- [ ] API errors handled (loading/error states)
- [ ] Mobile layout checked
- [ ] Auth/permissions verified (if relevant)

Validation run:

- `npm.cmd run lint` passed.
- `npm.cmd run build` passed after the known Windows sandbox `spawn EPERM` rerun.
- `npm.cmd audit` passed, `0 vulnerabilities`.
- `npm.cmd audit --omit=dev` passed, `0 vulnerabilities`.
- `npm.cmd ls axios plain-crypto-js` returned an empty tree, confirming neither package is installed.

## Risk & Rollback

Risk level: Low / Medium

Rollback plan:

- [x] Revert PR
- [ ] Feature flag off
- [ ] Hotfix path described:

Risk is limited to authenticated blog like/save UI and the profile Saved Stories section. Backend contracts are unchanged.

## Notes for Reviewer (Codex/Copilot)

Focus review on:

- [x] Security (auth, permissions, file uploads, CSRF/CORS)
- [ ] Performance (N+1 queries, heavy renders, unnecessary requests)
- [x] Maintainability (naming, structure, duplicated logic)

Please specifically check:

- Saved stories are client-fetched only behind the profile/auth boundary.
- Saved-post data is not SSR’d, stored in browser storage, or added to metadata/JSON-LD.
- Blog like state hydrates correctly for authenticated users.
- Removing a saved story updates the profile section immediately.