### PR TITLE
Add Google social login to Next auth flow

### DIFF
--- a/openeire-next/.env.example
+++ b/openeire-next/.env.example
@@ -1,4 +1,10 @@
 NEXT_PUBLIC_API_BASE_URL=https://api.openeire.ie/api/
 NEXT_PUBLIC_STRIPE_PUBLIC_KEY=pk_test_replace_me
+NEXT_PUBLIC_GOOGLE_CLIENT_ID=replace-me.apps.googleusercontent.com
+NEXT_PUBLIC_SITE_URL=https://openeire.ie
+# NEXT_PUBLIC_MEDIA_BASE_URL=https://media.openeire.ie
+NEXT_PUBLIC_SITE_SOCIAL_INSTAGRAM_URL=https://www.instagram.com/openeirestudios/
+NEXT_PUBLIC_SITE_SOCIAL_YOUTUBE_URL=https://www.youtube.com/@openeirestudios
+NEXT_PUBLIC_IUBENDA_CONSENT_PUBLIC_API_KEY=
 NEXT_PUBLIC_IUBENDA_POLICY_URL=https://www.iubenda.com/privacy-policy/77203310
 NEXT_PUBLIC_IUBENDA_POLICY_EMBED_URL=https://www.iubenda.com/privacy-policy/77203310/legal

--- a/openeire-next/components/auth/AuthProvider.tsx
+++ b/openeire-next/components/auth/AuthProvider.tsx
@@ -12,6 +12,7 @@ import {
 import {
   getProfile,
   isApiError,
+  loginWithGoogleCode,
   loginUser,
   normalizeAuthErrorMessage,
   registerUser,
@@ -23,13 +24,19 @@ import {
   setTokens,
 } from "@/lib/auth/tokenStorage";
 import { clearCheckoutSuccessContext } from "@/lib/checkout/successContext";
-import type { LoginPayload, RegisterPayload, UserProfile } from "@/types/auth";
+import type {
+  GoogleLoginPayload,
+  LoginPayload,
+  RegisterPayload,
+  UserProfile,
+} from "@/types/auth";
 
 interface AuthContextValue {
   user: UserProfile | null;
   isAuthenticated: boolean;
   isLoading: boolean;
   login: (payload: LoginPayload) => Promise<void>;
+  loginWithGoogle: (payload: GoogleLoginPayload) => Promise<void>;
   register: (payload: RegisterPayload) => Promise<void>;
   logout: () => void;
   refreshUser: () => Promise<UserProfile | null>;
@@ -123,6 +130,19 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     [refreshUser],
   );
 
+  const loginWithGoogle = useCallback(
+    async (payload: GoogleLoginPayload) => {
+      clearCheckoutSuccessContext();
+      const tokens = await loginWithGoogleCode(payload);
+      if (!tokens.access || !tokens.refresh) {
+        throw new Error("Malformed Google login response.");
+      }
+      setTokens(tokens);
+      await refreshUser();
+    },
+    [refreshUser],
+  );
+
   const register = useCallback(async (payload: RegisterPayload) => {
     await registerUser(payload);
   }, []);
@@ -133,11 +153,12 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       isAuthenticated: Boolean(user && getAccessToken()),
       isLoading,
       login,
+      loginWithGoogle,
       register,
       logout,
       refreshUser,
     }),
-    [isLoading, login, logout, refreshUser, register, user],
+    [isLoading, login, loginWithGoogle, logout, refreshUser, register, user],
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;

--- a/openeire-next/components/auth/LoginForm.tsx
+++ b/openeire-next/components/auth/LoginForm.tsx
@@ -7,6 +7,7 @@ import { useAuth, normalizeAuthErrorMessage } from "@/components/auth/AuthProvid
 import { useToast } from "@/components/ui/ToastProvider";
 import { resendVerificationEmail } from "@/lib/api/auth";
 import { getSafeReturnPath } from "@/lib/auth/redirects";
