### PR TITLE
Forward internal API secret from server fetches

### DIFF
--- a/openeire-next/lib/api/client.ts
+++ b/openeire-next/lib/api/client.ts
@@ -167,6 +167,14 @@ const request = async <T>(
   const url = buildUrl(path, config.params);
   const requestInfo = { method, url };
   const headers = new Headers(config.headers);
+
+  if (typeof window === "undefined") {
+    const internalSecret = process.env.OPENEIRE_INTERNAL_API_SECRET;
+
+    if (internalSecret) {
+      headers.set("X-OpenEire-Internal", internalSecret);
+    }
+  }
   const { body, shouldSetJsonContentType } = createRequestBody(
     config.data,
     config.body,


### PR DESCRIPTION
## Summary

This PR updates the shared Next API client so server-side API requests can include the configured internal OpenEire API header when `OPENEIRE_INTERNAL_API_SECRET` is available.

## Why

Server-rendered public content can depend on API calls made from the Next server runtime. Forwarding the internal header from server-only code lets the backend recognise trusted Next-originated requests without exposing the secret to the browser.

## Screenshots / Demo

- [x] Not needed
- [ ] Added (attach screenshots / short Loom link)

## Changes

- Backend:
  - None.

- Frontend:
  - Adds `X-OpenEire-Internal` to API requests only when running server-side.
  - Reads the value from `OPENEIRE_INTERNAL_API_SECRET`.
  - Keeps browser/client requests unchanged.

- Infra/Config:
  - Requires `OPENEIRE_INTERNAL_API_SECRET` to be configured in the Next Render service if this header is expected by the backend.

## Testing

- [ ] Django tests pass locally
- [ ] React build passes locally
- [ ] Manual smoke test done

### Manual smoke test checklist (quick)

- [ ] No console errors
- [ ] Forms submit correctly (success + validation errors)
- [ ] API errors handled (loading/error states)
- [ ] Mobile layout checked
- [ ] Auth/permissions verified (if relevant)

## Risk & Rollback

Risk level: Low

Rollback plan:

- [x] Revert PR
- [ ] Feature flag off
- [ ] Hotfix path described:

This is server-only header forwarding. The secret is not exposed to browser requests because it is read only when `typeof window === "undefined"`.

## Notes for Reviewer (Codex/Copilot)

Focus review on:

- [x] Security (auth, permissions, file uploads, CSRF/CORS)
- [ ] Performance (N+1 queries, heavy renders, unnecessary requests)
- [x] Maintainability (naming, structure, duplicated logic)

Please verify the header is only sent from server-side Next fetches and that `OPENEIRE_INTERNAL_API_SECRET` is present in Render for the Next service.