### PR TITLE
Migrate the non-payment checkout shell

### DIFF
--- a/openeire-next/app/checkout/page.tsx
+++ b/openeire-next/app/checkout/page.tsx
@@ -1,0 +1,15 @@
+import type { Metadata } from "next";
+import { CheckoutClient } from "@/components/checkout/CheckoutClient";
+
+export const metadata: Metadata = {
+  title: "Checkout | OpenÉire Studios",
+  robots: {
+    index: false,
+    follow: false,
+  },
+};
+
+export default function CheckoutPage() {
+  return <CheckoutClient />;
+}
+

--- a/openeire-next/components/cart/OrderSummary.tsx
+++ b/openeire-next/components/cart/OrderSummary.tsx
@@ -52,14 +52,12 @@ export function OrderSummary() {
             Sign in before checkout
           </Link>
         ) : (
-          <button
-            type="button"
-            disabled
-            className="flex w-full cursor-not-allowed items-center justify-center rounded-xl bg-brand-700/60 px-5 py-4 text-sm font-bold text-paper opacity-75"
-            title="Checkout will be enabled in the next migration PR."
+          <Link
+            href="/checkout"
+            className="flex w-full items-center justify-center rounded-xl bg-brand-700 px-5 py-4 text-sm font-bold text-paper transition-colors hover:bg-brand-500"
           >
-            Checkout coming next
-          </button>
+            Continue to checkout
+          </Link>
         )}
         <p className="mt-3 text-center text-[11px] leading-relaxed text-gray-500">
           Shipping, discounts, and final totals are calculated securely by the

