### PR TITLE
Migrate legal and policy pages to Next.js

### DIFF
--- a/openeire-next/.env.example
+++ b/openeire-next/.env.example
@@ -1,2 +1,4 @@
 NEXT_PUBLIC_API_BASE_URL=https://api.openeire.ie/api/
 NEXT_PUBLIC_STRIPE_PUBLIC_KEY=pk_test_replace_me
+NEXT_PUBLIC_IUBENDA_POLICY_URL=https://www.iubenda.com/privacy-policy/77203310
+NEXT_PUBLIC_IUBENDA_POLICY_EMBED_URL=https://www.iubenda.com/privacy-policy/77203310/legal

--- a/openeire-next/app/cookie-policy/page.tsx
+++ b/openeire-next/app/cookie-policy/page.tsx
@@ -1,0 +1,17 @@
+import type { Metadata } from "next";
+import { PrivacyPolicyContent } from "@/components/legal/PrivacyPolicyContent";
+import { buildPageMetadata } from "@/lib/seo/metadata";
+
+export const metadata: Metadata = {
+  ...buildPageMetadata({
+    title: "Privacy and Cookie Policy | OpenÉire Studios",
+    description:
+      "Read the OpenÉire Studios privacy and cookie policy hosted by iubenda.",
+    path: "/privacy",
+    noIndex: true,
+  }),
+};
+
+export default function CookiePolicyPage() {
+  return <PrivacyPolicyContent />;
+}

--- a/openeire-next/app/globals.css
+++ b/openeire-next/app/globals.css
@@ -101,6 +101,56 @@ a {
   padding-top: var(--page-top-offset);
 }
 
