### PR TITLE
Migrate staff video uploader to Next

### DIFF
--- a/openeire-next/app/403/page.tsx
+++ b/openeire-next/app/403/page.tsx
@@ -1,0 +1,32 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+
+export const metadata: Metadata = {
+  title: "Access denied | OpenÉire Studios",
+  robots: { index: false, follow: false },
+};
+
+export default function ForbiddenPage() {
+  return (
+    <div className="page-top-offset flex min-h-screen items-center justify-center bg-black px-4 pb-20 text-center text-white">
+      <div className="max-w-xl rounded-3xl border border-white/10 bg-gray-900 p-8 shadow-2xl">
+        <p className="mb-3 text-xs font-bold uppercase tracking-[0.3em] text-accent">
+          Access denied
+        </p>
+        <h1 className="font-serif text-3xl font-bold">
+          This area is for staff accounts only.
+        </h1>
+        <p className="mt-4 text-sm leading-relaxed text-gray-400">
+          If you believe you should have access, sign in with the correct staff
+          account or contact the site owner.
+        </p>
+        <Link
+          href="/profile"
+          className="mt-8 inline-flex rounded-xl border border-white/15 px-6 py-3 text-sm font-bold uppercase tracking-widest text-white transition hover:bg-white hover:text-black"
+        >
+          Back to account
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/openeire-next/app/staff/uploads/videos/page.tsx
+++ b/openeire-next/app/staff/uploads/videos/page.tsx
@@ -1,0 +1,16 @@
+import type { Metadata } from "next";
+import { ProtectedRoute } from "@/components/auth/ProtectedRoute";
+import { StaffVideoUploadsClient } from "@/components/staff/StaffVideoUploadsClient";
+
+export const metadata: Metadata = {
+  title: "Staff Video Uploads | OpenÉire Studios",
+  robots: { index: false, follow: false },
+};
+
+export default function StaffVideoUploadsPage() {
+  return (
+    <ProtectedRoute staffOnly>
+      <StaffVideoUploadsClient />
+    </ProtectedRoute>
+  );
+}

--- a/openeire-next/components/profile/ProfilePageClient.tsx
+++ b/openeire-next/components/profile/ProfilePageClient.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useState } from "react";
 import {
@@ -236,11 +237,17 @@ export function ProfilePageClient() {
             account areas as they migrate.
           </p>
           {user.is_staff ? (
-            <div className="mt-5">
+            <div className="mt-5 flex flex-wrap items-center gap-3">
               <span className="inline-flex items-center gap-2 rounded-xl border border-accent/30 bg-accent/10 px-4 py-2 text-sm font-bold text-accent">
                 <FaShieldAlt aria-hidden="true" />
                 Staff account
               </span>
+              <Link
+                href="/staff/uploads/videos"
+                className="inline-flex items-center rounded-xl bg-brand-500 px-4 py-2 text-sm font-bold text-black transition hover:bg-white"
+              >
+                Open Staff Video Uploader
+              </Link>
             </div>
           ) : null}
         </div>

--- a/openeire-next/components/staff/StaffVideoUploadsClient.tsx
+++ b/openeire-next/components/staff/StaffVideoUploadsClient.tsx
@@ -1,0 +1,433 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { FaArrowLeft, FaCheckCircle, FaExclamationTriangle } from "react-icons/fa";
+import { useToast } from "@/components/ui/ToastProvider";
+import {
+  createMultipartVideoUpload,
+  isMultipartUploadCancelledError,
+} from "@/lib/uploads/multipartVideoUpload";
+import { searchVideoUploadTargets } from "@/lib/api/videoUploads";
+import type {
+  MultipartUploadProgress,
+  VideoUploadPurpose,
+  VideoUploadTarget,
+} from "@/types/videoUploads";
+
+const ACCEPTED_VIDEO_TYPES = "video/mp4,video/quicktime,video/webm,video/x-m4v";
+
+const formatMegabytes = (bytes: number) => `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+
+export function StaffVideoUploadsClient() {
+  const { showToast } = useToast();
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [purpose, setPurpose] = useState<VideoUploadPurpose>("master");
+  const [attachToVideo, setAttachToVideo] = useState(true);
+  const [targetQuery, setTargetQuery] = useState("");
+  const [targets, setTargets] = useState<VideoUploadTarget[]>([]);
+  const [selectedTargetId, setSelectedTargetId] = useState<number | null>(null);
+  const [isLoadingTargets, setIsLoadingTargets] = useState(false);
+  const [isUploading, setIsUploading] = useState(false);
+  const [statusMessage, setStatusMessage] = useState("Choose a file to begin.");
+  const [uploadError, setUploadError] = useState<string | null>(null);
+  const [progress, setProgress] = useState<MultipartUploadProgress | null>(null);
+  const [completedObjectKey, setCompletedObjectKey] = useState<string | null>(null);
+  const [completionVideoId, setCompletionVideoId] = useState<number | null>(null);
+  const [cancelUpload, setCancelUpload] = useState<(() => Promise<void>) | null>(null);
+  const cancelUploadRef = useRef<(() => Promise<void>) | null>(null);
+
+  useEffect(() => {
+    cancelUploadRef.current = cancelUpload;
+  }, [cancelUpload]);
+
+  useEffect(() => {
+    let isMounted = true;
+    const timeoutId = window.setTimeout(async () => {
+      if (!attachToVideo) {
+        setTargets([]);
+        setSelectedTargetId(null);
+        return;
+      }
+
+      setIsLoadingTargets(true);
+      try {
+        const results = await searchVideoUploadTargets(targetQuery.trim());
+        if (!isMounted) return;
+        setTargets(results);
+        setSelectedTargetId((currentTarget) => {
+          if (currentTarget && results.some((target) => target.id === currentTarget)) {
+            return currentTarget;
+          }
+          return results[0]?.id ?? null;
+        });
+      } catch {
+        if (!isMounted) return;
+        setTargets([]);
+      } finally {
+        if (isMounted) setIsLoadingTargets(false);
+      }
+    }, 250);
+
+    return () => {
+      isMounted = false;
+      window.clearTimeout(timeoutId);
+    };
+  }, [attachToVideo, targetQuery]);
+
+  useEffect(() => {
+    if (!isUploading) return;
+
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      event.preventDefault();
+      event.returnValue = "";
+    };
+
+    window.addEventListener("beforeunload", handleBeforeUnload);
+    return () => {
+      window.removeEventListener("beforeunload", handleBeforeUnload);
+      void cancelUploadRef.current?.();
+    };
+  }, [isUploading]);
+
+  const selectedTarget = useMemo(
+    () => targets.find((target) => target.id === selectedTargetId) ?? null,
+    [selectedTargetId, targets],
+  );
+
+  const resetUploadState = () => {
+    setUploadError(null);
+    setCompletedObjectKey(null);
+    setCompletionVideoId(null);
+    setProgress(null);
+  };
+
+  const handleStartUpload = async () => {
+    if (!selectedFile) {
+      showToast("Choose a video file first.", "error");
+      return;
+    }
+
+    if (attachToVideo && !selectedTargetId) {
+      showToast("Choose a target video before uploading.", "error");
+      return;
+    }
+
+    resetUploadState();
+    setIsUploading(true);
+
+    const uploadTask = createMultipartVideoUpload({
+      file: selectedFile,
+      purpose,
+      targetVideoId: attachToVideo ? selectedTargetId : null,
+      onStatusChange: setStatusMessage,
+      onProgress: setProgress,
+    });
+
+    setCancelUpload(() => uploadTask.cancel);
+
+    try {
+      const result = await uploadTask.promise;
+      setCompletedObjectKey(result.completion.object_key);
+      setCompletionVideoId(result.completion.video_id ?? null);
+      setStatusMessage("Upload complete.");
+      showToast("Video uploaded successfully.", "success");
+    } catch (error) {
+      if (isMultipartUploadCancelledError(error)) {
+        setUploadError(null);
+        setStatusMessage("Upload cancelled.");
+        return;
+      }
+      const message = error instanceof Error ? error.message : "Video upload failed.";
+      setUploadError(message);
+      setStatusMessage("Upload failed.");
+      showToast(message, "error");
+    } finally {
+      setIsUploading(false);
+      setCancelUpload(null);
+    }
+  };
+
+  const handleCancelUpload = async () => {
+    if (!cancelUpload) return;
+
+    setStatusMessage("Cancelling upload...");
+    try {
+      await cancelUpload();
+      setStatusMessage("Upload cancelled.");
+      showToast("Upload cancelled.", "info");
+    } catch {
+      setStatusMessage("Could not cancel cleanly. The upload may already be stopping.");
+      showToast("Could not cancel upload cleanly.", "error");
+    } finally {
+      setIsUploading(false);
+      setCancelUpload(null);
+    }
+  };
+
+  return (
+    <div className="page-top-offset min-h-screen bg-black pb-20 text-white">
+      <div className="container mx-auto max-w-5xl px-4 lg:px-8">
+        <div className="mb-10 border-b border-white/10 pb-6">
+          <Link
+            href="/profile"
+            className="mb-6 inline-flex items-center gap-2 text-xs font-bold uppercase tracking-[0.25em] text-gray-500 transition-colors hover:text-accent"
+          >
+            <FaArrowLeft aria-hidden="true" />
+            Back to account
+          </Link>
+          <p className="mb-3 text-xs uppercase tracking-[0.3em] text-accent">
+            Staff Tools
+          </p>
+          <h1 className="mb-3 font-serif text-4xl font-bold">
+            Multipart Video Uploads
+          </h1>
+          <p className="max-w-3xl leading-relaxed text-gray-400">
+            Upload large private master videos or public preview clips directly to
+            Cloudflare R2 without pushing file bytes through Django.
+          </p>
+        </div>
+
+        <div className="grid gap-8 lg:grid-cols-[1.15fr_0.85fr]">
+          <section className="rounded-3xl border border-white/10 bg-gray-900 p-6 shadow-2xl md:p-8">
+            <div className="space-y-6">
+              <div>
+                <label
+                  htmlFor="video-upload-purpose"
+                  className="mb-2 block text-xs font-bold uppercase tracking-[0.25em] text-gray-400"
+                >
+                  Upload purpose
+                </label>
+                <select
+                  id="video-upload-purpose"
+                  value={purpose}
+                  onChange={(event) =>
+                    setPurpose(event.target.value as VideoUploadPurpose)
+                  }
+                  disabled={isUploading}
+                  className="w-full rounded-xl border border-white/10 bg-black px-4 py-3 text-white outline-none transition focus:border-accent"
+                >
+                  <option value="master">Private master video</option>
+                  <option value="preview">Public preview clip</option>
+                </select>
+                <p className="mt-2 text-sm text-gray-500">
+                  {purpose === "master"
+                    ? "Master uploads stay private and feed secure purchase/licence delivery."
+                    : "Preview uploads are public-safe watermarked clips used for storefront playback."}
+                </p>
+              </div>
+
+              <div>
+                <label
+                  htmlFor="video-upload-file"
+                  className="mb-2 block text-xs font-bold uppercase tracking-[0.25em] text-gray-400"
+                >
+                  Video file
+                </label>
+                <input
+                  id="video-upload-file"
+                  type="file"
+                  accept={ACCEPTED_VIDEO_TYPES}
+                  disabled={isUploading}
+                  onChange={(event) => {
+                    setSelectedFile(event.target.files?.[0] ?? null);
+                    resetUploadState();
+                    setStatusMessage("Ready to upload.");
+                  }}
+                  className="block w-full rounded-xl border border-dashed border-white/20 bg-black px-4 py-4 text-sm text-gray-300 file:mr-4 file:rounded-lg file:border-0 file:bg-brand-500 file:px-4 file:py-2 file:font-semibold file:text-black hover:file:bg-white"
+                />
+                {selectedFile ? (
+                  <p className="mt-3 text-sm text-gray-400">
+                    {selectedFile.name} · {formatMegabytes(selectedFile.size)}
+                  </p>
+                ) : null}
+              </div>
+
+              <div className="rounded-2xl border border-white/10 bg-black/40 p-5">
+                <label className="flex items-start gap-3">
+                  <input
+                    type="checkbox"
+                    checked={attachToVideo}
+                    disabled={isUploading}
+                    onChange={(event) => setAttachToVideo(event.target.checked)}
+                    className="mt-1 h-4 w-4 rounded border-white/20 bg-black text-accent focus:ring-accent"
+                  />
+                  <span>
+                    <span className="block font-semibold text-white">
+                      Attach to an existing video record
+                    </span>
+                    <span className="mt-1 block text-sm text-gray-400">
+                      Leave this on to write the final object key straight onto a
+                      Video record. Turn it off if you only want to park the upload
+                      in R2 for later admin work.
+                    </span>
+                  </span>
+                </label>
+
+                {attachToVideo ? (
+                  <div className="mt-5 space-y-4">
+                    <label htmlFor="video-target-search" className="sr-only">
+                      Search videos by title
+                    </label>
+                    <input
+                      id="video-target-search"
+                      type="text"
+                      value={targetQuery}
+                      disabled={isUploading}
+                      onChange={(event) => setTargetQuery(event.target.value)}
+                      placeholder="Search videos by title..."
+                      className="w-full rounded-xl border border-white/10 bg-gray-950 px-4 py-3 text-white outline-none transition focus:border-accent"
+                    />
+
+                    <div className="max-h-64 overflow-y-auto rounded-2xl border border-white/10 bg-gray-950">
+                      {isLoadingTargets ? (
+                        <div className="px-4 py-5 text-sm text-gray-500">
+                          Loading videos...
+                        </div>
+                      ) : targets.length === 0 ? (
+                        <div className="px-4 py-5 text-sm text-gray-500">
+                          No matching videos found.
+                        </div>
+                      ) : (
+                        <ul className="divide-y divide-white/5">
+                          {targets.map((target) => (
+                            <li key={target.id}>
+                              <button
+                                type="button"
+                                disabled={isUploading}
+                                onClick={() => setSelectedTargetId(target.id)}
+                                className={`flex w-full items-center justify-between gap-4 px-4 py-4 text-left transition ${
+                                  selectedTargetId === target.id
+                                    ? "bg-brand-500/10 text-white"
+                                    : "text-gray-300 hover:bg-white/5"
+                                }`}
+                              >
+                                <span>
+                                  <span className="block font-semibold">
+                                    {target.title}
+                                  </span>
+                                  <span className="mt-1 block text-xs uppercase tracking-[0.2em] text-gray-500">
+                                    {target.collection} · #{target.id}
+                                  </span>
+                                </span>
+                                {!target.is_active ? (
+                                  <span className="rounded-full border border-white/10 px-3 py-1 text-[10px] uppercase tracking-[0.2em] text-gray-400">
+                                    Inactive
+                                  </span>
+                                ) : null}
+                              </button>
+                            </li>
+                          ))}
+                        </ul>
+                      )}
+                    </div>
+                  </div>
+                ) : null}
+              </div>
+
+              <div className="flex flex-wrap gap-3">
+                <button
+                  type="button"
+                  onClick={handleStartUpload}
+                  disabled={isUploading || !selectedFile}
+                  className="rounded-xl bg-brand-500 px-6 py-3 text-sm font-bold text-black transition hover:bg-white disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  {isUploading ? "Uploading..." : "Start upload"}
+                </button>
+                <button
+                  type="button"
+                  onClick={handleCancelUpload}
+                  disabled={!isUploading || !cancelUpload}
+                  className="rounded-xl border border-white/15 px-6 py-3 text-sm font-bold text-white transition hover:border-white hover:bg-white/5 disabled:cursor-not-allowed disabled:opacity-40"
+                >
+                  Cancel upload
+                </button>
+              </div>
+            </div>
+          </section>
+
+          <aside className="rounded-3xl border border-white/10 bg-gray-900 p-6 shadow-2xl md:p-8">
+            <h2 className="mb-6 font-serif text-2xl font-bold">Upload status</h2>
+
+            <div className="space-y-5">
+              <div>
+                <p className="mb-2 text-xs font-bold uppercase tracking-[0.25em] text-gray-500">
+                  Current state
+                </p>
+                <p className="text-sm leading-relaxed text-gray-300">
+                  {statusMessage}
+                </p>
+              </div>
+
+              {progress ? (
+                <div>
+                  <div className="mb-2 flex items-center justify-between text-xs uppercase tracking-[0.2em] text-gray-500">
+                    <span>Progress</span>
+                    <span>{progress.percentage.toFixed(1)}%</span>
+                  </div>
+                  <div className="h-3 overflow-hidden rounded-full bg-black">
+                    <div
+                      className="h-full rounded-full bg-brand-500 transition-all"
+                      style={{ width: `${progress.percentage}%` }}
+                    />
+                  </div>
+                  <p className="mt-3 text-sm text-gray-400">
+                    {progress.uploadedParts} / {progress.totalParts} parts uploaded ·{" "}
+                    {formatMegabytes(progress.bytesUploaded)} of{" "}
+                    {formatMegabytes(progress.totalBytes)}
+                  </p>
+                </div>
+              ) : null}
+
+              <div className="rounded-2xl border border-white/10 bg-black/40 p-5">
+                <p className="mb-2 text-xs font-bold uppercase tracking-[0.25em] text-gray-500">
+                  Target
+                </p>
+                {attachToVideo ? (
+                  selectedTarget ? (
+                    <div>
+                      <p className="font-semibold text-white">{selectedTarget.title}</p>
+                      <p className="mt-1 text-sm text-gray-400">
+                        #{selectedTarget.id} · {selectedTarget.collection}
+                      </p>
+                    </div>
+                  ) : (
+                    <p className="text-sm text-gray-500">No target selected yet.</p>
+                  )
+                ) : (
+                  <p className="text-sm text-gray-500">
+                    This upload will remain unattached until you wire it to a video later.
+                  </p>
+                )}
+              </div>
+
+              {uploadError ? (
+                <div className="rounded-2xl border border-red-500/20 bg-red-500/10 p-5 text-sm text-red-100">
+                  <FaExclamationTriangle className="mb-2" aria-hidden="true" />
+                  {uploadError}
+                </div>
+              ) : null}
+
+              {completedObjectKey ? (
+                <div className="rounded-2xl border border-emerald-500/20 bg-emerald-500/10 p-5">
+                  <p className="mb-2 flex items-center gap-2 text-xs font-bold uppercase tracking-[0.25em] text-emerald-200">
+                    <FaCheckCircle aria-hidden="true" />
+                    Uploaded object key
+                  </p>
+                  <code className="block break-all rounded-xl bg-black/40 px-3 py-3 text-sm text-emerald-100">
+                    {completedObjectKey}
+                  </code>
+                  <p className="mt-3 text-sm text-emerald-100">
+                    {completionVideoId
+                      ? `Attached to video #${completionVideoId}.`
+                      : "Stored in R2 and ready to attach later."}
+                  </p>
+                </div>
+              ) : null}
+            </div>
+          </aside>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/openeire-next/lib/api/videoUploads.ts
+++ b/openeire-next/lib/api/videoUploads.ts
@@ -1,0 +1,69 @@
+import { api } from "@/lib/api/client";
+import type {
+  CompletedVideoUpload,
+  CompletedVideoUploadPart,
+  StartedVideoUpload,
+  VideoUploadPurpose,
+  VideoUploadTarget,
+} from "@/types/videoUploads";
+
+export const requestVideoUploadStart = async (payload: {
+  filename: string;
+  content_type: string;
+  file_size: number;
+  purpose: VideoUploadPurpose;
+  target_video_id?: number | null;
+}): Promise<StartedVideoUpload> => {
+  const response = await api.post<StartedVideoUpload>(
+    "uploads/videos/start/",
+    payload,
+  );
+  return response.data;
+};
+
+export const requestVideoUploadPartUrl = async (payload: {
+  upload_id: string;
+  object_key: string;
+  part_number: number;
+}): Promise<{ url: string }> => {
+  const response = await api.post<{ url: string }>(
+    "uploads/videos/part-url/",
+    payload,
+  );
+  return response.data;
+};
+
+export const completeVideoUpload = async (payload: {
+  upload_id: string;
+  object_key: string;
+  parts: CompletedVideoUploadPart[];
+}): Promise<CompletedVideoUpload> => {
+  const response = await api.post<CompletedVideoUpload>(
+    "uploads/videos/complete/",
+    payload,
+  );
+  return response.data;
+};
+
+export const abortVideoUpload = async (payload: {
+  upload_id: string;
+  object_key: string;
+}): Promise<{ success: boolean; status: string }> => {
+  const response = await api.post<{ success: boolean; status: string }>(
+    "uploads/videos/abort/",
+    payload,
+  );
+  return response.data;
+};
+
+export const searchVideoUploadTargets = async (
+  query = "",
+): Promise<VideoUploadTarget[]> => {
+  const response = await api.get<VideoUploadTarget[]>(
+    "uploads/videos/targets/",
+    {
+      params: query ? { query } : undefined,
+    },
+  );
+  return response.data;
+};

