### PR TITLE
Harden cart and checkout state handling

### DIFF
--- a/openeire-next/components/cart/CartProvider.tsx
+++ b/openeire-next/components/cart/CartProvider.tsx
@@ -10,7 +10,11 @@ import {
   type ReactNode,
 } from "react";
 import { useAuth } from "@/components/auth/AuthProvider";
-import { buildCartId, sanitizeCartItems } from "@/lib/cart/sanitize";
+import {
+  buildCartId,
+  MAX_CART_ITEM_QUANTITY,
+  sanitizeCartItems,
+} from "@/lib/cart/sanitize";
 import { readStoredCart, writeStoredCart } from "@/lib/cart/storage";
 import type { AddToCartInput, CartItem } from "@/lib/cart/types";
 
@@ -49,7 +53,10 @@ export function CartProvider({ children }: { children: ReactNode }) {
       if (input.product.product_type !== "physical" && !isAuthenticated) return;
 
       const quantity = Number.isFinite(input.quantity)
-        ? Math.max(1, Math.floor(input.quantity ?? 1))
+        ? Math.min(
+            MAX_CART_ITEM_QUANTITY,
+            Math.max(1, Math.floor(input.quantity ?? 1)),
+          )
         : 1;
       const cartId = buildCartId(input.product, input.options);
       const nextItem: CartItem = {
@@ -76,7 +83,10 @@ export function CartProvider({ children }: { children: ReactNode }) {
           ...existing,
           quantity:
             existing.product.product_type === "physical"
-              ? existing.quantity + nextItem.quantity
+              ? Math.min(
+                  MAX_CART_ITEM_QUANTITY,
+                  existing.quantity + nextItem.quantity,
+                )
               : 1,
         };
         return sanitizeCartItems(nextItems, { isAuthenticated });
@@ -93,7 +103,13 @@ export function CartProvider({ children }: { children: ReactNode }) {
           if (item.product.product_type !== "physical") {
             return { ...item, quantity: 1 };
           }
-          return { ...item, quantity: Math.max(0, Math.floor(quantity)) };
+          return {
+            ...item,
+            quantity: Math.min(
+              MAX_CART_ITEM_QUANTITY,
+              Math.max(0, Math.floor(quantity)),
+            ),
+          };
         })
         .filter((item) => item.quantity > 0),
     );