+.legal-content {
+  @apply mx-auto max-w-5xl px-4 py-12 font-sans selection:bg-accent selection:text-black sm:px-6 lg:px-8;
+  padding-top: calc(var(--site-header-height, 0px) + 2rem);
+}
+
+.legal-content h1 {
+  @apply mb-4 font-serif text-4xl font-bold text-white;
+}
+
+.legal-content h2 {
+  @apply mb-4 mt-10 font-serif text-2xl font-bold text-white;
+}
+
+.legal-content h3 {
+  @apply mb-3 mt-6 font-serif text-xl font-semibold text-white;
+}
+
+.legal-content p {
+  @apply mb-4 text-base leading-8 text-gray-300;
+}
+
+.legal-content strong {
+  @apply font-semibold text-white;
+}
+
+.legal-content ul,
+.legal-content ol {
+  @apply mb-5 ml-6 space-y-3 text-base leading-8 text-gray-300;
+}
+
+.legal-content ul {
+  list-style: disc;
+}
+
+.legal-content ol {
+  list-style: decimal;
+}
+
+.legal-content li {
+  @apply pl-1;
+}
+
+.legal-content a {
+  @apply text-accent underline underline-offset-4 transition-colors hover:text-white;
+}
+
+.legal-content hr {
+  @apply my-8 border-white/10;
+}
+
 @media (max-width: 767px) {
   .page-top-offset,
   .mobile-page-offset {

--- a/openeire-next/app/licensing/terms/page.tsx
+++ b/openeire-next/app/licensing/terms/page.tsx
@@ -1,0 +1,446 @@
+import Link from "next/link";
+import {
+  FaBan,
+  FaBuilding,
+  FaGavel,
+  FaGlobe,
+  FaImage,
+  FaNewspaper,
+} from "react-icons/fa";
+import { JsonLd } from "@/components/JsonLd";
+import { buildBreadcrumbJsonLd } from "@/lib/seo/jsonLd";
+import { buildPageMetadata } from "@/lib/seo/metadata";
+import { buildAbsoluteUrl } from "@/lib/site";
+
+const BRAND_NAME = "OpenÉire Studios";
+
+const PERSONAL_RIGHTS = [
+  "Display physical prints in your home or private office",
+  "Give physical prints as a personal gift to another individual",
+  "Store digital files on your personal devices and make reasonable backup copies",
+  "Print digital files solely for your own personal, non-commercial display",
+];
+
+const PERSONAL_PROHIBITED = [
+  "Any business activity, advertising, client work, or promotional materials",
+  "Resale, redistribution, sublicensing, or sharing files publicly",
+  'Uploading to stock libraries, marketplaces, or "free asset" platforms',
+  "Uploading to Print-on-Demand (POD) services or merchandise platforms",
+  "Use in logos, trademarks, brand identities, templates, or design packs",
+  "Training artificial intelligence, machine learning systems, or dataset creation",
+];
+
+const PERSONAL_ADDITIONAL_TERMS = [
+  "Third-Party Rights: Images may depict locations or elements subject to third-party rights. This licence does not grant permission to use any trademarks or private property rights.",
+  "Privacy & Personality Rights: You must not use any work in a way that invades privacy, misrepresents a person, or implies endorsement by an identifiable individual.",
+  "Consumer Rights: Nothing in this licence limits your statutory rights under Irish or EU consumer protection law.",
+];
+
+const COMMERCIAL_KEY_TERMS = [
+  "Defined scope (specific campaign, property listing, brand, or project)",
+  "Non-exclusive by default (exclusivity only by written agreement)",
+  "Time-limited duration (e.g., 3 / 6 / 12 months)",
+  "Territory-limited (e.g., Ireland / EU / US / Worldwide)",
+  "Media-limited (e.g., web, social, print, broadcast, paid ads)",
+];
+
+const LICENCE_SCHEDULE_ITEMS = [
+  "Licensed Asset(s): specific file(s), ID(s), and SHA-256 hashes",
+  "Permitted Media: precisely defined usage channels",
+  "Territory: authorized geographic regions",
+  "Duration: activation date to expiry date",
+  "Project / Campaign: specific brand or project name",
+  "Reach / Distribution Limits: e.g., print run, ad spend cap, or impression limits",
+  "Modifications Allowed: defined limitations on edits",
+];
+
+const COMMERCIAL_PROHIBITED_USES = [
+  "Reselling, sublicensing, redistributing, or making the standalone file available to third parties",
+  "Physical merchandise, apparel, posters, or uploading to Print-on-Demand (POD) platforms for resale",
+  "Uploading to stock libraries, marketplaces, or asset repositories",
+  "Use as a trademark, logo, service mark, or source identifier",
+  "Use in political campaigns, defamatory material, adult content, or misleading endorsements",
+  "Incorporation into template packs, design kits, LUT bundles, or resale toolkits",
+  "NFT minting, tokenisation, blockchain registration, or smart-contract systems",
+];
+
+const AI_PROHIBITIONS = [
+  "Training, fine-tuning, or evaluating any AI, machine learning, deep learning, or generative models",
+  "Inclusion in any dataset, corpus, or archive for computational analysis",
+  "Use as input, conditioning material, or style reference for automated generation systems",
+  "Creation of derivative synthetic imagery, video, or 3D assets algorithmically",
+  "Reverse engineering or extraction of compositional data for machine-readable pattern replication",
+];
+
+const EDITORIAL_CONDITIONS = [
+  "Written approval required",
+  "Mandatory visual credit (when required)",
+  "No advertising, paid promotion, or commercial endorsement",
+];
+
+type LegalSection = {
+  title: string;
+  paragraphs: Array<{ text: string; className?: string }>;
+  listItems?: string[];
+  creditLine?: string;
+};
+
+const LEGAL_SECTIONS: LegalSection[] = [
+  {
+    title: "1. Ownership & Copyright",
+    paragraphs: [
+      {
+        text: `All Licensed Asset(s) remain the exclusive intellectual property of ${BRAND_NAME}. No ownership, title, or copyright is transferred. The Licensee receives only the limited rights expressly granted in the Licence Schedule.`,
+      },
+    ],
+  },
+  {
+    title: "2. Drone Capture Compliance & Limited Warranty",
+    paragraphs: [
+      {
+        text: `${BRAND_NAME} represents that, to the best of its knowledge, assets were captured in material compliance with applicable unmanned aircraft rules (including airspace restrictions and geographic zones). However, regulations evolve and ${BRAND_NAME} does not warrant the absence of all third-party rights in every element of the captured scene.`,
+      },
+    ],
+  },
+  {
+    title: "3. Grant of Licence, Territory & Duration",
+    paragraphs: [
+      {
+        text: `Subject to written approval and full payment, ${BRAND_NAME} grants a non-exclusive, non-transferable, rights-managed licence strictly within the defined scope, territory, duration, and permitted media channels stated in the Licence Schedule. Use is limited to the stated purpose; any new campaign, placement type, or media channel not listed is outside scope. Upon expiry, all usage must cease, and digital copies must be deleted except for one secure archival copy retained solely for legal record purposes.`,
+      },
+    ],
+  },
+  {
+    title: "4. Modifications & Moral Rights",
+    paragraphs: [
+      {
+        text: `Only modifications expressly permitted in the Licence Schedule are allowed. The Licensee shall not distort, mutilate, misrepresent, or treat the asset in a manner prejudicial to the honour or reputation of ${BRAND_NAME}.`,
+      },
+    ],
+  },
+  {
+    title: "5. Prohibited Uses & Standalone Value",
+    paragraphs: [
+      {
+        text: "The Licensed Asset(s) may not be used as the primary value component of any product for resale, redistribution, or extraction.",
+        className: "mb-2",
+      },
+    ],
+    listItems: COMMERCIAL_PROHIBITED_USES,
+  },
+  {
+    title: "6. Artificial Intelligence & Automated Systems Prohibition",
+    paragraphs: [
+      {
+        text: "The Licensee shall not, directly or indirectly, use, upload, distribute, embed, or make available the Licensed Asset(s) for:",
+        className: "mb-2",
+      },
+    ],
+    listItems: AI_PROHIBITIONS,
+  },
+  {
+    title: "7. Metadata & Copyright Management Information",
+    paragraphs: [
+      {
+        text: "The Licensee shall not remove, alter, obscure, or falsify copyright notices, attribution, embedded metadata (including EXIF/IPTC), digital watermarks, or file identifiers. Such removal may constitute material breach and statutory violation.",
+      },
+    ],
+  },
+  {
+    title: "8. Third-Party Rights, Releases & Clearances",
+    paragraphs: [
+      {
+        text: "Unless expressly stated as 'Releases Included', no model, property, trademark, or location releases are provided. The Licensee bears sole and absolute responsibility for determining whether their specific intended use requires any additional third-party releases, particularly for advertising or sensitive contexts.",
+      },
+    ],
+  },
+  {
+    title: "9. Agencies, Contractors & No Implied Endorsement",
+    paragraphs: [
+      {
+        text: `The Licensee may provide assets to contracted third parties solely for execution of the defined scope, remaining fully liable for their acts and omissions. The asset may not be used to suggest endorsement, sponsorship, or affiliation by ${BRAND_NAME} unless expressly authorised.`,
+      },
+    ],
+  },
+  {
+    title: "10. Editorial Use & Credit",
+    paragraphs: [
+      {
+        text: "Editorial use requires written approval and may not be used for advertising, paid promotion, or product/service endorsement.",
+        className: "mb-2",
+      },
+    ],
+    creditLine: `Where required by ${BRAND_NAME}, credit must be displayed as:`,
+  },
+  {
+    title: "11. Indemnity & Limitation of Liability",
+    paragraphs: [
+      {
+        text: `The Licensee agrees to indemnify and hold harmless ${BRAND_NAME} against claims and costs arising from misuse, breach, or use beyond the defined scope. ${BRAND_NAME} shall not be liable for indirect, incidental, or consequential damages.`,
+      },
+    ],
+  },
+  {
+    title: "12. Governing Law, Audit & Enforcement",
+    paragraphs: [
+      {
+        text: "This Licence is governed by the laws of Ireland and applicable EU law. Upon reasonable request, the Licensee shall provide written certification confirming compliance.",
+        className: "mb-2",
+      },
+      {
+        text: `${BRAND_NAME} reserves the right to pursue enforcement and remedies (including injunctive relief and statutory damages) in the jurisdiction where infringement occurs and/or where the Licensee is established.`,
+      },
+    ],
+  },
+  {
+    title: "13. Breach, Termination & Remedies",
+    paragraphs: [
+      {
+        text: `Any unauthorised use constitutes material breach and infringement. ${BRAND_NAME} may terminate the licence immediately upon breach. Remedies may include takedown demands, injunctive relief, damages (including statutory damages where available), account of profits, and recovery of reasonable legal costs.`,
+      },
+    ],
+  },
+  {
+    title: "14. Entire Agreement",
+    paragraphs: [
+      {
+        text: `These terms, together with the Licence Schedule and any written approval issued by ${BRAND_NAME}, constitute the entire agreement between the parties regarding the Licensed Asset(s) and supersede prior discussions or communications.`,
+      },
+    ],
+  },
+];
+
+function BulletList({ items, className = "" }: { items: string[]; className?: string }) {
+  return (
+    <ul className={`list-inside list-disc ${className}`.trim()}>
+      {items.map((item) => (
+        <li key={item}>{item}</li>
+      ))}
+    </ul>
+  );
+}
+
+export const metadata = buildPageMetadata({
+  title: "Licensing Terms & Legal Agreement | OpenÉire Studios",
+  description:
+    "Read the legal licensing terms for personal, editorial, and rights-managed commercial use of aerial footage and fine art photography from OpenÉire Studios.",
+  path: "/licensing/terms",
+  noIndex: true,
+});
+
+export default function LicensingTermsPage() {
+  return (
+    <main className="page-top-offset min-h-screen bg-black pb-20 font-sans text-white selection:bg-accent selection:text-black">
+      <JsonLd
+        data={buildBreadcrumbJsonLd([
+          { name: "Home", url: buildAbsoluteUrl("/") },
+          { name: "Licensing", url: buildAbsoluteUrl("/licensing") },
+          { name: "Terms", url: buildAbsoluteUrl("/licensing/terms") },
+        ])}
+      />
+
+      <div className="container mx-auto max-w-5xl px-4 lg:px-8">
+        <div className="mb-8 rounded-2xl border border-white/10 bg-white/5 p-5 md:p-6">
+          <p className="text-xs font-semibold uppercase tracking-[0.28em] text-accent">
+            Need the commercial overview?
+          </p>
+          <div className="mt-3 flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+            <p className="max-w-3xl text-sm leading-relaxed text-gray-300">
+              Looking for the buyer-friendly licensing overview? Start with the
+              main Licensing page, then return here when you need the legal
+              wording.
+            </p>
+            <Link
+              href="/licensing"
+              className="inline-flex items-center justify-center rounded-full border border-white/20 px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-white/10"
+            >
+              Go to Licensing Overview
+            </Link>
+          </div>
+        </div>
+
+        <h1 className="mb-6 font-serif text-4xl font-bold text-white md:text-5xl">
+          Licensing Terms &amp; Legal Agreement
+        </h1>
+        <p className="mb-6 max-w-3xl text-lg leading-relaxed text-gray-400">
+          {BRAND_NAME} offers premium fine-art photography and high-resolution
+          aerial footage. To protect the integrity of the work, all media is
+          subject to strict licensing terms. Please review the tiers below to
+          ensure your intended use complies with our copyright and licensing
+          policies.
+        </p>
+
+        <div className="mb-12 rounded-2xl border border-white/10 bg-white/5 p-6 md:p-8">
+          <div className="mb-3 flex items-center gap-3">
+            <div className="flex h-10 w-10 items-center justify-center rounded-full bg-gray-800 text-lg text-white">
+              <FaGlobe aria-hidden="true" />
+            </div>
+            <h2 className="text-lg font-bold">International use (EU, US, and beyond)</h2>
+          </div>
+          <p className="text-sm leading-relaxed text-gray-400">
+            Licences issued by {BRAND_NAME} apply to customers worldwide. Your
+            permitted usage is governed by the licence you purchase and the
+            scope we approve. Copyright protection is recognised internationally
+            and unauthorised use may be pursued in Ireland and/or the
+            jurisdiction where the use occurs.
+          </p>
+        </div>
+
+        <div className="space-y-12">
+          <section className="rounded-2xl border border-white/10 bg-white/5 p-8 md:p-10">
+            <div className="mb-6 flex items-center gap-4">
+              <div className="flex h-12 w-12 items-center justify-center rounded-full bg-gray-800 text-xl text-white">
+                <FaImage aria-hidden="true" />
+              </div>
+              <h2 className="text-2xl font-bold">Art &amp; Personal Use (Default)</h2>
+            </div>
+            <p className="mb-6 text-gray-400">
+              Applies where you purchase an {BRAND_NAME} photograph, artwork,
+              or video as an individual for personal use, and not in connection
+              with a business, trade, profession, or organisation.
+            </p>
+            <div className="mb-8 grid gap-8 md:grid-cols-2">
+              <div>
+                <h3 className="mb-3 text-sm uppercase tracking-widest text-gray-500">
+                  Permitted Personal Use
+                </h3>
+                <BulletList items={PERSONAL_RIGHTS} className="space-y-2 text-sm text-gray-300" />
+              </div>
+              <div>
+                <h3 className="mb-3 flex items-center gap-2 text-sm uppercase tracking-widest text-red-400">
+                  <FaBan aria-hidden="true" /> Strictly Prohibited
+                </h3>
+                <BulletList items={PERSONAL_PROHIBITED} className="space-y-2 text-sm text-gray-300" />
+              </div>
+            </div>
+            <div className="rounded-xl border border-white/10 bg-black/30 p-5">
+              <h3 className="mb-3 text-sm uppercase tracking-widest text-gray-500">
+                Important Notices
+              </h3>
+              <ul className="space-y-3 text-sm text-gray-300">
+                {PERSONAL_ADDITIONAL_TERMS.map((term) => (
+                  <li key={term}>{term}</li>
+                ))}
+              </ul>
+            </div>
+          </section>
+
+          <section className="rounded-2xl border border-white/10 bg-white/5 p-8 md:p-10">
+            <div className="mb-6 flex items-center gap-4">
+              <div className="flex h-12 w-12 items-center justify-center rounded-full bg-gray-800 text-xl text-white">
+                <FaBuilding aria-hidden="true" />
+              </div>
+              <h2 className="text-2xl font-bold">
+                Commercial &amp; Marketing Licence (Rights-Managed)
+              </h2>
+            </div>
+            <p className="mb-6 text-gray-400">
+              Applies to real estate agencies, hospitality brands, developers,
+              and tourism operators. This is a{" "}
+              <span className="font-semibold text-white">Rights-Managed</span>{" "}
+              licence and requires approval.
+            </p>
+            <div className="grid gap-8 md:grid-cols-2">
+              <div>
+                <h3 className="mb-3 text-sm uppercase tracking-widest text-gray-500">
+                  Key Terms (Summary)
+                </h3>
+                <BulletList items={COMMERCIAL_KEY_TERMS} className="space-y-2 text-sm text-gray-300" />
+              </div>
+              <div className="flex md:items-start md:justify-end">
+                <Link
+                  href="/licensing"
+                  className="mt-4 inline-block rounded-lg bg-white px-6 py-3 font-bold text-black transition-colors hover:bg-gray-200"
+                >
+                  Back to Licensing Overview
+                </Link>
+              </div>
+            </div>
+
+            <div className="mt-10 border-t border-white/10 pt-8">
+              <div className="mb-4 flex items-center gap-3">
+                <div className="flex h-10 w-10 items-center justify-center rounded-full bg-gray-800 text-lg text-white">
+                  <FaGavel aria-hidden="true" />
+                </div>
+                <h3 className="text-xl font-bold">
+                  Commercial Rights-Managed Licence Agreement
+                </h3>
+              </div>
+              <p className="mb-6 text-sm leading-relaxed text-gray-400">
+                The terms below summarise the legal licensing framework for
+                commercial usage. The exact scope of your licence is set out in
+                the <span className="font-semibold text-white">Licence Schedule</span>{" "}
+                (asset, media, territory, duration, and any limits). By
+                purchasing or using licensed media, the Licensee agrees to the
+                Master Rights-Managed Agreement.
+              </p>
+              <div className="space-y-6 text-sm leading-relaxed text-gray-300">
+                <div className="rounded-xl border border-white/10 bg-black/30 p-5">
+                  <p className="mb-2 font-semibold text-gray-200">Licence Schedule Format</p>
+                  <BulletList items={LICENCE_SCHEDULE_ITEMS} className="space-y-1 text-gray-300" />
+                </div>
+                {LEGAL_SECTIONS.map((section) => (
+                  <div key={section.title}>
+                    <p className="mb-1 font-semibold text-gray-200">{section.title}</p>
+                    {section.paragraphs.map((paragraph) => (
+                      <p key={paragraph.text} className={paragraph.className}>
+                        {paragraph.text}
+                      </p>
+                    ))}
+                    {section.listItems ? (
+                      <BulletList items={section.listItems} className="mt-2 space-y-1" />
+                    ) : null}
+                    {section.creditLine ? (
+                      <p className="mt-2">
+                        {section.creditLine}{" "}
+                        <span className="font-semibold text-white">© {BRAND_NAME}</span>.
+                      </p>
+                    ) : null}
+                  </div>
+                ))}
+              </div>
+              <div className="mt-6 rounded-xl border border-white/10 bg-white/5 p-5">
+                <p className="text-xs leading-relaxed text-gray-400">
+                  Note: Your commercial licence is valid only after written
+                  approval and full payment. If you are unsure whether your use
+                  is within scope, request clarification before publishing.
+                </p>
+              </div>
+            </div>
+          </section>
+
+          <section className="rounded-2xl border border-white/10 bg-white/5 p-8 md:p-10">
+            <div className="mb-6 flex items-center gap-4">
+              <div className="flex h-12 w-12 items-center justify-center rounded-full bg-gray-800 text-xl text-white">
+                <FaNewspaper aria-hidden="true" />
+              </div>
+              <h2 className="text-2xl font-bold">Editorial Licence</h2>
+            </div>
+            <p className="mb-6 text-gray-400">
+              Applies to media outlets, documentaries, magazines, and
+              educational content where the goal is storytelling, not selling.
+              Editorial usage requires written approval.
+            </p>
+            <div className="grid gap-8 md:grid-cols-2">
+              <div>
+                <h3 className="mb-3 text-sm uppercase tracking-widest text-gray-500">
+                  Conditions (Summary)
+                </h3>
+                <BulletList items={EDITORIAL_CONDITIONS} className="space-y-2 text-sm text-gray-300" />
+              </div>
+            </div>
+          </section>
+        </div>
+
+        <div className="mt-16 border-t border-white/10 p-6 text-center">
+          <p className="text-xs uppercase leading-loose tracking-widest text-gray-500">
+            © {new Date().getFullYear()} {BRAND_NAME}. All rights reserved.
+            Unauthorised use may constitute copyright infringement and may
+            result in takedown demands, injunctive relief, damages, and recovery
+            of legal costs.
+          </p>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/openeire-next/app/privacy/page.tsx
+++ b/openeire-next/app/privacy/page.tsx
@@ -1,0 +1,13 @@
+import { PrivacyPolicyContent } from "@/components/legal/PrivacyPolicyContent";
+import { buildPageMetadata } from "@/lib/seo/metadata";
+
+export const metadata = buildPageMetadata({
+  title: "Privacy and Cookie Policy | OpenÉire Studios",
+  description:
+    "Read the OpenÉire Studios privacy and cookie policy hosted by iubenda.",
+  path: "/privacy",
+});
+
+export default function PrivacyPage() {
+  return <PrivacyPolicyContent />;
+}

--- a/openeire-next/app/refunds/page.tsx
+++ b/openeire-next/app/refunds/page.tsx
@@ -1,0 +1,126 @@
+import Link from "next/link";
+import { LegalPageShell } from "@/components/legal/LegalPageShell";
+import { buildPageMetadata } from "@/lib/seo/metadata";
+
+export const metadata = buildPageMetadata({
+  title: "Refund Policy | OpenÉire Studios",
+  description:
+    "Read the refund and return policy for OpenÉire Studios digital licences, downloads, and physical print orders.",
+  path: "/refunds",
+});
+
+export default function RefundsPage() {
+  return (
+    <LegalPageShell>
+      <h1>Refund &amp; Return Policy</h1>
+      <p>
+        <strong>Last Updated: March 2026</strong>
+      </p>
+      <p>
+        OpenÉire Studios sells two distinct product types: digital media
+        licences and physical art prints. Because these products are fulfilled
+        differently, the refund and return rules are different as well. Nothing
+        in this policy affects your statutory rights under Irish or European
+        Union consumer protection law.
+      </p>
+
+      <hr />
+
+      <h2>1. Digital Downloads &amp; Licensing</h2>
+      <p>
+        This section applies to digital files purchased for personal use and to
+        digital assets licensed for commercial or editorial use.
+      </p>
+      <h3>All Digital Sales Are Final</h3>
+      <p>
+        Because digital assets are delivered immediately and cannot be returned
+        in a physical sense, we do not offer refunds, returns, or exchanges for
+        digital products once the secure download link has been generated and
+        sent.
+      </p>
+      <h3>EU 14-Day Right of Withdrawal Waiver</h3>
+      <p>
+        Under EU consumer law, customers generally have a 14-day right to
+        cancel online purchases. By purchasing a digital download from OpenÉire
+        Studios, you explicitly consent to immediate digital delivery and
+        acknowledge that you lose that withdrawal right once download access
+        begins.
+      </p>
+      <h3>Exceptions for Corrupted or Incorrect Files</h3>
+      <p>
+        If the file you receive is corrupted, damaged, or does not match the
+        product specifications shown at purchase, contact us within 7 days of
+        purchase.
+      </p>
+      <ul>
+        <li>We will first attempt to provide a replacement file.</li>
+        <li>
+          If a replacement cannot be provided, we will issue a full refund for
+          the affected digital product.
+        </li>
+      </ul>
+
+      <h2>2. Physical Art Prints</h2>
+      <p>
+        Physical prints are produced through specialist Print-on-Demand
+        partners and are custom-made to the selected size, material, and finish
+        after the order is placed.
+      </p>
+      <h3>Change of Mind Returns</h3>
+      <p>
+        Because each print is bespoke and made to order, physical prints are
+        exempt from the standard EU 14-day right of withdrawal for change of
+        mind. We cannot offer refunds if the wrong size or finish is chosen, or
+        if you simply change your mind after production begins.
+      </p>
+      <h3>Damaged, Defective, or Incorrect Items</h3>
+      <p>
+        If your print arrives damaged in transit, has a manufacturing defect,
+        or is not the item you ordered, we will replace it at no additional
+        cost.
+      </p>
+      <ol>
+        <li>Contact us within 14 days of receiving the item.</li>
+        <li>
+          Include your order number and clear photographs of the issue,
+          including the packaging where relevant.
+        </li>
+        <li>
+          Once the issue is reviewed and approved, we will arrange a replacement
+          to the original shipping address.
+        </li>
+      </ol>
+      <p>
+        If a replacement is not possible, we will issue a full refund for the
+        physical item.
+      </p>
+
+      <h2>3. Processing Approved Refunds</h2>
+      <p>
+        If a refund is approved for a corrupted digital file or an unreplaceable
+        damaged print:
+      </p>
+      <ul>
+        <li>
+          The refund will be issued to the original payment method used at
+          checkout.
+        </li>
+        <li>
+          Please allow 5 to 10 business days for the funds to appear, depending
+          on your bank or card provider.
+        </li>
+      </ul>
+
+      <h2>4. Contact Us</h2>
+      <p>
+        To report a damaged package, request a replacement, or raise a digital
+        delivery issue, please contact us at{" "}
+        <a href="mailto:support@openeire.ie">support@openeire.ie</a>.
+      </p>
+      <p>
+        You can also review our <Link href="/shipping">Shipping Policy</Link>{" "}
+        for dispatch and transit expectations.
+      </p>
+    </LegalPageShell>
+  );
+}

--- a/openeire-next/app/shipping/page.tsx
+++ b/openeire-next/app/shipping/page.tsx
@@ -1,0 +1,155 @@
+import Link from "next/link";
+import { LegalPageShell } from "@/components/legal/LegalPageShell";
+import { buildPageMetadata } from "@/lib/seo/metadata";
+
+export const metadata = buildPageMetadata({
+  title: "Shipping Policy | OpenÉire Studios",
+  description:
+    "Review OpenÉire Studios shipping and delivery information for digital products, licensing fulfilment, and physical art prints.",
+  path: "/shipping",
+});
+
+export default function ShippingPage() {
+  return (
+    <LegalPageShell>
+      <h1>Shipping &amp; Delivery Policy</h1>
+      <p>
+        <strong>Last Updated: March 2026</strong>
+      </p>
+      <p>
+        At OpenÉire Studios, we deliver our premium media in two formats:
+        digital vault delivery for commercial licences and digital downloads,
+        and physical print delivery for bespoke, museum-quality art prints. We
+        currently ship physical prints exclusively to Ireland and the United
+        States.
+      </p>
+
+      <hr />
+
+      <h2>1. Digital Vault Delivery</h2>
+      <p>
+        If you have purchased a digital download for personal use or a
+        rights-managed digital asset for commercial or editorial use, no
+        physical item will be shipped to you.
+      </p>
+      <p>
+        Upon successful payment, our secure delivery flow generates a
+        time-sensitive download link and sends it to the email address provided
+        at checkout.
+      </p>
+      <ul>
+        <li>There are no shipping fees for digital products.</li>
+        <li>The download link is delivered immediately after successful payment.</li>
+        <li>
+          For security and copyright protection, the secure link expires 48
+          hours after it is generated.
+        </li>
+        <li>
+          We recommend downloading and backing up your high-resolution files as
+          soon as you receive them.
+        </li>
+      </ul>
+
+      <h2>2. Physical Art Prints</h2>
+      <p>
+        We partner with a specialist Print-on-Demand network to manufacture our
+        physical fine art prints. Every physical order is bespoke and produced
+        specifically for you after checkout.
+      </p>
+      <h3>Localized Printing</h3>
+      <p>
+        To reduce delivery time, orders are typically routed to the print lab
+        closest to the delivery address. United States orders are usually
+        printed in the US, and Irish orders are typically printed within the EU
+        or UK network.
+      </p>
+      <h3>Production Times</h3>
+      <p>
+        Because your artwork may be custom-printed, framed, or mounted on
+        demand, production and quality assurance take place before dispatch.
+        Shipping transit times are additional to production time.
+      </p>
+
+      <h2>3. Shipping Methods &amp; Transit Times</h2>
+      <p>
+        Shipping costs are calculated dynamically at checkout based on artwork
+        size, material, and delivery destination. We currently offer three
+        shipping tiers:
+      </p>
+      <ul>
+        <li>
+          <strong>Budget:</strong> Typically an untracked or slower postal
+          service. Some products and destinations may still include tracking.
+        </li>
+        <li>
+          <strong>Standard:</strong> Standard postal delivery. Tracking depends
+          on destination and product type.
+        </li>
+        <li>
+          <strong>Express:</strong> A premium courier service, typically
+          tracked, using providers such as FedEx, DHL, or DPD.
+        </li>
+      </ul>
+      <h3>Estimated Standard Postal Transit Times</h3>
+      <ul>
+        <li>
+          <strong>US to US:</strong> 4 to 6 working days
+        </li>
+        <li>
+          <strong>EU or UK to Ireland:</strong> 5 to 7 working days
+        </li>
+        <li>
+          <strong>EU or UK to US:</strong> 10 to 15 working days for specialty
+          items printed in Europe
+        </li>
+      </ul>
+      <h3>Estimated Express Transit Times</h3>
+      <p>
+        Orders shipped using the express option usually arrive within 1 to 6
+        working days after dispatch.
+      </p>
+
+      <h2>4. Customs, Duties, and Import Taxes</h2>
+      <p>
+        Because we use a localized printing network, most physical orders are
+        fulfilled domestically within the customer&apos;s region. This means
+        import charges are uncommon, but they may still apply in some cases.
+      </p>
+      <ul>
+        <li>
+          The buyer is responsible for any customs charges, import taxes, or
+          duties that apply at delivery.
+        </li>
+        <li>
+          OpenÉire Studios is not responsible for delays caused by customs
+          processing.
+        </li>
+      </ul>
+
+      <h2>5. Lost or Damaged Packages</h2>
+      <p>
+        We insure our physical shipments. A package is considered lost in
+        transit if it has not arrived within the following timeframes after
+        dispatch:
+      </p>
+      <ul>
+        <li>
+          <strong>US domestic orders:</strong> 10 working days
+        </li>
+        <li>
+          <strong>Ireland orders from the EU or UK network:</strong> 15 working
+          days
+        </li>
+        <li>
+          <strong>US orders shipped from the EU or UK:</strong> 28 working days
+        </li>
+      </ul>
+      <p>
+        If a package is lost within those criteria, or if it arrives damaged,
+        we will arrange a replacement at no additional cost. For reporting
+        damage or replacement requests, please review our{" "}
+        <Link href="/refunds">Refund &amp; Return Policy</Link>.
+      </p>
+    </LegalPageShell>
+  );
+}

--- a/openeire-next/app/sitemap.ts
+++ b/openeire-next/app/sitemap.ts
@@ -13,6 +13,10 @@ const staticPublicRoutes = [
   "/blog",
   "/contact",
   "/gallery/physical",
+  "/terms",
+  "/shipping",
+  "/refunds",
+  "/privacy",
 ];
 
 export const dynamic = "force-dynamic";

--- a/openeire-next/app/terms/page.tsx
+++ b/openeire-next/app/terms/page.tsx
@@ -1,0 +1,207 @@
+import Link from "next/link";
+import { LegalPageShell } from "@/components/legal/LegalPageShell";
+import { buildPageMetadata } from "@/lib/seo/metadata";
+
+export const metadata = buildPageMetadata({
+  title: "Terms and Conditions | OpenÉire Studios",
+  description:
+    "Read the terms and conditions governing purchases, licensing, and use of the OpenÉire Studios website and products.",
+  path: "/terms",
+});
+
+export default function TermsPage() {
+  return (
+    <LegalPageShell>
+      <h1>Terms &amp; Conditions</h1>
+      <p>
+        <strong>Last Updated: March 2026</strong>
+      </p>
+      <p>
+        Welcome to OpenÉire Studios. These Terms &amp; Conditions
+        (&quot;Terms&quot;) govern your access to and use of our website, as
+        well as the purchase of any physical prints, digital downloads, or
+        commercial media licenses. By accessing our website or placing an
+        order, you agree to be bound by these Terms. If you do not agree to
+        these Terms, please do not use our site or purchase our products.
+      </p>
+
+      <hr />
+
+      <h2>1. About Us</h2>
+      <p>
+        This website is operated by OpenÉire Studios, based in Ireland.
+        Throughout the site, the terms &quot;we&quot;, &quot;us&quot;, and
+        &quot;our&quot; refer to OpenÉire Studios.
+      </p>
+
+      <h2>2. Products and Services</h2>
+      <p>We offer two distinct categories of products:</p>
+      <ol>
+        <li>
+          <strong>Physical Prints:</strong> Bespoke, made-to-order art prints
+          fulfilled via our Print-on-Demand partners.
+        </li>
+        <li>
+          <strong>Digital Media:</strong> High-resolution digital files
+          provided under a strict Personal Use Licence or a Rights-Managed
+          Commercial Licence.
+        </li>
+      </ol>
+      <h3>Purchasing a Licence, Not Ownership</h3>
+      <p>
+        When you purchase digital media from OpenÉire Studios, you are
+        purchasing a limited licence to use the asset, not the ownership of the
+        asset itself. All copyright and intellectual property rights remain the
+        exclusive property of OpenÉire Studios.
+      </p>
+
+      <h2>3. Intellectual Property &amp; Strict Licensing Rules</h2>
+      <p>
+        Your use of any digital or physical product purchased from OpenÉire
+        Studios is strictly governed by our licensing terms. By purchasing from
+        us, you expressly agree that you will not:
+      </p>
+      <ul>
+        <li>
+          Use any digital file as the primary value component of physical
+          merchandise or Print-on-Demand products for resale.
+        </li>
+        <li>
+          Upload, use, or embed any asset for the purpose of training
+          artificial intelligence, machine learning systems, or generative
+          models.
+        </li>
+        <li>
+          Mint, tokenise, or commercialise the assets as NFTs or via blockchain
+          technology.
+        </li>
+        <li>
+          Remove, alter, or obscure any embedded metadata, copyright notices,
+          or digital watermarks.
+        </li>
+      </ul>
+      <p>
+        For full details regarding permitted uses, please read our{" "}
+        <Link href="/licensing/terms">
+          Licensing Terms &amp; Legal Agreement
+        </Link>{" "}
+        page. Unauthorised use constitutes copyright infringement and may
+        result in legal action.
+      </p>
+
+      <h2>4. Orders, Pricing, and Payments</h2>
+      <ul>
+        <li>
+          <strong>Pricing:</strong> All prices are subject to change without
+          notice. We reserve the right to modify or discontinue any product or
+          service at any time.
+        </li>
+        <li>
+          <strong>Payments:</strong> Payments are securely processed via
+          Stripe. You agree to provide current, complete, and accurate purchase
+          and account information for all purchases made through our store.
+        </li>
+        <li>
+          <strong>Custom Quotes:</strong> Commercial Rights-Managed licences
+          require approval and are subject to custom pricing based on your
+          intended media, territory, duration, and reach.
+        </li>
+      </ul>
+
+      <h2>5. Fulfillment and Delivery</h2>
+      <ul>
+        <li>
+          <strong>Physical Prints:</strong> Physical orders are routed to our
+          global Print-on-Demand network. Production and transit times vary.
+          Please review our{" "}
+          <Link href="/shipping">Shipping &amp; Delivery Policy</Link> for
+          detailed estimates.
+        </li>
+        <li>
+          <strong>Digital Vault:</strong> Digital purchases are delivered via a
+          secure, pre-signed download link sent to your email. This link
+          automatically expires after 48 hours.
+        </li>
+        <li>
+          <strong>Customs &amp; Duties:</strong> For physical shipments crossing
+          international borders, the buyer is responsible for any customs fees,
+          import taxes, or duties applied by their local government.
+        </li>
+      </ul>
+
+      <h2>6. Returns, Refunds, and Consumer Rights</h2>
+      <p>
+        Because of the nature of our products, our return policies are strictly
+        defined:
+      </p>
+      <ul>
+        <li>
+          <strong>Physical Prints:</strong> As bespoke, custom-made goods,
+          physical prints are exempt from standard change-of-mind return
+          policies.
+        </li>
+        <li>
+          <strong>Digital Files:</strong> By purchasing a digital download, you
+          consent to immediate delivery and acknowledge the loss of your 14-day
+          right of withdrawal under EU consumer law.
+        </li>
+        <li>
+          <strong>Defective Goods:</strong> We will replace physical prints
+          damaged in transit or digital files that are corrupted. For full
+          instructions, please review our{" "}
+          <Link href="/refunds">Refund &amp; Return Policy</Link>.
+        </li>
+      </ul>
+      <p>
+        Nothing in these Terms limits your statutory rights under Irish or
+        European Union consumer protection law.
+      </p>
+
+      <h2>7. Limitation of Liability</h2>
+      <p>
+        To the maximum extent permitted by applicable law, OpenÉire Studios
+        shall not be liable for any indirect, incidental, special,
+        consequential, or punitive damages, including without limitation loss
+        of profits, data, use, goodwill, or other intangible losses, resulting
+        from your access to or use of, or inability to access or use, the
+        website, any conduct or content of any third party on the website, or
+        unauthorised access, use, or alteration of your transmissions or
+        content.
+      </p>
+
+      <h2>8. Indemnification</h2>
+      <p>
+        You agree to indemnify and hold harmless OpenÉire Studios and its
+        affiliates, partners, and employees from any claim or demand, including
+        reasonable legal fees, made by any third party due to or arising out of
+        your breach of these Terms, your violation of any law, or your misuse
+        of our licensed assets.
+      </p>
+
+      <h2>9. Governing Law and Jurisdiction</h2>
+      <p>
+        These Terms and any separate agreements whereby we provide services
+        shall be governed by and construed in accordance with the laws of
+        Ireland and applicable European Union law. OpenÉire Studios reserves
+        the right to pursue enforcement and remedies for copyright infringement
+        in the jurisdiction where the infringement occurs and/or where the
+        licensee is established.
+      </p>
+
+      <h2>10. Changes to Terms &amp; Conditions</h2>
+      <p>
+        We reserve the right to update, change, or replace any part of these
+        Terms by posting updates and/or changes to our website. It is your
+        responsibility to check this page periodically for changes. Your
+        continued use of or access to the website following the posting of any
+        changes constitutes acceptance of those changes.
+      </p>
+
+      <h2>11. Contact Information</h2>
+      <p>
+        Questions about these Terms &amp; Conditions can be sent to{" "}
+        <a href="mailto:contact@openeire.ie">contact@openeire.ie</a>.
+      </p>
+    </LegalPageShell>
+  );
+}

--- a/openeire-next/components/checkout/CheckoutTerms.tsx
+++ b/openeire-next/components/checkout/CheckoutTerms.tsx
@@ -2,10 +2,10 @@
 
 import type { CheckoutFormState } from "@/types/checkout";
 
-const LIVE_LEGAL_URLS = {
-  terms: "https://openeire.ie/terms",
-  privacy: "https://openeire.ie/privacy",
-  licensing: "https://openeire.ie/licensing/terms",
+const LEGAL_URLS = {
+  terms: "/terms",
+  privacy: "/privacy",
+  licensing: "/licensing/terms",
 } as const;
 
 interface CheckoutTermsProps {
@@ -53,7 +53,7 @@ export function CheckoutTerms({
           <span>
             I agree to the{" "}
             <a
-              href={LIVE_LEGAL_URLS.terms}
+              href={LEGAL_URLS.terms}
               target="_blank"
               rel="noopener noreferrer"
               className="text-accent underline-offset-4 hover:underline"
@@ -74,7 +74,7 @@ export function CheckoutTerms({
           <span>
             I understand how my information is handled under the{" "}
             <a
-              href={LIVE_LEGAL_URLS.privacy}
+              href={LEGAL_URLS.privacy}
               target="_blank"
               rel="noopener noreferrer"
               className="text-accent underline-offset-4 hover:underline"
@@ -99,7 +99,7 @@ export function CheckoutTerms({
               I understand digital purchases are for personal use only unless a
               separate commercial licence is agreed.{" "}
               <a
-                href={LIVE_LEGAL_URLS.licensing}
+                href={LEGAL_URLS.licensing}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="text-accent underline-offset-4 hover:underline"

--- a/openeire-next/components/gallery/DigitalGalleryDetailClient.tsx
+++ b/openeire-next/components/gallery/DigitalGalleryDetailClient.tsx
@@ -259,7 +259,7 @@ export function DigitalGalleryDetailClient({
   const tags = splitTags(detail.tags);
   const capturedDate = formatDate(detail.created_at);
   const relatedProducts = detail.related_products ?? [];
-  const legalTermsHref = "https://openeire.ie/licensing/terms";
+  const legalTermsHref = "/licensing/terms";
   const handleAddToCart = () => {
     if (!isCartLoaded) return;
 

--- a/openeire-next/components/legal/LegalPageShell.tsx
+++ b/openeire-next/components/legal/LegalPageShell.tsx
@@ -1,0 +1,9 @@
+import type { ReactNode } from "react";
+
+export function LegalPageShell({ children }: { children: ReactNode }) {
+  return (
+    <main className="min-h-screen bg-black text-white">
+      <article className="legal-content">{children}</article>
+    </main>
+  );
+}

--- a/openeire-next/components/legal/PrivacyPolicyContent.tsx
+++ b/openeire-next/components/legal/PrivacyPolicyContent.tsx
@@ -1,0 +1,37 @@
+import { LegalPageShell } from "@/components/legal/LegalPageShell";
+import {
+  IUBENDA_POLICY_EMBED_URL,
+  IUBENDA_POLICY_URL,
+} from "@/lib/legal/iubenda";
+
+export function PrivacyPolicyContent() {
+  return (
+    <LegalPageShell>
+      <h1>Privacy &amp; Cookie Policy</h1>
+      <p>This policy is hosted by iubenda, our compliance provider.</p>
+
+      <div className="mt-8 overflow-hidden rounded-2xl border border-white/10 bg-white/5 shadow-sm">
+        <iframe
+          title="OpenÉire Studios Privacy and Cookie Policy"
+          src={IUBENDA_POLICY_EMBED_URL}
+          className="block h-[75vh] min-h-[720px] w-full border-0 bg-white"
+          loading="lazy"
+          referrerPolicy="no-referrer"
+        />
+      </div>
+
+      <p className="mt-6">
+        If the embedded policy does not load in your browser, you can open it
+        directly here:{" "}
+        <a
+          href={IUBENDA_POLICY_URL}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          View Privacy &amp; Cookie Policy
+        </a>
+        .
+      </p>
+    </LegalPageShell>
+  );
+}

--- a/openeire-next/lib/legal/iubenda.ts
+++ b/openeire-next/lib/legal/iubenda.ts
@@ -1,0 +1,21 @@
+const DEFAULT_POLICY_URL = "https://www.iubenda.com/privacy-policy/77203310";
+
+const getSafePublicUrl = (value: string | undefined): string | null => {
+  const trimmed = value?.trim();
+  if (!trimmed || trimmed === "undefined" || trimmed === "null") return null;
+
+  try {
+    const url = new URL(trimmed);
+    return url.protocol === "https:" ? url.toString() : null;
+  } catch {
+    return null;
+  }
+};
+
+export const IUBENDA_POLICY_URL =
+  getSafePublicUrl(process.env.NEXT_PUBLIC_IUBENDA_POLICY_URL) ??
+  DEFAULT_POLICY_URL;
+
+export const IUBENDA_POLICY_EMBED_URL =
+  getSafePublicUrl(process.env.NEXT_PUBLIC_IUBENDA_POLICY_EMBED_URL) ??
+  `${IUBENDA_POLICY_URL}/legal`;


### PR DESCRIPTION
## Summary

Migrates OpenÉire Studios legal and policy pages into the Next.js application and connects existing footer, checkout, and digital-product legal links.

## Why

The migrated application needed local legal routes before launch so users can review policies and licence terms without returning to the legacy frontend.

## Screenshots / Demo

- [x] Not needed
- [ ] Added screenshots or recording

## Changes

- Backend: No changes.
- Frontend: Added Terms, Shipping, Refunds, Privacy, Cookie Policy, and Licensing Terms routes.
- Frontend: Added reusable legal page and Iubenda privacy-policy components.
- Frontend: Updated checkout and digital-detail legal links to use Next.js routes.
- Frontend: Added indexable legal routes to the sitemap while preserving noindex behaviour for duplicate/private-purpose routes.
- Infra/Config: Documented optional public Iubenda policy URLs.

## Testing

- [ ] Django tests pass locally (not applicable, no backend changes)
- [x] React build passes locally
- [x] Manual route smoke test done

### Manual smoke test checklist (quick)

- [x] All six legal routes return HTTP 200
- [x] Canonical and robots metadata are correct
- [x] Sitemap includes indexable legal routes
- [x] Cookie Policy and Licensing Terms remain excluded from indexing
- [x] Checkout and digital-detail links resolve locally
- [ ] Final mobile visual check after deployment

## Risk & Rollback

Risk level: Low. Changes are limited to static legal pages, metadata, sitemap entries, and legal links. Payment and backend behaviour are unchanged.

Rollback plan: Revert this PR and restore the previous production legal URLs.

## Notes for Reviewer

- `/cookie-policy` remains noindex with `/privacy` as its canonical URL.
- `/licensing/terms` preserves the existing noindex behaviour.
- Iubenda URLs are validated as HTTPS and have safe defaults.
- Legal copy currently says download links expire after 48 hours, while backend token defaults appear to be 7 days. This should receive a separate content/legal review.
- `npm run lint`, `npm run build`, `npm audit`, and `npm audit --omit=dev` passed.
- `axios` and `plain-crypto-js` remain absent.