--- a/openeire-next/lib/uploads/multipartVideoUpload.ts
+++ b/openeire-next/lib/uploads/multipartVideoUpload.ts
@@ -1,0 +1,439 @@
+import { isApiError } from "@/lib/api/client";
+import {
+  abortVideoUpload,
+  completeVideoUpload,
+  requestVideoUploadPartUrl,
+  requestVideoUploadStart,
+} from "@/lib/api/videoUploads";
+import type {
+  CompletedVideoUploadPart,
+  MultipartUploadProgress,
+  MultipartUploadResult,
+  StartedVideoUpload,
+  VideoUploadPurpose,
+} from "@/types/videoUploads";
+
+const DEFAULT_RETRY_LIMIT = 3;
+
+const R2_CORS_ERROR_MESSAGE =
+  "Upload blocked by Cloudflare R2 CORS. Allow this frontend origin on the target bucket and expose the ETag header.";
+const UPLOAD_CANCELLED_MESSAGE = "Upload cancelled.";
+
+const VIDEO_CONTENT_TYPE_BY_EXTENSION: Record<string, string> = {
+  ".mp4": "video/mp4",
+  ".mov": "video/quicktime",
+  ".webm": "video/webm",
+  ".m4v": "video/x-m4v",
+};
+
+interface UploadMultipartVideoOptions {
+  file: File;
+  purpose: VideoUploadPurpose;
+  targetVideoId?: number | null;
+  retryLimit?: number;
+  onProgress?: (progress: MultipartUploadProgress) => void;
+  onStatusChange?: (status: string) => void;
+}
+
+export class MultipartUploadCancelledError extends Error {
+  constructor(message = UPLOAD_CANCELLED_MESSAGE) {
+    super(message);
+    this.name = "MultipartUploadCancelledError";
+  }
+}
+
+export class UploadPartError extends Error {
+  code?: string;
+  status?: number;
+  data?: unknown;
+  requestUrl: string;
+
+  constructor(
+    message: string,
+    {
+      code,
+      status,
+      data,
+      requestUrl,
+    }: {
+      code?: string;
+      status?: number;
+      data?: unknown;
+      requestUrl: string;
+    },
+  ) {
+    super(message);
+    this.name = "UploadPartError";
+    this.code = code;
+    this.status = status;
+    this.data = data;
+    this.requestUrl = requestUrl;
+  }
+}
+
+const buildProgressSnapshot = (
+  partProgress: Map<number, number>,
+  totalBytes: number,
+  uploadedParts: number,
+  totalParts: number,
+): MultipartUploadProgress => {
+  const bytesUploaded = Array.from(partProgress.values()).reduce(
+    (sum, current) => sum + current,
+    0,
+  );
+
+  return {
+    bytesUploaded,
+    totalBytes,
+    percentage:
+      totalBytes > 0 ? Math.min(100, (bytesUploaded / totalBytes) * 100) : 0,
+    uploadedParts,
+    totalParts,
+  };
+};
+
+export const sortCompletedParts = (
+  completedParts: Map<number, string>,
+): CompletedVideoUploadPart[] =>
+  Array.from(completedParts.entries())
+    .sort(([partA], [partB]) => partA - partB)
+    .map(([part_number, etag]) => ({ part_number, etag }));
+
+export const inferVideoContentType = (file: File): string => {
+  if (file.type) return file.type;
+
+  const filename = file.name.toLowerCase();
+  const matchedExtension = Object.keys(VIDEO_CONTENT_TYPE_BY_EXTENSION).find(
+    (extension) => filename.endsWith(extension),
+  );
+
+  return matchedExtension
+    ? VIDEO_CONTENT_TYPE_BY_EXTENSION[matchedExtension]
+    : "application/octet-stream";
+};
+
+const isDirectRequestUrl = (value?: string): boolean =>
+  typeof value === "string" &&
+  (value.startsWith("http://") || value.startsWith("https://"));
+
+const isUploadPartError = (error: unknown): error is UploadPartError =>
+  error instanceof UploadPartError;
+
+const parseHeaderString = (headers: string): Record<string, string> =>
+  headers
+    .trim()
+    .split(/[\r\n]+/)
+    .filter(Boolean)
+    .reduce<Record<string, string>>((acc, line) => {
+      const separatorIndex = line.indexOf(":");
+      if (separatorIndex === -1) return acc;
+      const key = line.slice(0, separatorIndex).trim().toLowerCase();
+      const value = line.slice(separatorIndex + 1).trim();
+      if (key) acc[key] = value;
+      return acc;
+    }, {});
+
+const parseResponseText = (text: string): unknown => {
+  if (!text.trim()) return undefined;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+};
+
+const getPayloadDetail = (payload: unknown): string | null => {
+  if (typeof payload === "string" && payload.trim()) return payload.trim();
+  if (!payload || typeof payload !== "object") return null;
+
+  const record = payload as Record<string, unknown>;
+  return (
+    (typeof record.detail === "string" && record.detail) ||
+    (typeof record.message === "string" && record.message) ||
+    null
+  );
+};
+
+const uploadPartWithProgress = ({
+  chunk,
+  contentType,
+  onProgress,
+  signal,
+  url,
+}: {
+  chunk: Blob;
+  contentType: string;
+  onProgress: (loadedBytes: number) => void;
+  signal: AbortSignal;
+  url: string;
+}): Promise<{ headers: Record<string, string> }> =>
+  new Promise((resolve, reject) => {
+    const xhr = new XMLHttpRequest();
+    let settled = false;
+
+    const rejectOnce = (error: unknown) => {
+      if (settled) return;
+      settled = true;
+      signal.removeEventListener("abort", abortHandler);
+      reject(error);
+    };
+
+    const resolveOnce = (value: { headers: Record<string, string> }) => {
+      if (settled) return;
+      settled = true;
+      signal.removeEventListener("abort", abortHandler);
+      resolve(value);
+    };
+
+    const abortHandler = () => {
+      xhr.abort();
+      rejectOnce(new MultipartUploadCancelledError());
+    };
+
+    xhr.upload.onprogress = (event) => {
+      onProgress(Math.min(event.loaded, chunk.size));
+    };
+
+    xhr.onerror = () => {
+      rejectOnce(
+        new UploadPartError("Network request failed.", {
+          code: "ERR_NETWORK",
+          requestUrl: url,
+        }),
+      );
+    };
+
+    xhr.onabort = () => {
+      rejectOnce(new MultipartUploadCancelledError());
+    };
+
+    xhr.onload = () => {
+      const headers = parseHeaderString(xhr.getAllResponseHeaders());
+      if (xhr.status >= 200 && xhr.status < 300) {
+        resolveOnce({ headers });
+        return;
+      }
+      rejectOnce(
+        new UploadPartError(`Upload part request failed with status ${xhr.status}.`, {
+          status: xhr.status,
+          data: parseResponseText(xhr.responseText),
+          requestUrl: url,
+        }),
+      );
+    };
+
+    signal.addEventListener("abort", abortHandler, { once: true });
+    xhr.open("PUT", url);
+    xhr.setRequestHeader("Content-Type", contentType);
+    xhr.send(chunk);
+  });
+
+export const getMultipartUploadErrorMessage = (error: unknown): string => {
+  if (
+    error instanceof MultipartUploadCancelledError ||
+    (isUploadPartError(error) && error.code === "ERR_CANCELED")
+  ) {
+    return UPLOAD_CANCELLED_MESSAGE;
+  }
+
+  if (isUploadPartError(error)) {
+    const isDirectR2Request = isDirectRequestUrl(error.requestUrl);
+    if (
+      (error.code === "ERR_NETWORK" || error.status === 403) &&
+      isDirectR2Request
+    ) {
+      return R2_CORS_ERROR_MESSAGE;
+    }
+
+    const detail = getPayloadDetail(error.data);
+    if (detail) return detail;
+  }
+
+  if (isApiError(error)) {
+    const detail = getPayloadDetail(error.response?.data);
+    if (detail) return detail;
+  }
+
+  if (error instanceof Error && error.message) return error.message;
+  return "Video upload failed.";
+};
+
+const isCancellationError = (error: unknown): boolean =>
+  error instanceof MultipartUploadCancelledError ||
+  (isApiError(error) && error.code === "ERR_CANCELED") ||
+  (isUploadPartError(error) && error.code === "ERR_CANCELED");
+
+export const isMultipartUploadCancelledError = (
+  error: unknown,
+): error is MultipartUploadCancelledError =>
+  error instanceof MultipartUploadCancelledError;
+
+export const createMultipartVideoUpload = ({
+  file,
+  onProgress,
+  onStatusChange,
+  purpose,
+  retryLimit = DEFAULT_RETRY_LIMIT,
+  targetVideoId,
+}: UploadMultipartVideoOptions) => {
+  const abortController = new AbortController();
+  let startedUpload: StartedVideoUpload | null = null;
+  let hasCompleted = false;
+  let hasCancelled = false;
+  let abortPromise: Promise<void> | null = null;
+  let fatalError: unknown = null;
+
+  const abortMultipartUploadOnce = async () => {
+    if (!startedUpload || hasCompleted) return;
+    if (!abortPromise) {
+      abortPromise = abortVideoUpload({
+        upload_id: startedUpload.upload_id,
+        object_key: startedUpload.object_key,
+      })
+        .then(() => undefined)
+        .catch(() => undefined);
+    }
+    await abortPromise;
+  };
+
+  const uploadPromise = (async (): Promise<MultipartUploadResult> => {
+    onStatusChange?.("Starting upload session...");
+    const uploadContentType = inferVideoContentType(file);
+
+    const upload = await requestVideoUploadStart({
+      filename: file.name,
+      content_type: uploadContentType,
+      file_size: file.size,
+      purpose,
+      target_video_id: targetVideoId ?? null,
+    });
+    startedUpload = upload;
+
+    const totalParts = Math.ceil(file.size / upload.part_size);
+    const completedParts = new Map<number, string>();
+    const partProgress = new Map<number, number>();
+    const uploadedPartNumbers = new Set<number>();
+
+    const emitProgress = () => {
+      onProgress?.(
+        buildProgressSnapshot(
+          partProgress,
+          file.size,
+          uploadedPartNumbers.size,
+          totalParts,
+        ),
+      );
+    };
+
+    const uploadSinglePart = async (partNumber: number) => {
+      const partStart = (partNumber - 1) * upload.part_size;
+      const partEnd = Math.min(file.size, partStart + upload.part_size);
+      const chunk = file.slice(partStart, partEnd);
+      let lastError: unknown = null;
+
+      for (let attempt = 1; attempt <= retryLimit; attempt += 1) {
+        try {
+          partProgress.set(partNumber, 0);
+          emitProgress();
+          onStatusChange?.(
+            `Uploading part ${partNumber} of ${totalParts}${
+              attempt > 1 ? ` (retry ${attempt}/${retryLimit})` : ""
+            }...`,
+          );
+
+          const { url } = await requestVideoUploadPartUrl({
+            upload_id: upload.upload_id,
+            object_key: upload.object_key,
+            part_number: partNumber,
+          });
+
+          const response = await uploadPartWithProgress({
+            chunk,
+            contentType: uploadContentType,
+            onProgress: (loadedBytes) => {
+              partProgress.set(partNumber, loadedBytes);
+              emitProgress();
+            },
+            signal: abortController.signal,
+            url,
+          });
+
+          const etag = String(response.headers.etag || "").trim();
+          if (!etag) {
+            throw new Error(`Missing ETag for uploaded part ${partNumber}.`);
+          }
+
+          partProgress.set(partNumber, chunk.size);
+          uploadedPartNumbers.add(partNumber);
+          completedParts.set(partNumber, etag);
+          emitProgress();
+          return;
+        } catch (error) {
+          lastError = error;
+          if (abortController.signal.aborted) {
+            throw new MultipartUploadCancelledError();
+          }
+          if (attempt === retryLimit) break;
+        }
+      }
+
+      const resolvedError =
+        lastError instanceof Error
+          ? lastError
+          : new Error(`Failed to upload part ${partNumber}.`);
+      fatalError = resolvedError;
+      abortController.abort();
+      throw resolvedError;
+    };
+
+    let nextPartIndex = 0;
+    const workerCount = Math.max(1, Math.min(upload.max_concurrency, totalParts));
+
+    const workers = Array.from({ length: workerCount }, async () => {
+      while (!fatalError && !abortController.signal.aborted) {
+        const currentIndex = nextPartIndex;
+        nextPartIndex += 1;
+        if (currentIndex >= totalParts) return;
+        await uploadSinglePart(currentIndex + 1);
+      }
+    });
+
+    try {
+      await Promise.all(workers);
+
+      if (hasCancelled || abortController.signal.aborted) {
+        throw new MultipartUploadCancelledError();
+      }
+
+      onStatusChange?.("Finalising upload...");
+
+      const completion = await completeVideoUpload({
+        upload_id: upload.upload_id,
+        object_key: upload.object_key,
+        parts: sortCompletedParts(completedParts),
+      });
+
+      hasCompleted = true;
+      onStatusChange?.("Upload complete.");
+      return { upload, completion };
+    } catch (error) {
+      if (hasCancelled || isCancellationError(error)) {
+        throw new MultipartUploadCancelledError();
+      }
+
+      if (startedUpload && !hasCompleted) {
+        await abortMultipartUploadOnce();
+      }
+      throw new Error(getMultipartUploadErrorMessage(fatalError ?? error));
+    }
+  })();
+
+  return {
+    promise: uploadPromise,
+    cancel: async () => {
+      hasCancelled = true;
+      abortController.abort();
+      await abortMultipartUploadOnce();
+    },
+  };
+};