+import { SocialLogin } from "@/components/auth/SocialLogin";
 
 const inputClass =
   "w-full rounded-lg border border-white/20 bg-black p-3 text-white outline-none transition-all focus:border-brand-500 focus:ring-1 focus:ring-brand-500";
@@ -155,6 +156,8 @@ export function LoginForm() {
           {loading ? "Signing in..." : "Log In"}
         </button>
       </form>
+
+      <SocialLogin redirectPath={redirectPath} />
 
       <div className="mt-8 border-t border-white/10 pt-6 text-center text-sm text-gray-500">
         <p className="mb-2">

--- a/openeire-next/components/auth/RegisterForm.tsx
+++ b/openeire-next/components/auth/RegisterForm.tsx
@@ -6,6 +6,7 @@ import { useEffect, useMemo, useState, type ChangeEvent, type FormEvent } from "
 import { useAuth, normalizeAuthErrorMessage } from "@/components/auth/AuthProvider";
 import { useToast } from "@/components/ui/ToastProvider";
 import { getSafeReturnPath } from "@/lib/auth/redirects";
+import { SocialLogin } from "@/components/auth/SocialLogin";
 
 interface RegisterFormData {
   first_name: string;
@@ -242,6 +243,8 @@ export function RegisterForm() {
           {loading ? "Creating Account..." : "Create Account"}
         </button>
       </form>
+
+      <SocialLogin redirectPath={redirectPath} />
 
       <div className="mt-6 border-t border-white/10 pt-6 text-center text-sm text-gray-500">
         Already have an account?{" "}

--- a/openeire-next/components/auth/SocialLogin.tsx
+++ b/openeire-next/components/auth/SocialLogin.tsx
@@ -1,0 +1,210 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import { FcGoogle } from "react-icons/fc";
+import { useRouter } from "next/navigation";
+import { useAuth, normalizeAuthErrorMessage } from "@/components/auth/AuthProvider";
+import { useToast } from "@/components/ui/ToastProvider";
+import { getSafeReturnPath } from "@/lib/auth/redirects";
+
+interface SocialLoginProps {
+  redirectPath?: string;
+}
+
+interface GoogleCodeResponse {
+  code?: string;
+  error?: string;
+  error_description?: string;
+}
+
+interface GoogleCodeClient {
+  requestCode: () => void;
+}
+
+declare global {
+  interface Window {
+    google?: {
+      accounts?: {
+        oauth2?: {
+          initCodeClient: (config: {
+            client_id: string;
+            scope: string;
+            ux_mode: "popup";
+            callback: (response: GoogleCodeResponse) => void;
+          }) => GoogleCodeClient;
+        };
+      };
+    };
+  }
+}
+
+const GOOGLE_CLIENT_ID =
+  process.env.NEXT_PUBLIC_GOOGLE_CLIENT_ID?.trim() ?? "";
+const GOOGLE_SCRIPT_SRC = "https://accounts.google.com/gsi/client";
+const GOOGLE_SCRIPT_ID = "google-identity-services";
+
+const loadGoogleIdentityScript = (): Promise<void> => {
+  if (typeof window === "undefined") return Promise.resolve();
+  if (window.google?.accounts?.oauth2) return Promise.resolve();
+
+  const existingScript = document.getElementById(
+    GOOGLE_SCRIPT_ID,
+  ) as HTMLScriptElement | null;
+
+  if (existingScript) {
+    return new Promise((resolve, reject) => {
+      existingScript.addEventListener("load", () => resolve(), { once: true });
+      existingScript.addEventListener(
+        "error",
+        () => reject(new Error("Google sign-in script failed to load.")),
+        { once: true },
+      );
+    });
+  }
+
+  return new Promise((resolve, reject) => {
+    const script = document.createElement("script");
+    script.id = GOOGLE_SCRIPT_ID;
+    script.src = GOOGLE_SCRIPT_SRC;
+    script.async = true;
+    script.defer = true;
+    script.onload = () => resolve();
+    script.onerror = () =>
+      reject(new Error("Google sign-in script failed to load."));
+    document.head.appendChild(script);
+  });
+};
+
+export function SocialLogin({ redirectPath }: SocialLoginProps) {
+  const router = useRouter();
+  const { loginWithGoogle } = useAuth();
+  const { showToast } = useToast();
+  const [isReady, setIsReady] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [scriptError, setScriptError] = useState<string | null>(null);
+
+  const postLoginPath = useMemo(
+    () => getSafeReturnPath(redirectPath),
+    [redirectPath],
+  );
+
+  useEffect(() => {
+    if (!GOOGLE_CLIENT_ID) {
+      setScriptError("Google sign-in is not configured.");
+      return;
+    }
+
+    let isMounted = true;
+    loadGoogleIdentityScript()
+      .then(() => {
+        if (isMounted) {
+          setIsReady(Boolean(window.google?.accounts?.oauth2));
+        }
+      })
+      .catch(() => {
+        if (isMounted) {
+          setScriptError(
+            "Google sign-in could not be prepared. Please use email and password.",
+          );
+        }
+      });
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
+  const handleGoogleLogin = () => {
+    if (isSubmitting) return;
+
+    if (!GOOGLE_CLIENT_ID || !window.google?.accounts?.oauth2) {
+      showToast(
+        "Google sign-in is not ready yet. Please try again in a moment.",
+        "error",
+      );
+      return;
+    }
+
+    setScriptError(null);
+    setIsSubmitting(true);
+    const client = window.google.accounts.oauth2.initCodeClient({
+      client_id: GOOGLE_CLIENT_ID,
+      scope: "openid profile email",
+      ux_mode: "popup",
+      callback: async (response) => {
+        if (!response.code) {
+          showToast(
+            response.error
+              ? "Google sign-in was cancelled or could not be completed."
+              : "Google sign-in did not return an authorisation code.",
+            "error",
+          );
+          setIsSubmitting(false);
+          return;
+        }
+
+        try {
+          await loginWithGoogle({ code: response.code });
+          showToast("Welcome back.", "success");
+          router.replace(postLoginPath);
+        } catch (error) {
+          showToast(
+            normalizeAuthErrorMessage(
+              error,
+              "Google sign-in could not be completed right now. Please try again or use email and password.",
+            ),
+            "error",
+          );
+        } finally {
+          setIsSubmitting(false);
+        }
+      },
+    });
+
+    try {
+      client.requestCode();
+    } catch {
+      setIsSubmitting(false);
+      showToast(
+        "Google sign-in could not be opened. Please try again or use email and password.",
+        "error",
+      );
+    }
+  };
+
+  if (!GOOGLE_CLIENT_ID) return null;
+
+  return (
+    <div className="mt-8">
+      <div className="relative">
+        <div className="absolute inset-0 flex items-center">
+          <div className="w-full border-t border-white/10" />
+        </div>
+        <div className="relative flex justify-center text-xs uppercase tracking-widest">
+          <span className="bg-gray-900 px-2 text-gray-500">
+            Or continue with
+          </span>
+        </div>
+      </div>
+
+      <button
+        type="button"
+        onClick={handleGoogleLogin}
+        disabled={!isReady || isSubmitting}
+        className="mt-6 flex w-full items-center justify-center rounded-lg border border-white/20 bg-black px-4 py-3 text-sm font-bold text-white shadow-sm transition-all hover:bg-white/5 disabled:cursor-wait disabled:opacity-60"
+        title={isReady ? "Sign in with Google" : "Preparing Google sign-in"}
+      >
+        <FcGoogle className="mr-3 text-xl" aria-hidden="true" />
+        {isSubmitting
+          ? "Signing in with Google..."
+          : isReady
+            ? "Sign in with Google"
+            : "Preparing Google sign-in..."}
+      </button>
+
+      {scriptError ? (
+        <p className="mt-3 text-center text-xs text-gray-500">{scriptError}</p>
+      ) : null}
+    </div>
+  );
+}

--- a/openeire-next/docs/pr7-auth-foundation-audit.md
+++ b/openeire-next/docs/pr7-auth-foundation-audit.md
@@ -60,7 +60,7 @@ If the backend uses a different refresh route, update `lib/api/auth.ts` and `lib
 
 ## Known Gaps
 
-- Google social login is not migrated yet because the Vite app uses `@react-oauth/google`, and this PR does not add new auth dependencies.
+- Google social login was intentionally deferred from PR 7 because the Vite app used `@react-oauth/google`, and that auth-foundation PR did not add new auth dependencies.
 - `/profile` is not migrated yet; successful login keeps the production redirect target for parity, but the page itself belongs to a later account PR.
 - There is no dedicated test script in `openeire-next` yet, so auth validation is currently covered by lint/build and manual browser checks.
 

--- a/openeire-next/lib/api/auth.ts
+++ b/openeire-next/lib/api/auth.ts
@@ -1,6 +1,7 @@
 import { api, isApiError } from "@/lib/api/client";
 import type {
   ApiErrorResponse,
+  GoogleLoginPayload,
   LoginPayload,
   LoginResponse,
   MessageResponse,
@@ -81,6 +82,15 @@ export const loginUser = async (
   payload: LoginPayload,
 ): Promise<LoginResponse> => {
   const response = await api.post<LoginResponse>("auth/login/", payload, {
+    skipAuthRefresh: true,
+  });
+  return response.data;
+};
+
+export const loginWithGoogleCode = async (
+  payload: GoogleLoginPayload,
+): Promise<LoginResponse> => {
+  const response = await api.post<LoginResponse>("auth/google/", payload, {
     skipAuthRefresh: true,
   });
   return response.data;

--- a/openeire-next/next.config.ts
+++ b/openeire-next/next.config.ts
@@ -3,6 +3,18 @@ import type { NextConfig } from "next";
 const nextConfig: NextConfig = {
   reactStrictMode: true,
   outputFileTracingRoot: process.cwd(),
+  images: {
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "api.openeire.ie",
+      },
+      {
+        protocol: "https",
+        hostname: "media.openeire.ie",
+      },
+    ],
+  },
   async redirects() {
     return [
       {

--- a/openeire-next/types/auth.ts
+++ b/openeire-next/types/auth.ts
@@ -42,6 +42,10 @@ export interface LoginResponse {
   refresh: string;
 }
 
+export interface GoogleLoginPayload {
+  code: string;
+}
+
 export interface RegisterPayload {
   username: string;
   first_name?: string;


### PR DESCRIPTION
## Summary
Adds Google social login support to the Next.js app using Google Identity Services and the existing Django `auth/google/` endpoint.

## Changes
- Added reusable `SocialLogin` component for login/register pages.
- Added `loginWithGoogle` support to `AuthProvider`.
- Added typed Google login API helper and payload type.
- Prevented duplicate Google popup/login attempts while a request is pending.
- Updated `.env.example` with `NEXT_PUBLIC_GOOGLE_CLIENT_ID` and other public runtime values.
- Kept auth-code exchange server-side through the existing backend endpoint.
- Added allowed remote image hosts in `next.config.ts`.

## Security Notes
- Only the public Google client ID is exposed to the browser.
- The frontend sends a short-lived Google auth code to the backend.
- No Google client secret or backend secret is exposed.
- Existing redirect sanitisation is preserved.

## Validation
- `npm.cmd run lint` passed.
- `npm.cmd run build` passed.
- `npm audit` passed with 0 vulnerabilities.
- `npm audit --omit=dev` passed with 0 vulnerabilities.
- `npm.cmd ls axios plain-crypto-js` shows both absent.

## Deploy Notes
- Set `NEXT_PUBLIC_GOOGLE_CLIENT_ID` in the Next frontend environment.
- Confirm the Google OAuth client allows the production origin.
- Deploy with or after the backend PR so existing email/password accounts can link safely.