### PR TITLE
Harden server-side API fetch diagnostics for launch

### DIFF
--- a/openeire-next/lib/api/blog.ts
+++ b/openeire-next/lib/api/blog.ts
@@ -20,6 +20,7 @@ export const getPublishedBlogPosts = async (
         page: options.page,
       },
       next: { revalidate: BLOG_REVALIDATE_SECONDS },
+      publicFetchContext: "blog:list",
     });
 
     return response.data;
@@ -51,6 +52,7 @@ export const getPublishedBlogPostBySlug = async (
   try {
     const response = await api.get<BlogPostDetail>(`blog/${slug}/`, {
       next: { revalidate: BLOG_REVALIDATE_SECONDS },
+      publicFetchContext: "blog:detail",
     });
 
     return response.data;

--- a/openeire-next/lib/api/client.ts
+++ b/openeire-next/lib/api/client.ts
@@ -26,6 +26,7 @@ export interface ApiRequestConfig {
   _retry?: boolean;
   cache?: RequestCache;
   next?: NextFetchRequestConfig;
+  publicFetchContext?: string;
 }
 
 export class ApiError extends Error {
@@ -121,6 +122,7 @@ const isBodyInit = (value: unknown): value is BodyInit =>
   typeof value === "string";
 
 const SAFE_AUTH_REFRESH_RETRY_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
+const SERVER_PUBLIC_FETCH_USER_AGENT = "OpenEire-Next-SSR/1.0";
 
 const canRetryAfterAuthRefresh = (
   method: string,
@@ -167,14 +169,16 @@ const request = async <T>(
   const url = buildUrl(path, config.params);
   const requestInfo = { method, url };
   const headers = new Headers(config.headers);
+  const isServerRequest = typeof window === "undefined";
+  const internalSecret = isServerRequest
+    ? process.env.OPENEIRE_INTERNAL_API_SECRET
+    : undefined;
 
-  if (typeof window === "undefined") {
-    const internalSecret = process.env.OPENEIRE_INTERNAL_API_SECRET;
-
-    if (internalSecret) {
-      headers.set("X-OpenEire-Internal", internalSecret);
-    }
+  if (isServerRequest) {
+    headers.set("User-Agent", SERVER_PUBLIC_FETCH_USER_AGENT);
+    if (internalSecret) headers.set("X-OpenEire-Internal", internalSecret);
   }
+
   const { body, shouldSetJsonContentType } = createRequestBody(
     config.data,
     config.body,
@@ -190,6 +194,17 @@ const request = async <T>(
   }
   if (shouldSetJsonContentType && !headers.has("Content-Type")) {
     headers.set("Content-Type", "application/json");
+  }
+
+  if (isServerRequest && config.publicFetchContext) {
+    console.info("[server-public-fetch-debug]", {
+      context: config.publicFetchContext,
+      finalUrl: url,
+      isServer: true,
+      hasInternalSecret: Boolean(internalSecret),
+      hasInternalHeader: headers.has("X-OpenEire-Internal"),
+      userAgentSet: headers.has("User-Agent"),
+    });
   }
 
   try {

--- a/openeire-next/lib/api/gallery.ts
+++ b/openeire-next/lib/api/gallery.ts
@@ -54,6 +54,7 @@ export const getPublicGalleryItems = async (
         page: query.page,
       },
       next: { revalidate: GALLERY_REVALIDATE_SECONDS },
+      publicFetchContext: "gallery:public-list",
     });
 
     return asGalleryPage(response.data);
@@ -137,6 +138,7 @@ export const getPublicPhysicalProduct = async (
       `products/${id}/`,
       {
         next: { revalidate: GALLERY_REVALIDATE_SECONDS },
+        publicFetchContext: "gallery:physical-detail",
       },
     );
 
@@ -184,6 +186,7 @@ export const getShoppingBagRecommendations = async (): Promise<
       PublicGalleryItem[] | PaginatedResponse<PublicGalleryItem>
     >("products/recommendations/", {
       cache: "no-store",
+      publicFetchContext: "gallery:recommendations",
     });
 
     const recommendations = asGalleryPage(response.data).results.filter(


### PR DESCRIPTION
## Summary

Adds safe server-side API fetch diagnostics for the Next frontend and sends a server-only internal header/User-Agent on public SSR fetches. This helps diagnose Render/Cloudflare API fetch failures without exposing secrets to the browser.

## Why

Public server-rendered pages were falling back when Render SSR requests to the API were blocked/challenged. This makes the failed URL/status path observable while keeping the user-facing fallback UI intact.

## Screenshots / Demo

- [x] Not needed
- [ ] Added (attach screenshots / short Loom link)

## Changes

- Backend:
  - N/A
- Frontend:
  - Added server-only `X-OpenEire-Internal` header when `OPENEIRE_INTERNAL_API_SECRET` is available.
  - Added server-only `User-Agent: OpenEire-Next-SSR/1.0`.
  - Added safe `[server-public-fetch-debug]` logging with URL/context/header-presence booleans only.
  - Tagged blog and gallery public fetches with diagnostic contexts.
- Infra/Config:
  - Uses existing `OPENEIRE_INTERNAL_API_SECRET` if configured.
  - No secret values are logged or exposed client-side.

## Testing

- [ ] Django tests pass locally
- [x] React build passes locally
- [x] Manual smoke test done

### Manual smoke test checklist (quick)

- [ ] No console errors
- [ ] Forms submit correctly (success + validation errors)
- [x] API errors handled (loading/error states)
- [ ] Mobile layout checked
- [x] Auth/permissions verified (if relevant)

## Risk & Rollback

Risk level: Low

Rollback plan:

- [x] Revert PR
- [ ] Feature flag off
- [ ] Hotfix path described:

## Notes for Reviewer (Codex/Copilot)

Focus review on:

- [x] Security (auth, permissions, file uploads, CSRF/CORS)
- [ ] Performance (N+1 queries, heavy renders, unnecessary requests)
- [x] Maintainability (naming, structure, duplicated logic)