--- a/openeire-next/components/checkout/CheckoutClient.tsx
+++ b/openeire-next/components/checkout/CheckoutClient.tsx
@@ -205,6 +205,7 @@ export function CheckoutClient() {
   const [paymentError, setPaymentError] = useState<string | null>(null);
   const prefilledProfileRef = useRef(false);
   const intentRequestSequenceRef = useRef(0);
+  const discountRequestSequenceRef = useRef(0);
   const activeIntentRequestRef = useRef<ActiveIntentRequest | null>(null);
   const latestCheckoutSignatureRef = useRef("");
   const checkoutRequestIdentityRef = useRef<CheckoutRequestIdentity | null>(null);
@@ -212,6 +213,18 @@ export function CheckoutClient() {
   const hasPhysicalItems = useMemo(() => hasPhysicalCartItems(items), [items]);
   const hasDigitalItems = useMemo(() => hasDigitalCartItems(items), [items]);
   const cartSignature = useMemo(() => getCheckoutCartSignature(items), [items]);
+  const discountCustomerEmail = (
+    formState.contact.email || user?.email || ""
+  )
+    .trim()
+    .toLowerCase();
+  const discountRequestSignature = JSON.stringify({
+    cart: cartSignature,
+    email: discountCustomerEmail,
+    code: discountCode.trim().toUpperCase(),
+  });
+  const latestDiscountRequestSignatureRef = useRef(discountRequestSignature);
+  latestDiscountRequestSignatureRef.current = discountRequestSignature;
   const requiresAuthenticatedCheckout = hasDigitalItems;
   const checkoutStateSignature = useMemo(
     () =>
@@ -309,9 +322,11 @@ export function CheckoutClient() {
   }, [hasPhysicalItems]);
 
   useEffect(() => {
+    discountRequestSequenceRef.current += 1;
     setAppliedDiscount(null);
     setDiscountError(null);
-  }, [cartSignature]);
+    setIsApplyingDiscount(false);
+  }, [cartSignature, discountCustomerEmail]);
 
   useEffect(() => {
     const activeRequest = activeIntentRequestRef.current;
@@ -418,6 +433,8 @@ export function CheckoutClient() {
 
     setIsApplyingDiscount(true);
     setDiscountError(null);
+    const requestId = ++discountRequestSequenceRef.current;
+    const requestSignature = discountRequestSignature;
 
     try {
       const response = await validateDiscountCode({
@@ -425,6 +442,13 @@ export function CheckoutClient() {
         email: email || user?.email || undefined,
         discount_code: normalizedCode,
       });
+
+      if (
+        requestId !== discountRequestSequenceRef.current ||
+        requestSignature !== latestDiscountRequestSignatureRef.current
+      ) {
+        return;
+      }
 
       setAppliedDiscount({
         code: response.code,
@@ -434,6 +458,12 @@ export function CheckoutClient() {
       });
       setDiscountCode(response.code);
     } catch (error) {
+      if (
+        requestId !== discountRequestSequenceRef.current ||
+        requestSignature !== latestDiscountRequestSignatureRef.current
+      ) {
+        return;
+      }
       setAppliedDiscount(null);
       setDiscountError(
         getErrorMessage(
@@ -442,9 +472,11 @@ export function CheckoutClient() {
         ),
       );
     } finally {
-      setIsApplyingDiscount(false);
+      if (requestId === discountRequestSequenceRef.current) {
+        setIsApplyingDiscount(false);
+      }
     }
-  }, [discountCode, formState.contact.email, items, user?.email]);
+  }, [discountCode, discountRequestSignature, formState.contact.email, items, user?.email]);
 
   const handleRemoveDiscount = useCallback(() => {
     setAppliedDiscount(null);

--- a/openeire-next/components/checkout/StripePaymentForm.tsx
+++ b/openeire-next/components/checkout/StripePaymentForm.tsx
@@ -9,7 +9,7 @@ import type {
   ConfirmPaymentData,
   StripePaymentElementOptions,
 } from "@stripe/stripe-js";
-import { useMemo, useState, type FormEvent } from "react";
+import { useMemo, useRef, useState, type FormEvent } from "react";
 import { FaCreditCard } from "react-icons/fa";
 import {
   clearCheckoutSuccessContext,
@@ -50,6 +50,7 @@ export function StripePaymentForm({
   const elements = useElements();
   const [isElementReady, setIsElementReady] = useState(false);
   const [isProcessing, setIsProcessing] = useState(false);
+  const processingRef = useRef(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   const paymentElementOptions = useMemo<StripePaymentElementOptions>(
@@ -92,7 +93,7 @@ export function StripePaymentForm({
 
   const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    if (isProcessing || isCheckoutBusy) return;
+    if (processingRef.current || isProcessing || isCheckoutBusy) return;
 
     if (!isIntentCurrent) {
       setErrorMessage(
@@ -106,6 +107,7 @@ export function StripePaymentForm({
       return;
     }
 
+    processingRef.current = true;
     setIsProcessing(true);
     setErrorMessage(null);
 
@@ -150,6 +152,7 @@ export function StripePaymentForm({
         "Payment could not be completed because of a network error. Please try again.",
       );
     } finally {
+      processingRef.current = false;
       setIsProcessing(false);
     }
   };

--- a/openeire-next/lib/cart/pricing.ts
+++ b/openeire-next/lib/cart/pricing.ts
@@ -1,7 +1,7 @@
 import type { CartItem, CartProductSnapshot } from "@/lib/cart/types";
 
 const parsePrice = (value: unknown): number => {
-  const parsed = Number.parseFloat(String(value ?? ""));
+  const parsed = Number(value);
   return Number.isFinite(parsed) && parsed >= 0 ? parsed : 0;
 };
 

--- a/openeire-next/lib/cart/sanitize.ts
+++ b/openeire-next/lib/cart/sanitize.ts
@@ -13,6 +13,8 @@ const SUPPORTED_PRODUCT_TYPES = new Set<CartProductType>([
   "video",
 ]);
 
+export const MAX_CART_ITEM_QUANTITY = 100;
+
 const toPositiveInteger = (value: unknown): number | null => {
   const parsed = Number(value);
   if (!Number.isInteger(parsed) || parsed <= 0) return null;
@@ -31,9 +33,9 @@ const sanitizePrice = (value: unknown): string | number | null | undefined => {
   if (value === undefined || value === null || value === "") {
     return value as null | undefined;
   }
-  const parsed = Number.parseFloat(String(value));
+  const parsed = Number(value);
   return Number.isFinite(parsed) && parsed >= 0
-    ? (value as string | number)
+    ? parsed
     : undefined;
 };
 
@@ -116,13 +118,17 @@ export const sanitizeCartItem = (
     return null;
   }
 
-  const quantity = toPositiveInteger(value.quantity) ?? 1;
+  const quantity = Math.min(
+    toPositiveInteger(value.quantity) ?? 1,
+    MAX_CART_ITEM_QUANTITY,
+  );
   const sanitizedOptions = sanitizeOptions(value.options, product.product_type);
   if (product.product_type === "physical" && !sanitizedOptions) return null;
 
   const productId = toPositiveInteger(value.productId) ?? product.id;
-  const cartId =
-    toSafeString(value.cartId) ?? buildCartId(product, sanitizedOptions);
+  // Persisted cart IDs are untrusted and legacy clients used different JSON
+  // property ordering. Always rebuild a canonical identity from safe fields.
+  const cartId = buildCartId(product, sanitizedOptions);
 
   return {
     cartId,
@@ -138,7 +144,26 @@ export const sanitizeCartItems = (
   options: { isAuthenticated: boolean },
 ): CartItem[] => {
   if (!Array.isArray(value)) return [];
-  return value
+  const sanitizedItems = value
     .map((item) => sanitizeCartItem(item, options))
     .filter((item): item is CartItem => item !== null);
+
+  return sanitizedItems.reduce<CartItem[]>((mergedItems, item) => {
+    const existingIndex = mergedItems.findIndex(
+      (candidate) => candidate.cartId === item.cartId,
+    );
+    if (existingIndex === -1) return [...mergedItems, item];
+
+    if (item.product.product_type === "physical") {
+      const existing = mergedItems[existingIndex];
+      mergedItems[existingIndex] = {
+        ...existing,
+        quantity: Math.min(
+          existing.quantity + item.quantity,
+          MAX_CART_ITEM_QUANTITY,
+        ),
+      };
+    }
+    return mergedItems;
+  }, []);
 };

--- a/openeire-next/lib/cart/storage.ts
+++ b/openeire-next/lib/cart/storage.ts
@@ -19,10 +19,18 @@ export const readStoredCart = (options: {
 
 export const writeStoredCart = (items: CartItem[]): void => {
   if (typeof window === "undefined") return;
-  window.localStorage.setItem(CART_STORAGE_KEY, JSON.stringify(items));
+  try {
+    window.localStorage.setItem(CART_STORAGE_KEY, JSON.stringify(items));
+  } catch {
+    // Storage is optional. The in-memory cart remains usable for this session.
+  }
 };
 
 export const clearStoredCart = (): void => {
   if (typeof window === "undefined") return;
-  window.localStorage.removeItem(CART_STORAGE_KEY);
+  try {
+    window.localStorage.removeItem(CART_STORAGE_KEY);
+  } catch {
+    // Ignore browser storage restrictions.
+  }
 };


### PR DESCRIPTION
## Summary

Hardens the migrated Next.js cart and checkout against malformed persisted data, stale discount responses, duplicate items, excessive quantities, storage failures, and rapid duplicate payment submissions.

## Why

The commerce QA pass identified edge cases that could cause inconsistent cart presentation or stale checkout state. Backend pricing, Stripe confirmation, and webhook-only order creation remain authoritative and unchanged.

## Screenshots / Demo

- [x] Not needed
- [ ] Added (attach screenshots / short Loom link)

## Changes

- Backend: No frontend-repository backend changes.
- Frontend: Canonicalised restored cart identities and merged duplicate items.
- Frontend: Enforced the backend quantity limit of 100.
- Frontend: Rejected malformed persisted price values.
- Frontend: Made localStorage failures non-fatal.
- Frontend: Invalidated stale discount responses after cart, email, or code changes.
- Frontend: Added an immediate lock against duplicate Stripe confirmation submissions.
- Infra/Config: No changes.

## Testing

- [x] Django tests pass locally
- [x] React build passes locally
- [x] Manual smoke test done

### Manual smoke test checklist (quick)

- [x] No console errors
- [x] Forms submit correctly (success + validation errors)
- [x] API errors handled (loading/error states)
- [x] Mobile layout checked
- [x] Auth/permissions verified (if relevant)

## Risk & Rollback

Risk level: Medium

Rollback plan:

- [x] Revert PR
- [ ] Feature flag off
- [ ] Hotfix path described:

## Notes for Reviewer (Codex/Copilot)

Focus review on:

- [x] Security (auth, permissions, file uploads, CSRF/CORS)
- [x] Performance (N+1 queries, heavy renders, unnecessary requests)
- [x] Maintainability (naming, structure, duplicated logic)

Validation completed:
- `npm run lint`
- `npm run build`
- `npm audit`
- `npm audit --omit=dev`
- `npm ls axios plain-crypto-js`
- Zero vulnerabilities; Axios and plain-crypto-js are absent.