--- a/openeire-next/types/videoUploads.ts
+++ b/openeire-next/types/videoUploads.ts
@@ -1,0 +1,43 @@
+export type VideoUploadPurpose = "master" | "preview";
+
+export interface VideoUploadTarget {
+  id: number;
+  title: string;
+  collection: string;
+  is_active: boolean;
+}
+
+export interface StartedVideoUpload {
+  upload_id: string;
+  object_key: string;
+  bucket: string;
+  part_size: number;
+  max_concurrency: number;
+  purpose: VideoUploadPurpose;
+  target_video_id?: number | null;
+}
+
+export interface CompletedVideoUploadPart {
+  part_number: number;
+  etag: string;
+}
+
+export interface CompletedVideoUpload {
+  success: boolean;
+  object_key: string;
+  status: string;
+  video_id?: number | null;
+}
+
+export interface MultipartUploadProgress {
+  bytesUploaded: number;
+  totalBytes: number;
+  percentage: number;
+  uploadedParts: number;
+  totalParts: number;
+}
+
+export interface MultipartUploadResult {
+  upload: StartedVideoUpload;
+  completion: CompletedVideoUpload;
+}


### PR DESCRIPTION
## Summary

Migrates the staff-only multipart video uploader into `openeire-next`. The route is protected behind staff auth, preserves the existing backend/R2 upload flow, and keeps uploads client-side only.

