### PR TITLE
Harden checkout success verification and cart cleanup

### DIFF
--- a/openeire-next/app/checkout-success/page.tsx
+++ b/openeire-next/app/checkout-success/page.tsx
@@ -4,6 +4,7 @@ import { CheckoutSuccessClient } from "@/components/checkout/CheckoutSuccessClie
 
 export const metadata: Metadata = {
   title: "Payment Status | OpenÉire Studios",
+  description: "Review the status of your OpenÉire Studios payment submission.",
   robots: {
     index: false,
     follow: false,

--- a/openeire-next/components/auth/AuthProvider.tsx
+++ b/openeire-next/components/auth/AuthProvider.tsx
@@ -22,6 +22,7 @@ import {
   migrateLegacyLocalStorageTokens,
   setTokens,
 } from "@/lib/auth/tokenStorage";
+import { clearCheckoutSuccessContext } from "@/lib/checkout/successContext";
 import type { LoginPayload, RegisterPayload, UserProfile } from "@/types/auth";
 
 interface AuthContextValue {
@@ -46,6 +47,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const logout = useCallback(() => {
     clearTokens();
+    clearCheckoutSuccessContext();
     setUser(null);
   }, []);
 
@@ -110,6 +112,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
   const login = useCallback(
     async (payload: LoginPayload) => {
+      clearCheckoutSuccessContext();
       const tokens = await loginUser(payload);
       if (!tokens.access || !tokens.refresh) {
         throw new Error("Malformed login response.");

--- a/openeire-next/components/checkout/CheckoutClient.tsx
+++ b/openeire-next/components/checkout/CheckoutClient.tsx
@@ -243,11 +243,12 @@ export function CheckoutClient() {
   const checkoutSuccessContext = useMemo(
     () => ({
       paymentIntentId: paymentIntentId ?? "",
+      cartSignature,
       hasDigitalItems,
       hasPhysicalItems,
       itemCount: items.reduce((total, item) => total + item.quantity, 0),
     }),
-    [hasDigitalItems, hasPhysicalItems, items, paymentIntentId],
+    [cartSignature, hasDigitalItems, hasPhysicalItems, items, paymentIntentId],
   );
 
   useEffect(() => {

--- a/openeire-next/components/checkout/CheckoutSuccessClient.tsx
+++ b/openeire-next/components/checkout/CheckoutSuccessClient.tsx
@@ -2,71 +2,141 @@
 
 import Link from "next/link";
 import { useSearchParams } from "next/navigation";
-import { useEffect, useMemo, useState } from "react";
-import { FaCheckCircle, FaClock, FaExclamationCircle } from "react-icons/fa";
+import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  FaBoxOpen,
+  FaCheckCircle,
+  FaClock,
+  FaDownload,
+  FaEnvelope,
+  FaExclamationCircle,
+} from "react-icons/fa";
+import { useAuth } from "@/components/auth/AuthProvider";
 import { useCart } from "@/components/cart/CartProvider";
 import {
   clearCheckoutSuccessContext,
+  isCheckoutSuccessHistoryEntry,
+  markCheckoutSuccessHistoryEntry,
   readCheckoutSuccessContext,
+  stripCheckoutReturnParameters,
+  writeCheckoutSuccessContext,
 } from "@/lib/checkout/successContext";
+import { getCheckoutCartSignature } from "@/lib/checkout/payload";
 import { stripePromise } from "@/lib/stripe/client";
 import type { CheckoutSuccessContext } from "@/types/checkout";
 
-type RedirectStatus = "succeeded" | "processing" | "incomplete";
+type RedirectStatus =
+  | "checking"
+  | "succeeded"
+  | "processing"
+  | "incomplete"
+  | "unavailable";
+
+const emptyContext = (paymentIntentId: string): CheckoutSuccessContext => ({
+  paymentIntentId,
+  cartSignature: "",
+  hasDigitalItems: false,
+  hasPhysicalItems: false,
+  itemCount: 0,
+});
 
 export function CheckoutSuccessClient() {
   const searchParams = useSearchParams();
-  const { clearCart, isLoaded: isCartLoaded } = useCart();
+  const { isAuthenticated, isLoading: isAuthLoading } = useAuth();
+  const { clearCart, isLoaded: isCartLoaded, items } = useCart();
+  const hasClearedCart = useRef(false);
   const [context, setContext] = useState<CheckoutSuccessContext | null>(null);
   const [displayStatus, setDisplayStatus] =
-    useState<RedirectStatus>("processing");
+    useState<RedirectStatus>("checking");
 
   useEffect(() => {
     const storedContext = readCheckoutSuccessContext();
-    setContext(storedContext);
     const clientSecret = searchParams.get("payment_intent_client_secret") ?? "";
     const paymentIntentId = searchParams.get("payment_intent") ?? "";
-    window.history.replaceState(window.history.state, "", "/checkout-success");
+    const hasReturnParameters = Boolean(clientSecret || paymentIntentId);
+
+    setContext(storedContext);
+
+    if (!hasReturnParameters) {
+      if (
+        storedContext?.returnStatus &&
+        isCheckoutSuccessHistoryEntry(storedContext.paymentIntentId)
+      ) {
+        setDisplayStatus(storedContext.returnStatus);
+      } else {
+        clearCheckoutSuccessContext();
+        setContext(null);
+        setDisplayStatus("unavailable");
+      }
+      return;
+    }
+
+    stripCheckoutReturnParameters();
+
+    if (!clientSecret || !paymentIntentId) {
+      clearCheckoutSuccessContext();
+      setDisplayStatus("unavailable");
+      return;
+    }
+
+    if (
+      storedContext?.paymentIntentId &&
+      storedContext.paymentIntentId !== paymentIntentId
+    ) {
+      clearCheckoutSuccessContext();
+      setDisplayStatus("unavailable");
+      return;
+    }
 
     let isActive = true;
     const verifyPayment = async () => {
-      if (!clientSecret || !paymentIntentId || !stripePromise) {
-        clearCheckoutSuccessContext();
-        if (isActive) setDisplayStatus("incomplete");
-        return;
-      }
-      if (
-        storedContext?.paymentIntentId &&
-        storedContext.paymentIntentId !== paymentIntentId
-      ) {
-        clearCheckoutSuccessContext();
-        if (isActive) setDisplayStatus("incomplete");
-        return;
-      }
-
       try {
         const stripe = await stripePromise;
         if (!stripe) {
-          if (isActive) setDisplayStatus("processing");
+          clearCheckoutSuccessContext();
+          if (isActive) setDisplayStatus("unavailable");
           return;
         }
+
         const { paymentIntent, error } = await stripe.retrievePaymentIntent(
           clientSecret,
         );
         if (!isActive) return;
+
         if (error || !paymentIntent || paymentIntent.id !== paymentIntentId) {
-          setDisplayStatus("processing");
-        } else if (paymentIntent.status === "succeeded") {
-          setDisplayStatus("succeeded");
-        } else if (paymentIntent.status === "processing") {
-          setDisplayStatus("processing");
-        } else {
-          setDisplayStatus("incomplete");
+          clearCheckoutSuccessContext();
+          setDisplayStatus("unavailable");
+          return;
         }
-      } catch {
-        if (isActive) setDisplayStatus("processing");
-      } finally {
+
+        if (paymentIntent.status === "succeeded") {
+          const verifiedContext: CheckoutSuccessContext = {
+            ...(storedContext ?? emptyContext(paymentIntentId)),
+            paymentIntentId,
+            returnStatus: "succeeded",
+            returnRecordedAt: Date.now(),
+          };
+          writeCheckoutSuccessContext(verifiedContext);
+          markCheckoutSuccessHistoryEntry(paymentIntentId);
+          setContext(verifiedContext);
+          setDisplayStatus("succeeded");
+          return;
+        }
+
+        if (paymentIntent.status === "processing") {
+          // Processing is deliberately not persisted because it can later fail.
+          // A refresh must not present a stale status without rechecking Stripe.
+          clearCheckoutSuccessContext();
+          setContext(storedContext ?? emptyContext(paymentIntentId));
+          setDisplayStatus("processing");
+          return;
+        }
+
         clearCheckoutSuccessContext();
+        setDisplayStatus("incomplete");
+      } catch {
+        clearCheckoutSuccessContext();
+        if (isActive) setDisplayStatus("unavailable");
       }
     };
 
@@ -77,15 +147,36 @@ export function CheckoutSuccessClient() {
   }, [searchParams]);
 
   useEffect(() => {
-    if (displayStatus === "succeeded" && isCartLoaded) clearCart();
-  }, [clearCart, displayStatus, isCartLoaded]);
+    const cartMatchesReceipt = Boolean(
+      context?.cartSignature &&
+        context.cartSignature === getCheckoutCartSignature(items),
+    );
+    if (
+      displayStatus === "succeeded" &&
+      isCartLoaded &&
+      cartMatchesReceipt &&
+      !hasClearedCart.current
+    ) {
+      hasClearedCart.current = true;
+      clearCart();
+    }
+  }, [clearCart, context?.cartSignature, displayStatus, isCartLoaded, items]);
 
   const content = useMemo(() => {
+    if (displayStatus === "checking") {
+      return {
+        title: "Checking payment status",
+        description: "We’re securely checking the result returned by Stripe.",
+        icon: FaClock,
+        iconClass: "text-accent",
+      };
+    }
+
     if (displayStatus === "succeeded") {
       return {
-        title: "Payment received",
+        title: "Thank you — payment submitted",
         description:
-          "Stripe accepted your payment. Our secure webhook is now confirming your order; your confirmation email and account order history are the source of truth.",
+          "We’re finalising your order now. Your confirmation email will arrive once backend processing is complete.",
         icon: FaCheckCircle,
         iconClass: "text-brand-400",
       };
@@ -95,25 +186,54 @@ export function CheckoutSuccessClient() {
       return {
         title: "Payment processing",
         description:
-          "Stripe is still processing your payment. Keep your bag unchanged and wait for the confirmation email before trying again.",
+          "Stripe is still confirming the payment. Please wait for your confirmation email before submitting the order again.",
         icon: FaClock,
         iconClass: "text-accent",
       };
     }
 
+    if (displayStatus === "incomplete") {
+      return {
+        title: "Payment not completed",
+        description:
+          "Stripe did not return a successful payment status. Your bag remains available so you can review checkout and try again.",
+        icon: FaExclamationCircle,
+        iconClass: "text-red-300",
+      };
+    }
+
     return {
-      title: "Payment not completed",
+      title: "No payment status available",
       description:
-        "We have not received a successful Stripe result. Your bag is still available so you can review the checkout and try again safely.",
+        "We cannot verify a recent payment from this page. If you completed checkout, use your confirmation email or account order history as the source of truth.",
       icon: FaExclamationCircle,
-      iconClass: "text-red-300",
+      iconClass: "text-gray-400",
     };
   }, [displayStatus]);
 
+  const isReturnedPayment =
+    displayStatus === "succeeded" || displayStatus === "processing";
   const StatusIcon = content.icon;
+  const showAccountLink =
+    isReturnedPayment && !isAuthLoading && isAuthenticated;
+  const primaryHref = showAccountLink
+    ? "/profile"
+    : displayStatus === "incomplete" || displayStatus === "unavailable"
+      ? "/checkout"
+      : "/gallery/physical";
+  const primaryLabel = showAccountLink
+    ? "View Account & Orders"
+    : displayStatus === "incomplete" || displayStatus === "unavailable"
+      ? "Return to Checkout"
+      : "Continue Browsing";
 
   return (
-    <main className="page-top-offset flex min-h-screen items-center justify-center bg-black px-4 pb-24 pt-16 text-white md:pt-20">
+    <main
+      className="flex min-h-screen items-start justify-center bg-black px-4 pb-24 text-white"
+      style={{
+        paddingTop: "calc(var(--site-header-height, 0px) + 2rem)",
+      }}
+    >
       <section className="w-full max-w-2xl rounded-2xl border border-white/10 bg-gray-900 p-8 text-center shadow-2xl md:p-12">
         <StatusIcon
           className={`mx-auto mb-7 h-16 w-16 ${content.iconClass}`}
@@ -126,32 +246,83 @@ export function CheckoutSuccessClient() {
           {content.description}
         </p>
 
-        {displayStatus === "succeeded" && context ? (
-          <div className="mx-auto mt-7 max-w-lg rounded-xl border border-white/10 bg-black/40 p-4 text-sm text-gray-300">
-            {context.hasDigitalItems && context.hasPhysicalItems
-              ? "Your digital delivery and physical fulfilment will appear after backend confirmation."
-              : context.hasDigitalItems
-                ? "Your secure digital delivery will appear after backend confirmation."
-                : "Your physical fulfilment will begin after backend confirmation."}
+        {isReturnedPayment ? (
+          <div className="mt-8 grid gap-4 text-left">
+            <div className="rounded-xl border border-white/10 bg-black/40 p-5">
+              <div className="flex items-center gap-3 text-white">
+                <FaEnvelope className="text-accent" aria-hidden="true" />
+                <h2 className="font-bold">Confirmation email</h2>
+              </div>
+              <p className="mt-2 text-sm leading-relaxed text-gray-400">
+                Your receipt and order confirmation are sent after the secure
+                backend webhook finishes processing.
+              </p>
+            </div>
+
+            {context?.hasDigitalItems ? (
+              <div className="rounded-xl border border-white/10 bg-black/40 p-5">
+                <div className="flex items-center gap-3 text-white">
+                  <FaDownload className="text-brand-400" aria-hidden="true" />
+                  <h2 className="font-bold">Digital delivery</h2>
+                </div>
+                <p className="mt-2 text-sm leading-relaxed text-gray-400">
+                  Personal-use download and licence links will be delivered by
+                  email and through your account where available after the order
+                  is created.
+                </p>
+              </div>
+            ) : null}
+
+            {context?.hasPhysicalItems ? (
+              <div className="rounded-xl border border-white/10 bg-black/40 p-5">
+                <div className="flex items-center gap-3 text-white">
+                  <FaBoxOpen className="text-blue-400" aria-hidden="true" />
+                  <h2 className="font-bold">Print fulfilment</h2>
+                </div>
+                <p className="mt-2 text-sm leading-relaxed text-gray-400">
+                  Physical prints move to production only after backend order
+                  confirmation. Tracking details will follow by email.
+                </p>
+              </div>
+            ) : null}
           </div>
+        ) : null}
+
+        {isReturnedPayment && !isAuthLoading ? (
+          <p className="mx-auto mt-6 max-w-lg text-sm leading-relaxed text-gray-400">
+            {isAuthenticated
+              ? "Orders, downloads, and licences may take a moment to appear in your account while processing completes."
+              : "As a guest, your confirmation and fulfilment updates will be sent to the email used at checkout."}
+          </p>
         ) : null}
 
         <div className="mt-9 flex flex-col justify-center gap-3 sm:flex-row">
           <Link
-            href={displayStatus === "incomplete" ? "/checkout" : "/profile"}
-            className="rounded-xl bg-brand-500 px-7 py-4 font-bold text-black transition-colors hover:bg-white"
+            href={primaryHref}
+            className="rounded-xl bg-brand-500 px-7 py-4 font-bold text-black transition-colors hover:bg-white focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-400"
           >
-            {displayStatus === "incomplete"
-              ? "Return to Checkout"
-              : "View Account"}
+            {primaryLabel}
           </Link>
           <Link
             href="/"
-            className="rounded-xl border border-white/15 px-7 py-4 font-bold text-white transition-colors hover:bg-white/10"
+            className="rounded-xl border border-white/15 px-7 py-4 font-bold text-white transition-colors hover:bg-white/10 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-white"
           >
             Return Home
           </Link>
         </div>
+
+        {isReturnedPayment ? (
+          <p className="mt-7 text-sm text-gray-500">
+            No confirmation email after 15 minutes?{" "}
+            <Link
+              href="/contact"
+              className="text-accent underline underline-offset-4 hover:text-white"
+            >
+              Contact support
+            </Link>
+            .
+          </p>
+        ) : null}
       </section>
     </main>
   );

--- a/openeire-next/lib/checkout/successContext.ts
+++ b/openeire-next/lib/checkout/successContext.ts
@@ -1,6 +1,15 @@
 import type { CheckoutSuccessContext } from "@/types/checkout";
 
 const CHECKOUT_SUCCESS_CONTEXT_KEY = "checkoutSuccessContext";
+const CHECKOUT_SUCCESS_HISTORY_KEY = "openeireCheckoutSuccessPaymentIntent";
+const CHECKOUT_RETURN_MAX_AGE_MS = 24 * 60 * 60 * 1000;
+
+const getHistoryState = (): Record<string, unknown> => {
+  const state = window.history.state;
+  return state && typeof state === "object"
+    ? (state as Record<string, unknown>)
+    : {};
+};
 
 export const writeCheckoutSuccessContext = (
   context: CheckoutSuccessContext,
@@ -24,16 +33,32 @@ export const readCheckoutSuccessContext = (): CheckoutSuccessContext | null => {
     if (!raw) return null;
     const parsed = JSON.parse(raw) as Partial<CheckoutSuccessContext>;
     const itemCount = Number(parsed.itemCount);
+    const returnRecordedAt = Number(parsed.returnRecordedAt);
+    const hasFreshReturnStatus =
+      parsed.returnStatus === "succeeded" &&
+      Number.isFinite(returnRecordedAt) &&
+      returnRecordedAt > 0 &&
+      Date.now() - returnRecordedAt <= CHECKOUT_RETURN_MAX_AGE_MS;
 
     return {
       paymentIntentId:
         typeof parsed.paymentIntentId === "string"
           ? parsed.paymentIntentId.trim()
           : "",
+      cartSignature:
+        typeof parsed.cartSignature === "string"
+          ? parsed.cartSignature.trim()
+          : "",
       hasDigitalItems: Boolean(parsed.hasDigitalItems),
       hasPhysicalItems: Boolean(parsed.hasPhysicalItems),
       itemCount:
         Number.isInteger(itemCount) && itemCount > 0 ? itemCount : 0,
+      ...(hasFreshReturnStatus
+        ? {
+            returnStatus: parsed.returnStatus,
+            returnRecordedAt,
+          }
+        : {}),
     };
   } catch {
     return null;
@@ -47,4 +72,30 @@ export const clearCheckoutSuccessContext = (): void => {
   } catch {
     // Ignore storage restrictions; payment and order state live elsewhere.
   }
+};
+
+export const markCheckoutSuccessHistoryEntry = (
+  paymentIntentId: string,
+): void => {
+  if (typeof window === "undefined") return;
+  window.history.replaceState(
+    {
+      ...getHistoryState(),
+      [CHECKOUT_SUCCESS_HISTORY_KEY]: paymentIntentId,
+    },
+    "",
+    "/checkout-success",
+  );
+};
+
+export const isCheckoutSuccessHistoryEntry = (
+  paymentIntentId: string,
+): boolean => {
+  if (typeof window === "undefined" || !paymentIntentId) return false;
+  return getHistoryState()[CHECKOUT_SUCCESS_HISTORY_KEY] === paymentIntentId;
+};
+
+export const stripCheckoutReturnParameters = (): void => {
+  if (typeof window === "undefined") return;
+  window.history.replaceState(getHistoryState(), "", "/checkout-success");
 };

--- a/openeire-next/types/checkout.ts
+++ b/openeire-next/types/checkout.ts
@@ -131,7 +131,10 @@ export interface CheckoutCartSnapshot {
 
 export interface CheckoutSuccessContext {
   paymentIntentId: string;
+  cartSignature: string;
   hasDigitalItems: boolean;
   hasPhysicalItems: boolean;
   itemCount: number;
+  returnStatus?: "succeeded";
+  returnRecordedAt?: number;
 }


### PR DESCRIPTION
## Summary

Hardens the Next checkout-success flow so it only displays verified Stripe results and only clears the cart associated with the completed payment.

## Why

Stale checkout state could display a previous successful payment after direct navigation, logout, or a later checkout. Stripe lookup failures could also appear incorrectly as processing.

## Screenshots / Demo

- [x] Not needed
- [ ] Added

## Changes

- Backend: No changes.
- Frontend: Bind successful status to the verified PaymentIntent and browser history entry.
- Frontend: Clear success state during login/logout.
- Frontend: Do not persist unresolved Stripe processing states.
- Frontend: Show “status unavailable” when Stripe verification fails.
- Frontend: Clear only the cart whose signature matches the completed checkout.
- Frontend: Fix checkout-success spacing beneath the responsive navbar.
- Infra/Config: No changes.

## Testing

- [ ] Django tests pass locally
- [x] Next.js lint passes locally
- [x] Next.js production build passes locally
- [x] Manual payment smoke test done
- [x] npm audit passes with 0 vulnerabilities

### Manual smoke test checklist (quick)

- [x] Successful Stripe payment reaches the result page
- [x] Stripe creates only one payment
- [x] Prodigi receives a valid physical order
- [x] Direct checkout-success navigation does not reuse stale success
- [x] Auth changes clear stale checkout-result context
- [x] Navbar no longer covers the result card
- [ ] Recheck unavailable-status and mismatched-cart states after deploy

## Risk & Rollback

Risk level: Medium

Rollback plan:

- [x] Revert PR
- [ ] Feature flag off
- [ ] Hotfix path described

## Notes for Reviewer (Codex/Copilot)

Focus review on:

- [x] Security and PaymentIntent verification boundaries
- [x] Idempotent cart cleanup
- [x] Browser history/session state lifecycle
- [x] Maintainability