--- a/openeire-next/components/checkout/CheckoutClient.tsx
+++ b/openeire-next/components/checkout/CheckoutClient.tsx
@@ -1,0 +1,441 @@
+"use client";
+
+import Link from "next/link";
+import { useRouter } from "next/navigation";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { FaLock, FaShieldAlt } from "react-icons/fa";
+import { useAuth } from "@/components/auth/AuthProvider";
+import { useCart } from "@/components/cart/CartProvider";
+import { CheckoutContactForm } from "@/components/checkout/CheckoutContactForm";
+import { CheckoutDiscountCard } from "@/components/checkout/CheckoutDiscountCard";
+import { CheckoutOrderSummary } from "@/components/checkout/CheckoutOrderSummary";
+import { CheckoutShippingForm } from "@/components/checkout/CheckoutShippingForm";
+import { CheckoutTerms } from "@/components/checkout/CheckoutTerms";
+import { isApiError } from "@/lib/api/client";
+import { getCheckoutCountries } from "@/lib/api/countries";
+import { validateDiscountCode } from "@/lib/api/checkout";
+import {
+  buildCheckoutCartPayload,
+  buildCreatePaymentIntentPayload,
+  getCheckoutCartSignature,
+  hasCompleteContactDetails,
+  hasCompleteShippingDetails,
+  hasDigitalCartItems,
+  hasPhysicalCartItems,
+} from "@/lib/checkout/payload";
+import type { Country } from "@/types/auth";
+import type {
+  AppliedDiscount,
+  CheckoutFormState,
+  CheckoutReadiness,
+} from "@/types/checkout";
+
+const EMPTY_FORM_STATE: CheckoutFormState = {
+  contact: {
+    name: "",
+    email: "",
+    phone: "",
+  },
+  shipping: {
+    line1: "",
+    line2: "",
+    city: "",
+    state: "",
+    country: "",
+    postal_code: "",
+  },
+  shippingMethod: "budget",
+  saveInfo: true,
+  acceptsTerms: false,
+  acceptsPrivacy: false,
+  acceptsPersonalUse: false,
+};
+
+const getSafeErrorText = (value: unknown): string | null => {
+  if (typeof value !== "string") return null;
+
+  const normalized = value.trim();
+  if (
+    !normalized ||
+    normalized.length > 300 ||
+    /<[^>]+>/.test(normalized)
+  ) {
+    return null;
+  }
+
+  return normalized;
+};
+
+const getErrorMessage = (error: unknown, fallback: string): string => {
+  if (isApiError(error)) {
+    if ((error.response?.status ?? 0) >= 500) return fallback;
+
+    const data = error.response?.data;
+    const stringMessage = getSafeErrorText(data);
+    if (stringMessage) return stringMessage;
+
+    if (data && typeof data === "object") {
+      const record = data as Record<string, unknown>;
+      for (const key of ["detail", "message", "error"]) {
+        const message = getSafeErrorText(record[key]);
+        if (message) return message;
+      }
+
+      for (const value of Object.values(record)) {
+        const message = getSafeErrorText(
+          Array.isArray(value) ? value[0] : value,
+        );
+        if (message) return message;
+      }
+    }
+
+    return getSafeErrorText(error.message) ?? fallback;
+  }
+  return fallback;
+};
+
+export function CheckoutClient() {
+  const router = useRouter();
+  const { items, isLoaded: isCartLoaded } = useCart();
+  const {
+    user,
+    isAuthenticated,
+    isLoading: isAuthLoading,
+  } = useAuth();
+  const [formState, setFormState] =
+    useState<CheckoutFormState>(EMPTY_FORM_STATE);
+  const [countries, setCountries] = useState<Country[]>([]);
+  const [countriesError, setCountriesError] = useState<string | null>(null);
+  const [isLoadingCountries, setIsLoadingCountries] = useState(false);
+  const [discountCode, setDiscountCode] = useState("");
+  const [appliedDiscount, setAppliedDiscount] = useState<AppliedDiscount | null>(
+    null,
+  );
+  const [discountError, setDiscountError] = useState<string | null>(null);
+  const [isApplyingDiscount, setIsApplyingDiscount] = useState(false);
+  const prefilledProfileRef = useRef(false);
+
+  const hasPhysicalItems = useMemo(() => hasPhysicalCartItems(items), [items]);
+  const hasDigitalItems = useMemo(() => hasDigitalCartItems(items), [items]);
+  const cartSignature = useMemo(() => getCheckoutCartSignature(items), [items]);
+  const requiresAuthenticatedCheckout = hasDigitalItems;
+
+  useEffect(() => {
+    if (isCartLoaded && items.length === 0) {
+      router.replace("/bag");
+    }
+  }, [isCartLoaded, items.length, router]);
+
+  useEffect(() => {
+    if (!isCartLoaded || !user || prefilledProfileRef.current) return;
+    prefilledProfileRef.current = true;
+
+    setFormState((current) => ({
+      ...current,
+      contact: {
+        name: `${user.first_name ?? ""} ${user.last_name ?? ""}`.trim(),
+        email: user.email ?? "",
+        phone: user.default_phone_number ?? "",
+      },
+      shipping: {
+        line1: user.default_street_address1 ?? "",
+        line2: user.default_street_address2 ?? "",
+        city: user.default_town ?? "",
+        state: user.default_county ?? "",
+        country:
+          hasPhysicalItems && user.country !== "IE" && user.country !== "US"
+            ? ""
+            : (user.country ?? ""),
+        postal_code: user.default_postcode ?? "",
+      },
+    }));
+  }, [hasPhysicalItems, isCartLoaded, user]);
+
+  useEffect(() => {
+    if (!hasPhysicalItems) return;
+    const controller = new AbortController();
+    setIsLoadingCountries(true);
+    setCountriesError(null);
+
+    getCheckoutCountries(controller.signal)
+      .then((payload) => {
+        if (!controller.signal.aborted) setCountries(payload);
+      })
+      .catch((error) => {
+        if (controller.signal.aborted) return;
+        setCountriesError(
+          getErrorMessage(
+            error,
+            "Could not load delivery countries. Please try again shortly.",
+          ),
+        );
+      })
+      .finally(() => {
+        if (!controller.signal.aborted) setIsLoadingCountries(false);
+      });
+
+    return () => controller.abort();
+  }, [hasPhysicalItems]);
+
+  useEffect(() => {
+    setAppliedDiscount(null);
+    setDiscountError(null);
+  }, [cartSignature]);
+
+  const readiness = useMemo<CheckoutReadiness>(() => {
+    const errors: string[] = [];
+
+    if (!items.length) errors.push("Your bag is empty.");
+    if (requiresAuthenticatedCheckout && !isAuthenticated) {
+      errors.push("Sign in to buy personal-use digital assets.");
+    }
+    if (!hasCompleteContactDetails(formState)) {
+      errors.push("Enter your name, a valid email and phone number.");
+    }
+    if (hasPhysicalItems && !hasCompleteShippingDetails(formState)) {
+      errors.push("Complete the required shipping details.");
+    }
+    if (!formState.acceptsTerms) {
+      errors.push("Accept the Terms & Conditions.");
+    }
+    if (!formState.acceptsPrivacy) {
+      errors.push("Confirm the privacy acknowledgement.");
+    }
+    if (hasDigitalItems && !formState.acceptsPersonalUse) {
+      errors.push("Accept the personal-use licence terms.");
+    }
+
+    try {
+      const payload = buildCreatePaymentIntentPayload({
+        cartItems: items,
+        formState,
+        discountCode: appliedDiscount?.code,
+        isAuthenticated,
+      });
+      return {
+        isReady: errors.length === 0,
+        errors,
+        payload: errors.length === 0 ? payload : null,
+      };
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : "One or more bag items are invalid.";
+      return {
+        isReady: false,
+        errors: [...errors, message],
+        payload: null,
+      };
+    }
+  }, [
+    appliedDiscount?.code,
+    formState,
+    hasDigitalItems,
+    hasPhysicalItems,
+    isAuthenticated,
+    items,
+    requiresAuthenticatedCheckout,
+  ]);
+
+  const handleApplyDiscount = useCallback(async () => {
+    const normalizedCode = discountCode.trim().toUpperCase();
+    if (!normalizedCode) {
+      setDiscountError("Enter a discount code.");
+      return;
+    }
+
+    const email = formState.contact.email.trim();
+    if (!email && !user?.email) {
+      setDiscountError("Enter your email before applying a discount code.");
+      return;
+    }
+
+    setIsApplyingDiscount(true);
+    setDiscountError(null);
+
+    try {
+      const response = await validateDiscountCode({
+        cart: buildCheckoutCartPayload(items),
+        email: email || user?.email || undefined,
+        discount_code: normalizedCode,
+      });
+
+      setAppliedDiscount({
+        code: response.code,
+        amount: Number(response.discountAmount ?? 0),
+        label: response.discountLabel ?? null,
+        eligibleSubtotal: Number(response.eligibleSubtotal ?? 0),
+      });
+      setDiscountCode(response.code);
+    } catch (error) {
+      setAppliedDiscount(null);
+      setDiscountError(
+        getErrorMessage(
+          error,
+          "We could not apply that discount code right now.",
+        ),
+      );
+    } finally {
+      setIsApplyingDiscount(false);
+    }
+  }, [discountCode, formState.contact.email, items, user?.email]);
+
+  const handleRemoveDiscount = useCallback(() => {
+    setAppliedDiscount(null);
+    setDiscountCode("");
+    setDiscountError(null);
+  }, []);
+
+  if (!isCartLoaded || isAuthLoading) {
+    return (
+      <div className="page-top-offset flex min-h-screen items-center justify-center bg-black px-4 pb-24 text-white">
+        <div className="h-12 w-12 animate-spin rounded-full border-2 border-accent border-t-transparent" />
+        <span className="sr-only">Preparing checkout</span>
+      </div>
+    );
+  }
+
+  if (items.length === 0) {
+    return (
+      <div className="page-top-offset flex min-h-screen items-center justify-center bg-black px-4 pb-24 text-center text-white">
+        <p className="text-sm text-gray-400">Redirecting to your bag...</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="page-top-offset min-h-screen bg-black pb-24 text-white">
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        <div className="mx-auto mb-12 max-w-3xl pt-16 text-center md:pt-20">
+          <div className="mb-6 inline-flex items-center gap-2 rounded-full border border-white/10 bg-white/5 px-4 py-2">
+            <FaShieldAlt className="text-accent" aria-hidden="true" />
+            <span className="text-sm text-gray-300">Secure Checkout</span>
+          </div>
+          <h1 className="mb-4 font-serif text-4xl font-bold text-white md:text-5xl">
+            Finalise Your Order
+          </h1>
+          <p className="text-lg text-gray-400">
+            {hasPhysicalItems
+              ? "Enter your details and review your order before secure payment."
+              : "Review your details before secure payment for your digital purchase."}
+          </p>
+        </div>
+
+        {requiresAuthenticatedCheckout && !isAuthenticated ? (
+          <div className="mx-auto max-w-3xl rounded-2xl border border-brand-500/30 bg-brand-500/10 px-5 py-6 text-center text-sm text-gray-200">
+            Digital purchases require an account so downloads can be attached to
+            your order history.
+            <div className="mt-4 flex flex-wrap items-center justify-center gap-3">
+              <Link
+                href="/login"
+                className="rounded-full bg-brand-500 px-5 py-2 text-sm font-bold text-black transition-colors hover:bg-white"
+              >
+                Log In to Continue
+              </Link>
+              <Link
+                href="/register"
+                className="rounded-full border border-white/20 px-5 py-2 text-sm font-bold text-white transition-colors hover:bg-white/10"
+              >
+                Create Account
+              </Link>
+            </div>
+          </div>
+        ) : (
+          <div className="grid gap-8 lg:grid-cols-5 lg:items-start">
+            <div className="space-y-8 lg:col-span-3">
+              <CheckoutContactForm
+                value={formState.contact}
+                lockedEmail={isAuthenticated ? user?.email : null}
+                onChange={(contact) =>
+                  setFormState((current) => ({ ...current, contact }))
+                }
+              />
+
+              {hasPhysicalItems ? (
+                <CheckoutShippingForm
+                  value={formState.shipping}
+                  onChange={(shipping) =>
+                    setFormState((current) => ({ ...current, shipping }))
+                  }
+                  shippingMethod={formState.shippingMethod}
+                  onShippingMethodChange={(shippingMethod) =>
+                    setFormState((current) => ({ ...current, shippingMethod }))
+                  }
+                  countries={countries}
+                  isLoadingCountries={isLoadingCountries}
+                  countriesError={countriesError}
+                />
+              ) : null}
+
+              <CheckoutTerms
+                value={formState}
+                hasDigitalItems={hasDigitalItems}
+                onChange={(terms) =>
+                  setFormState((current) => ({ ...current, ...terms }))
+                }
+              />
+
+              {readiness.errors.length ? (
+                <div className="rounded-xl border border-red-500/20 bg-red-500/10 p-4 text-sm font-bold text-red-300">
+                  <p>Required before payment:</p>
+                  <ul className="mt-2 list-disc space-y-1 pl-5 font-medium">
+                    {readiness.errors.map((error) => (
+                      <li key={error}>{error}</li>
+                    ))}
+                  </ul>
+                </div>
+              ) : null}
+
+              <div className="rounded-2xl border border-white/10 bg-gray-900 p-6 md:p-8">
+                <button
+                  type="button"
+                  disabled
+                  className="w-full cursor-not-allowed rounded-xl bg-brand-700/60 px-8 py-4 font-bold text-paper opacity-75"
+                  title="Stripe payment integration follows in PR 22."
+                >
+                  Continue to secure payment
+                </button>
+                <p className="mt-4 text-center text-xs leading-relaxed text-gray-500">
+                  PaymentIntent creation, Stripe PaymentElement and order
+                  creation remain intentionally disabled until PR 22.
+                </p>
+                {readiness.isReady && readiness.payload ? (
+                  <p className="mt-3 text-center text-xs text-brand-300">
+                    Checkout details are ready for secure payment integration.
+                  </p>
+                ) : null}
+              </div>
+            </div>
+
+            <aside className="space-y-6 lg:col-span-2 lg:sticky lg:top-28">
+              <CheckoutDiscountCard
+                value={discountCode}
+                onChange={(value) => {
+                  setDiscountCode(value);
+                  setDiscountError(null);
+                }}
+                onApply={handleApplyDiscount}
+                onRemove={handleRemoveDiscount}
+                appliedDiscount={appliedDiscount}
+                errorMessage={discountError}
+                isApplying={isApplyingDiscount}
+                disabled={!items.length}
+              />
+              <CheckoutOrderSummary
+                items={items}
+                appliedDiscount={appliedDiscount}
+                hasPhysicalItems={hasPhysicalItems}
+                hasDigitalItems={hasDigitalItems}
+              />
+              <div className="flex items-center justify-center gap-2 text-xs text-gray-500">
+                <FaLock aria-hidden="true" />
+                Payment processing will remain Stripe-protected.
+              </div>
+            </aside>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/openeire-next/components/checkout/CheckoutContactForm.tsx
+++ b/openeire-next/components/checkout/CheckoutContactForm.tsx
@@ -1,0 +1,99 @@
+"use client";
+
+import type { CheckoutContactDetails } from "@/types/checkout";
+
+interface CheckoutContactFormProps {
+  value: CheckoutContactDetails;
+  onChange: (value: CheckoutContactDetails) => void;
+  lockedEmail?: string | null;
+}
+
+const inputClass =
+  "w-full rounded-lg border border-white/20 bg-black p-4 text-white outline-none transition-all placeholder:text-gray-600 focus:border-brand-500 focus:ring-1 focus:ring-brand-500";
+
+const labelClass =
+  "mb-2 block text-xs font-bold uppercase tracking-widest text-gray-500";
+
+export function CheckoutContactForm({
+  value,
+  onChange,
+  lockedEmail,
+}: CheckoutContactFormProps) {
+  const updateField = (field: keyof CheckoutContactDetails, nextValue: string) => {
+    onChange({ ...value, [field]: nextValue });
+  };
+
+  const isEmailLocked = Boolean(lockedEmail);
+
+  return (
+    <section className="rounded-2xl border border-white/10 bg-gray-900 p-6 md:p-8">
+      <div className="mb-6 border-b border-white/10 pb-4">
+        <p className="text-xs font-bold uppercase tracking-[0.25em] text-accent">
+          Contact
+        </p>
+        <h2 className="mt-2 font-serif text-xl font-bold text-white">
+          Contact Details
+        </h2>
+      </div>
+
+      <div className="grid gap-5 md:grid-cols-2">
+        <div>
+          <label htmlFor="checkout-name" className={labelClass}>
+            Full Name
+          </label>
+          <input
+            id="checkout-name"
+            name="name"
+            value={value.name}
+            onChange={(event) => updateField("name", event.target.value)}
+            autoComplete="name"
+            className={inputClass}
+            placeholder="John Doe"
+            required
+          />
+        </div>
+
+        <div>
+          <label htmlFor="checkout-email" className={labelClass}>
+            Email
+          </label>
+          <input
+            id="checkout-email"
+            name="email"
+            type="email"
+            value={value.email}
+            onChange={(event) => updateField("email", event.target.value)}
+            autoComplete="email"
+            readOnly={isEmailLocked}
+            aria-readonly={isEmailLocked}
+            className={`${inputClass} ${isEmailLocked ? "cursor-not-allowed opacity-80" : ""}`}
+            placeholder="john@example.com"
+            required
+          />
+          {isEmailLocked && lockedEmail ? (
+            <p className="mt-2 text-xs text-gray-500">
+              Signed-in purchases use your account email: {lockedEmail}
+            </p>
+          ) : null}
+        </div>
+
+        <div className="md:col-span-2">
+          <label htmlFor="checkout-phone" className={labelClass}>
+            Phone
+          </label>
+          <input
+            id="checkout-phone"
+            name="phone"
+            value={value.phone}
+            onChange={(event) => updateField("phone", event.target.value)}
+            autoComplete="tel"
+            className={inputClass}
+            placeholder="+353 1 234 5678"
+            required
+          />
+        </div>
+      </div>
+    </section>
+  );
+}
+

--- a/openeire-next/components/checkout/CheckoutDiscountCard.tsx
+++ b/openeire-next/components/checkout/CheckoutDiscountCard.tsx
@@ -1,0 +1,84 @@
+"use client";
+
+import type { AppliedDiscount } from "@/types/checkout";
+
+interface CheckoutDiscountCardProps {
+  value: string;
+  onChange: (value: string) => void;
+  onApply: () => void;
+  onRemove: () => void;
+  appliedDiscount: AppliedDiscount | null;
+  errorMessage: string | null;
+  isApplying: boolean;
+  disabled?: boolean;
+}
+
+export function CheckoutDiscountCard({
+  value,
+  onChange,
+  onApply,
+  onRemove,
+  appliedDiscount,
+  errorMessage,
+  isApplying,
+  disabled = false,
+}: CheckoutDiscountCardProps) {
+  return (
+    <section className="rounded-2xl border border-white/10 bg-gray-950/90 p-6 shadow-2xl shadow-black/30">
+      <h2 className="font-serif text-xl font-bold text-white">Discount Code</h2>
+      <p className="mt-2 text-xs leading-relaxed text-gray-500">
+        Discounts are validated by the backend and applied only where eligible.
+      </p>
+
+      {appliedDiscount ? (
+        <div className="mt-5 rounded-xl border border-brand-500/30 bg-brand-500/10 p-4">
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <p className="text-xs font-bold uppercase tracking-[0.22em] text-accent">
+                Applied
+              </p>
+              <p className="mt-1 font-bold text-white">{appliedDiscount.code}</p>
+              {appliedDiscount.label ? (
+                <p className="mt-1 text-xs text-gray-400">
+                  {appliedDiscount.label}
+                </p>
+              ) : null}
+            </div>
+            <button
+              type="button"
+              onClick={onRemove}
+              className="text-xs font-bold uppercase tracking-[0.18em] text-gray-400 transition-colors hover:text-red-200"
+            >
+              Remove
+            </button>
+          </div>
+        </div>
+      ) : (
+        <div className="mt-5 flex flex-col gap-3 sm:flex-row lg:flex-col">
+          <input
+            value={value}
+            onChange={(event) => onChange(event.target.value.toUpperCase())}
+            disabled={disabled || isApplying}
+            placeholder="WELCOME10"
+            className="min-w-0 flex-1 rounded-xl border border-white/10 bg-black px-4 py-3 text-sm font-bold uppercase tracking-[0.16em] text-white outline-none transition-colors placeholder:text-gray-700 focus:border-accent disabled:cursor-not-allowed disabled:opacity-60"
+          />
+          <button
+            type="button"
+            onClick={onApply}
+            disabled={disabled || isApplying}
+            className="rounded-xl bg-brand-700 px-5 py-3 text-sm font-bold text-paper transition-colors hover:bg-brand-500 disabled:cursor-not-allowed disabled:bg-brand-700/50 disabled:opacity-70"
+          >
+            {isApplying ? "Applying..." : "Apply"}
+          </button>
+        </div>
+      )}
+
+      {errorMessage ? (
+        <div className="mt-4 rounded-xl border border-red-500/20 bg-red-500/10 p-3 text-sm font-bold text-red-300">
+          {errorMessage}
+        </div>
+      ) : null}
+    </section>
+  );
+}
+

--- a/openeire-next/components/checkout/CheckoutOrderSummary.tsx
+++ b/openeire-next/components/checkout/CheckoutOrderSummary.tsx
@@ -1,0 +1,121 @@
+"use client";
+
+import Link from "next/link";
+import { useMemo } from "react";
+import { formatCartCurrency, getCartTotal } from "@/lib/cart/pricing";
+import type { CartItem } from "@/lib/cart/types";
+import type { AppliedDiscount } from "@/types/checkout";
+
+interface CheckoutOrderSummaryProps {
+  items: CartItem[];
+  appliedDiscount: AppliedDiscount | null;
+  hasPhysicalItems: boolean;
+  hasDigitalItems: boolean;
+}
+
+const getItemTypeLabel = (item: CartItem): string => {
+  if (item.product.product_type === "physical") return "Fine Art Print";
+  if (item.product.product_type === "video") return "Digital Video";
+  return "Digital Photo";
+};
+
+export function CheckoutOrderSummary({
+  items,
+  appliedDiscount,
+  hasPhysicalItems,
+  hasDigitalItems,
+}: CheckoutOrderSummaryProps) {
+  const subtotal = useMemo(() => getCartTotal(items), [items]);
+  const discountAmount = appliedDiscount?.amount ?? 0;
+  const estimatedTotal = Math.max(0, subtotal - discountAmount);
+
+  return (
+    <section className="rounded-2xl border border-white/10 bg-gray-950/90 p-6 shadow-2xl shadow-black/30">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h2 className="font-serif text-xl font-bold text-white">
+            Order Summary
+          </h2>
+          <p className="mt-2 text-xs leading-relaxed text-gray-500">
+            Estimated only. Final totals are confirmed securely by the backend
+            when payment is enabled.
+          </p>
+        </div>
+        <Link
+          href="/bag"
+          className="text-xs font-bold uppercase tracking-[0.18em] text-accent hover:underline"
+        >
+          Edit
+        </Link>
+      </div>
+
+      <div className="mt-6 space-y-4">
+        {items.map((item) => (
+          <div
+            key={item.cartId}
+            className="rounded-xl border border-white/10 bg-black/40 p-4"
+          >
+            <div className="flex items-start justify-between gap-4">
+              <div className="min-w-0">
+                <p className="text-[10px] font-bold uppercase tracking-[0.22em] text-accent">
+                  {getItemTypeLabel(item)}
+                </p>
+                <p className="mt-1 font-semibold text-white">{item.product.title}</p>
+                <p className="mt-1 text-xs text-gray-500">
+                  {item.product.product_type === "physical"
+                    ? `Quantity ${item.quantity} · Physical fulfilment`
+                    : "Personal-use digital delivery"}
+                </p>
+              </div>
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <dl className="mt-6 space-y-4 border-t border-white/10 pt-6 text-sm">
+        <div className="flex items-center justify-between gap-4">
+          <dt className="text-gray-400">Subtotal</dt>
+          <dd className="font-semibold text-white">{formatCartCurrency(subtotal)}</dd>
+        </div>
+
+        {appliedDiscount ? (
+          <div className="flex items-center justify-between gap-4">
+            <dt className="text-gray-400">
+              Discount{" "}
+              <span className="text-xs uppercase text-accent">
+                ({appliedDiscount.code})
+              </span>
+            </dt>
+            <dd className="font-semibold text-brand-300">
+              -{formatCartCurrency(discountAmount)}
+            </dd>
+          </div>
+        ) : null}
+
+        <div className="flex items-center justify-between gap-4">
+          <dt className="text-gray-400">Shipping</dt>
+          <dd className="text-right font-semibold text-white">
+            {hasPhysicalItems ? "Calculated at payment step" : "No delivery charge"}
+          </dd>
+        </div>
+
+        {hasDigitalItems ? (
+          <div className="rounded-xl border border-accent/15 bg-accent/10 p-3 text-xs leading-relaxed text-gray-300">
+            Digital purchases are attached to your account and delivered through
+            secure one-time links after successful payment.
+          </div>
+        ) : null}
+
+        <div className="flex items-center justify-between gap-4 border-t border-white/10 pt-4">
+          <dt className="font-serif text-lg font-bold text-white">
+            Estimated total
+          </dt>
+          <dd className="font-serif text-2xl font-bold text-white">
+            {formatCartCurrency(estimatedTotal)}
+          </dd>
+        </div>
+      </dl>
+    </section>
+  );
+}
+

--- a/openeire-next/components/checkout/CheckoutShippingForm.tsx
+++ b/openeire-next/components/checkout/CheckoutShippingForm.tsx
@@ -1,0 +1,244 @@
+"use client";
+
+import type { Country } from "@/types/auth";
+import type { CheckoutShippingDetails, ShippingMethod } from "@/types/checkout";
+
+interface CheckoutShippingFormProps {
+  value: CheckoutShippingDetails;
+  onChange: (value: CheckoutShippingDetails) => void;
+  shippingMethod: ShippingMethod;
+  onShippingMethodChange: (value: ShippingMethod) => void;
+  countries: Country[];
+  isLoadingCountries: boolean;
+  countriesError: string | null;
+}
+
+const SHIPPING_METHODS: ShippingMethod[] = ["budget", "standard", "express"];
+
+const TRANSIT_ESTIMATES: Record<"IE" | "US", Record<ShippingMethod, string>> = {
+  IE: {
+    budget: "Estimated: Slower than Standard postal service",
+    standard: "Estimated: 5-7 working days",
+    express: "Estimated: 1-6 working days",
+  },
+  US: {
+    budget: "Estimated: Slower than Standard postal service",
+    standard: "Estimated: 4-6 working days",
+    express: "Estimated: 1-6 working days",
+  },
+};
+
+const inputClass =
+  "w-full rounded-lg border border-white/20 bg-black p-4 text-white outline-none transition-all placeholder:text-gray-600 focus:border-brand-500 focus:ring-1 focus:ring-brand-500";
+
+const labelClass =
+  "mb-2 block text-xs font-bold uppercase tracking-widest text-gray-500";
+
+export function CheckoutShippingForm({
+  value,
+  onChange,
+  shippingMethod,
+  onShippingMethodChange,
+  countries,
+  isLoadingCountries,
+  countriesError,
+}: CheckoutShippingFormProps) {
+  const updateField = (
+    field: keyof CheckoutShippingDetails,
+    nextValue: string,
+  ) => {
+    onChange({ ...value, [field]: nextValue });
+  };
+
+  const displayedCountries = countries.filter(
+    (country) => country.code === "IE" || country.code === "US",
+  );
+  const requiresState = value.country === "US";
+  const transitCountry =
+    value.country === "IE" || value.country === "US" ? value.country : null;
+
+  const getTransitEstimate = (method: ShippingMethod) => {
+    if (!transitCountry) return "Select country for estimate";
+    return TRANSIT_ESTIMATES[transitCountry][method];
+  };
+
+  return (
+    <>
+      <section className="rounded-2xl border border-white/10 bg-gray-900 p-6 md:p-8">
+        <div className="mb-6 border-b border-white/10 pb-4">
+          <p className="text-xs font-bold uppercase tracking-[0.25em] text-accent">
+            Delivery
+          </p>
+          <h2 className="mt-2 font-serif text-xl font-bold text-white">
+            Shipping Details
+          </h2>
+        </div>
+
+        {countriesError ? (
+          <div className="mb-5 rounded-xl border border-red-500/20 bg-red-500/10 p-4 text-sm font-bold text-red-300">
+            {countriesError}
+          </div>
+        ) : null}
+
+        <div className="space-y-5">
+          <div>
+            <label htmlFor="checkout-line1" className={labelClass}>
+              Address Line 1
+            </label>
+            <input
+              id="checkout-line1"
+              name="line1"
+              value={value.line1}
+              onChange={(event) => updateField("line1", event.target.value)}
+              autoComplete="address-line1"
+              className={inputClass}
+              placeholder="123 Main St"
+              required
+            />
+          </div>
+
+          <div>
+            <label htmlFor="checkout-line2" className={labelClass}>
+              Address Line 2
+            </label>
+            <input
+              id="checkout-line2"
+              name="line2"
+              value={value.line2}
+              onChange={(event) => updateField("line2", event.target.value)}
+              autoComplete="address-line2"
+              className={inputClass}
+              placeholder="Apartment, suite, etc. (optional)"
+            />
+          </div>
+
+          <div className="grid gap-5 md:grid-cols-2">
+            <div>
+              <label htmlFor="checkout-city" className={labelClass}>
+                City
+              </label>
+              <input
+                id="checkout-city"
+                name="city"
+                value={value.city}
+                onChange={(event) => updateField("city", event.target.value)}
+                autoComplete="address-level2"
+                className={inputClass}
+                placeholder="Dublin"
+                required
+              />
+            </div>
+
+            <div>
+              <label htmlFor="checkout-postal-code" className={labelClass}>
+                Postal Code
+              </label>
+              <input
+                id="checkout-postal-code"
+                name="postal_code"
+                value={value.postal_code}
+                onChange={(event) =>
+                  updateField("postal_code", event.target.value)
+                }
+                autoComplete="postal-code"
+                className={inputClass}
+                placeholder={value.country === "US" ? "12345" : "D01 X123"}
+                required
+              />
+            </div>
+          </div>
+
+          <div className="grid gap-5 md:grid-cols-2">
+            <div>
+              <label htmlFor="checkout-country" className={labelClass}>
+                Country
+              </label>
+              <select
+                id="checkout-country"
+                name="country"
+                value={value.country}
+                onChange={(event) => updateField("country", event.target.value)}
+                autoComplete="country"
+                className={inputClass}
+                disabled={isLoadingCountries}
+                required
+              >
+                <option value="">
+                  {isLoadingCountries ? "Loading countries..." : "Select Country"}
+                </option>
+                {displayedCountries.map((country) => (
+                  <option key={country.code} value={country.code}>
+                    {country.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            <div>
+              <label htmlFor="checkout-state" className={labelClass}>
+                {requiresState ? "State" : "County / Region"}
+              </label>
+              <input
+                id="checkout-state"
+                name="state"
+                value={value.state}
+                onChange={(event) => updateField("state", event.target.value)}
+                autoComplete="address-level1"
+                className={inputClass}
+                placeholder={requiresState ? "California" : "Dublin"}
+                required={requiresState}
+              />
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="rounded-2xl border border-white/10 bg-gray-900 p-6 md:p-8">
+        <div className="mb-6 border-b border-white/10 pb-4">
+          <p className="text-xs font-bold uppercase tracking-[0.25em] text-accent">
+            Fulfilment
+          </p>
+          <h2 className="mt-2 font-serif text-xl font-bold text-white">
+            Shipping Method
+          </h2>
+        </div>
+
+        <div className="space-y-4">
+          {SHIPPING_METHODS.map((method) => {
+            const isSelected = shippingMethod === method;
+            return (
+              <label
+                key={method}
+                className={`flex cursor-pointer items-start justify-between gap-4 rounded-xl border p-4 transition-all ${
+                  isSelected
+                    ? "border-brand-500 bg-brand-500/10"
+                    : "border-white/10 bg-black hover:bg-white/5"
+                }`}
+              >
+                <div>
+                  <div className="text-sm font-bold uppercase tracking-wide text-white">
+                    {method}
+                  </div>
+                  <div className="mt-1 text-xs text-gray-400">
+                    {getTransitEstimate(method)}
+                  </div>
+                </div>
+                <input
+                  type="radio"
+                  name="shipping_method"
+                  value={method}
+                  checked={isSelected}
+                  onChange={(event) =>
+                    onShippingMethodChange(event.target.value as ShippingMethod)
+                  }
+                  className="mt-1 h-4 w-4 accent-brand-500"
+                />
+              </label>
+            );
+          })}
+        </div>
+      </section>
+    </>
+  );
+}
+

--- a/openeire-next/components/checkout/CheckoutTerms.tsx
+++ b/openeire-next/components/checkout/CheckoutTerms.tsx
@@ -1,0 +1,116 @@
+"use client";
+
+import type { CheckoutFormState } from "@/types/checkout";
+
+const LIVE_LEGAL_URLS = {
+  terms: "https://openeire.ie/terms",
+  privacy: "https://openeire.ie/privacy",
+  licensing: "https://openeire.ie/licensing/terms",
+} as const;
+
+interface CheckoutTermsProps {
+  value: Pick<
+    CheckoutFormState,
+    "acceptsTerms" | "acceptsPrivacy" | "acceptsPersonalUse"
+  >;
+  hasDigitalItems: boolean;
+  onChange: (
+    value: Pick<
+      CheckoutFormState,
+      "acceptsTerms" | "acceptsPrivacy" | "acceptsPersonalUse"
+    >,
+  ) => void;
+}
+
+export function CheckoutTerms({
+  value,
+  hasDigitalItems,
+  onChange,
+}: CheckoutTermsProps) {
+  const updateField = (field: keyof CheckoutTermsProps["value"], checked: boolean) => {
+    onChange({ ...value, [field]: checked });
+  };
+
+  return (
+    <section className="rounded-2xl border border-white/10 bg-gray-900 p-6 md:p-8">
+      <div className="mb-6 border-b border-white/10 pb-4">
+        <p className="text-xs font-bold uppercase tracking-[0.25em] text-accent">
+          Review
+        </p>
+        <h2 className="mt-2 font-serif text-xl font-bold text-white">
+          Terms & Acknowledgements
+        </h2>
+      </div>
+
+      <div className="space-y-4 text-sm text-gray-300">
+        <label className="flex items-start gap-3">
+          <input
+            type="checkbox"
+            checked={value.acceptsTerms}
+            onChange={(event) => updateField("acceptsTerms", event.target.checked)}
+            className="mt-1 h-4 w-4 rounded border-white/20 bg-black text-brand-500 focus:ring-brand-500"
+          />
+          <span>
+            I agree to the{" "}
+            <a
+              href={LIVE_LEGAL_URLS.terms}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-accent underline-offset-4 hover:underline"
+            >
+              Terms & Conditions
+            </a>
+            .
+          </span>
+        </label>
+
+        <label className="flex items-start gap-3">
+          <input
+            type="checkbox"
+            checked={value.acceptsPrivacy}
+            onChange={(event) => updateField("acceptsPrivacy", event.target.checked)}
+            className="mt-1 h-4 w-4 rounded border-white/20 bg-black text-brand-500 focus:ring-brand-500"
+          />
+          <span>
+            I understand how my information is handled under the{" "}
+            <a
+              href={LIVE_LEGAL_URLS.privacy}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-accent underline-offset-4 hover:underline"
+            >
+              Privacy & Cookie Policy
+            </a>
+            .
+          </span>
+        </label>
+
+        {hasDigitalItems ? (
+          <label className="flex items-start gap-3">
+            <input
+              type="checkbox"
+              checked={value.acceptsPersonalUse}
+              onChange={(event) =>
+                updateField("acceptsPersonalUse", event.target.checked)
+              }
+              className="mt-1 h-4 w-4 rounded border-white/20 bg-black text-brand-500 focus:ring-brand-500"
+            />
+            <span>
+              I understand digital purchases are for personal use only unless a
+              separate commercial licence is agreed.{" "}
+              <a
+                href={LIVE_LEGAL_URLS.licensing}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-accent underline-offset-4 hover:underline"
+              >
+                View licence terms
+              </a>
+              .
+            </span>
+          </label>
+        ) : null}
+      </div>
+    </section>
+  );
+}

--- a/openeire-next/lib/api/checkout.ts
+++ b/openeire-next/lib/api/checkout.ts
@@ -1,0 +1,17 @@
+import { api } from "@/lib/api/client";
+import type { DiscountValidationPayload, DiscountValidationResponse } from "@/types/checkout";
+
+export const validateDiscountCode = async (
+  payload: DiscountValidationPayload,
+): Promise<DiscountValidationResponse> => {
+  const response = await api.post<DiscountValidationResponse>(
+    "checkout/validate-discount/",
+    payload,
+    {
+      cache: "no-store",
+      retryOnAuthRefresh: true,
+    },
+  );
+  return response.data;
+};
+

--- a/openeire-next/lib/api/countries.ts
+++ b/openeire-next/lib/api/countries.ts
@@ -1,0 +1,12 @@
+import { api } from "@/lib/api/client";
+import type { Country } from "@/types/auth";
+
+export const getCheckoutCountries = async (
+  signal?: AbortSignal,
+): Promise<Country[]> => {
+  const response = await api.get<Country[]>("auth/countries/", {
+    cache: "no-store",
+    signal,
+  });
+  return response.data;
+};

--- a/openeire-next/lib/checkout/payload.ts
+++ b/openeire-next/lib/checkout/payload.ts
@@ -1,0 +1,126 @@
+import type { CartItem, PhysicalCartOptions } from "@/lib/cart/types";
+import { sanitizeCartItems } from "@/lib/cart/sanitize";
+import type {
+  CheckoutCartItemPayload,
+  CheckoutFormState,
+  CreatePaymentIntentPayload,
+  ShippingMethod,
+} from "@/types/checkout";
+
+const trim = (value: string): string => value.trim();
+const isValidEmail = (value: string): boolean =>
+  /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(trim(value));
+
+const isPhysicalOptions = (
+  value: CartItem["options"],
+): value is PhysicalCartOptions =>
+  Boolean(
+    value &&
+      "variantId" in value &&
+      Number.isFinite(Number(value.variantId)) &&
+      Number(value.variantId) > 0,
+  );
+
+export const hasPhysicalCartItems = (items: CartItem[]): boolean =>
+  items.some((item) => item.product.product_type === "physical");
+
+export const hasDigitalCartItems = (items: CartItem[]): boolean =>
+  items.some((item) => item.product.product_type !== "physical");
+
+export const buildCheckoutCartPayload = (
+  cartItems: CartItem[],
+): CheckoutCartItemPayload[] =>
+  cartItems.map((item) => {
+    if (item.product.product_type === "physical") {
+      if (!isPhysicalOptions(item.options)) {
+        throw new Error(
+          "One or more print options are invalid. Remove and re-add the item.",
+        );
+      }
+
+      const variantId = Number(item.options.variantId);
+      return {
+        product_id: variantId,
+        product_type: "physical",
+        quantity: item.quantity,
+        options: {
+          material: item.options.material,
+          size: item.options.size,
+          variantId,
+        },
+      };
+    }
+
+    return {
+      product_id: item.product.id,
+      product_type: item.product.product_type,
+      quantity: 1,
+    };
+  });
+
+export const getCheckoutCartSignature = (items: CartItem[]): string =>
+  items.map((item) => `${item.cartId}:${item.quantity}`).join("|");
+
+export const hasCompleteContactDetails = (state: CheckoutFormState): boolean =>
+  Boolean(
+    trim(state.contact.name) &&
+      isValidEmail(state.contact.email) &&
+      trim(state.contact.phone),
+  );
+
+export const hasCompleteShippingDetails = (
+  state: CheckoutFormState,
+): boolean => {
+  const required = [
+    state.shipping.line1,
+    state.shipping.city,
+    state.shipping.country,
+    state.shipping.postal_code,
+  ];
+
+  if (!required.every((field) => trim(field).length > 0)) return false;
+  if (state.shipping.country === "US") return trim(state.shipping.state).length > 0;
+  return true;
+};
+
+export const buildCreatePaymentIntentPayload = ({
+  cartItems,
+  formState,
+  discountCode,
+  isAuthenticated,
+}: {
+  cartItems: CartItem[];
+  formState: CheckoutFormState;
+  discountCode?: string | null;
+  isAuthenticated: boolean;
+}): CreatePaymentIntentPayload => {
+  const sanitizedItems = sanitizeCartItems(cartItems, { isAuthenticated });
+  const hasPhysicalItems = hasPhysicalCartItems(sanitizedItems);
+  const payload: CreatePaymentIntentPayload = {
+    cart: buildCheckoutCartPayload(sanitizedItems),
+    save_info: formState.saveInfo,
+  };
+
+  if (discountCode) {
+    payload.discount_code = discountCode;
+  }
+
+  if (hasPhysicalItems) {
+    payload.shipping_method = formState.shippingMethod as ShippingMethod;
+    payload.shipping_details = {
+      name: trim(formState.contact.name),
+      email: trim(formState.contact.email),
+      phone: trim(formState.contact.phone),
+      address: {
+        line1: trim(formState.shipping.line1),
+        line2: trim(formState.shipping.line2),
+        city: trim(formState.shipping.city),
+        state: trim(formState.shipping.state),
+        country: trim(formState.shipping.country),
+        postal_code: trim(formState.shipping.postal_code),
+      },
+    };
+  }
+
+  return payload;
+};

--- a/openeire-next/types/checkout.ts
+++ b/openeire-next/types/checkout.ts
@@ -1,0 +1,105 @@
+import type { CartItem } from "@/lib/cart/types";
+
+export type ShippingMethod = "budget" | "standard" | "express";
+
+export interface CheckoutContactDetails {
+  name: string;
+  email: string;
+  phone: string;
+}
+
+export interface CheckoutShippingDetails {
+  line1: string;
+  line2: string;
+  city: string;
+  state: string;
+  country: string;
+  postal_code: string;
+}
+
+export interface CheckoutFormState {
+  contact: CheckoutContactDetails;
+  shipping: CheckoutShippingDetails;
+  shippingMethod: ShippingMethod;
+  saveInfo: boolean;
+  acceptsTerms: boolean;
+  acceptsPrivacy: boolean;
+  acceptsPersonalUse: boolean;
+}
+
+export interface CheckoutPhysicalOptionsPayload {
+  material?: string;
+  size?: string;
+  variantId: number;
+}
+
+export type CheckoutCartItemPayload =
+  | {
+      product_id: number;
+      product_type: "photo" | "video";
+      quantity: number;
+    }
+  | {
+      product_id: number;
+      product_type: "physical";
+      quantity: number;
+      options: CheckoutPhysicalOptionsPayload;
+    };
+
+export interface CheckoutShippingAddressPayload {
+  line1: string;
+  line2: string;
+  city: string;
+  state: string;
+  country: string;
+  postal_code: string;
+}
+
+export interface CheckoutShippingDetailsPayload {
+  name: string;
+  email: string;
+  phone: string;
+  address: CheckoutShippingAddressPayload;
+}
+
+export interface CreatePaymentIntentPayload {
+  cart: CheckoutCartItemPayload[];
+  save_info: boolean;
+  shipping_details?: CheckoutShippingDetailsPayload;
+  shipping_method?: ShippingMethod;
+  discount_code?: string;
+}
+
+export interface DiscountValidationPayload {
+  cart: CheckoutCartItemPayload[];
+  email?: string;
+  discount_code: string;
+}
+
+export interface DiscountValidationResponse {
+  code: string;
+  discountAmount: number;
+  discountPercent: number;
+  discountLabel: string;
+  eligibleSubtotal: number;
+}
+
+export interface AppliedDiscount {
+  code: string;
+  amount: number;
+  label: string | null;
+  eligibleSubtotal: number | null;
+}
+
+export interface CheckoutReadiness {
+  isReady: boolean;
+  errors: string[];
+  payload: CreatePaymentIntentPayload | null;
+}
+
+export interface CheckoutCartSnapshot {
+  items: CartItem[];
+  hasPhysicalItems: boolean;
+  hasDigitalItems: boolean;
+}
+


### PR DESCRIPTION
## Summary

Adds the Next.js checkout shell with contact and shipping forms, country selection, backend discount validation, legal acknowledgements, and an estimated order summary. Stripe PaymentElement, PaymentIntent creation, order creation, and fulfilment remain intentionally deferred.

## Why

Continues the staged commerce migration by preparing a secure, backend-compatible checkout experience without risking the existing Stripe, webhook, or Prodigi flows.

## Screenshots / Demo

- [ ] Not needed
- [x] Added (attach screenshots / short Loom link)

## Changes

- Backend: No changes.
- Frontend: Added the protected client-side checkout route and reusable checkout components.
- Frontend: Added typed country and discount API helpers.
- Frontend: Added sanitised checkout payload preparation using existing backend field names.
- Frontend: Preserved guest physical checkout and authenticated digital checkout rules.
- Frontend: Connected the shopping bag CTA to `/checkout`.
- Frontend: Added live legal links without storing customer details locally.
- Infra/Config: No changes.

## Testing

- [ ] Django tests pass locally — not applicable
- [x] React build passes locally
- [x] Manual smoke test done

### Manual smoke test checklist (quick)

- [x] No console errors
- [x] Forms show validation and readiness errors correctly
- [x] API errors handled with safe loading/error states
- [x] Mobile and desktop layout checked
- [x] Guest physical and authenticated digital rules verified
- [x] Empty cart redirects to `/bag`
- [x] Valid and invalid discount flows checked
- [x] Cart changes clear stale discount state
- [x] No PaymentIntent, order, Stripe confirmation, or Prodigi call occurs

## Risk & Rollback

Risk level: Medium

The checkout UI and payload preparation are new, but payment execution remains disabled. Backend pricing, discount eligibility, shipping, availability, order creation, and fulfilment remain authoritative.

Rollback plan:

- [x] Revert PR
- [ ] Feature flag off
- [ ] Hotfix path described:

## Notes for Reviewer (Codex/Copilot)

Focus review on:

- [x] Security (client-only customer data, sanitised cart payloads, backend-authoritative totals)
- [x] Performance (request cancellation and avoiding unnecessary API calls)
- [x] Maintainability (typed helpers, focused components, and Stripe-ready payload structure)

Please confirm that PR 22 continues to revalidate all checkout data through `create-payment-intent/` and does not trust the estimated frontend total.