## Why

This restores the staff video upload workflow in the Next.js migration without changing backend contracts, R2 storage behaviour, or public/customer flows.

## Screenshots / Demo

- [ ] Not needed
- [x] Added (local smoke tested; upload currently reaches R2 and is blocked by bucket CORS until configured)

## Changes

- Backend:
  - No backend changes.
  - Reuses existing `/api/uploads/videos/*` endpoints.

- Frontend:
  - Added `/staff/uploads/videos` route behind `ProtectedRoute staffOnly`.
  - Added `/403` access denied page for non-staff users.
  - Added staff-only profile link to the uploader.
  - Added typed video upload API helpers.
  - Ported multipart upload logic with signed part URLs, progress, cancellation, completion, and abort cleanup.
  - Ported staff upload UI for master/private videos and public preview clips.

- Infra/Config:
  - No code config changes.
  - Cloudflare R2 CORS must allow the frontend origin and expose the `ETag` header for browser multipart uploads.

## Testing

- [ ] Django tests pass locally
- [x] React build passes locally
- [x] Manual smoke test done

### Manual smoke test checklist (quick)

- [x] No console errors unrelated to expected R2 CORS block
- [x] Forms submit correctly (file selection, target selection, upload start)
- [x] API errors handled (loading/error states)
- [x] Mobile layout checked
- [x] Auth/permissions verified (staff route guarded; non-staff UI link hidden)

Validation run:

- `npm.cmd run lint` passed
- `npm.cmd run build` passed after rerunning with approved sandbox escalation
- `npm.cmd audit` passed
- `npm.cmd audit --omit=dev` passed
- `npm.cmd ls axios plain-crypto-js` returned empty tree as expected
- No test script exists in `openeire-next`

## Risk & Rollback

Risk level: Medium

Rollback plan:

- [x] Revert PR
- [ ] Feature flag off
- [ ] Hotfix path described:

Risk is isolated to the staff-only uploader route. Public pages, checkout, gallery access, downloads, reviews, Stripe, and Prodigi are untouched.

## Notes for Reviewer (Codex/Copilot)

Focus review on:

- [x] Security (auth, permissions, file uploads, CSRF/CORS)
- [x] Performance (N+1 queries, heavy renders, unnecessary requests)
- [x] Maintainability (naming, structure, duplicated logic)

Specific review notes:

- Frontend staff access is guarded with `ProtectedRoute staffOnly`; backend remains the true permission boundary.
- Signed R2 URLs are requested only after staff auth passes and a staff user starts an upload.
- No signed URLs, original footage URLs, master files, or upload tokens are rendered in SSR HTML, metadata, sitemap, or logs.
- Upload mutations are not auth-refresh replayed, avoiding duplicate multipart side effects.
- R2 bucket CORS must expose `ETag`; otherwise completion cannot collect uploaded part ETags.