### PR TITLE
Polish pre-live services navigation and split page UX

### DIFF
--- a/openeire-next/app/globals.css
+++ b/openeire-next/app/globals.css
@@ -124,7 +124,7 @@ a {
 }
 
 .page-top-offset {
-  padding-top: var(--page-top-offset);
+  padding-top: calc(var(--site-header-height, var(--page-top-offset)) + 1rem);
 }
 
 .header-safe-top {
@@ -184,7 +184,7 @@ a {
 @media (max-width: 767px) {
   .page-top-offset,
   .mobile-page-offset {
-    padding-top: calc(var(--site-header-height, 0px) + 1rem);
+    padding-top: calc(var(--site-header-height, var(--page-top-offset)) + 1rem);
   }
 }
 

--- a/openeire-next/app/layout.tsx
+++ b/openeire-next/app/layout.tsx
@@ -25,8 +25,9 @@ export default function RootLayout({
       </head>
       <body>
         <Script
+          id="openeire-iubenda-widget"
           src="https://embeds.iubenda.com/widgets/b39f0cd0-25d9-49f2-9306-1258615676f2.js"
-          strategy="afterInteractive"
+          strategy="beforeInteractive"
         />
         <Providers>
           <div className="flex min-h-screen flex-col">

--- a/openeire-next/app/services/page.tsx
+++ b/openeire-next/app/services/page.tsx
@@ -1,0 +1,174 @@
+import Link from "next/link";
+import { JsonLd } from "@/components/JsonLd";
+import { PUBLIC_IMAGES } from "@/lib/assets";
+import { SITE_NAME, buildAbsoluteUrl } from "@/lib/site";
+import { buildBreadcrumbJsonLd } from "@/lib/seo/jsonLd";
+import { buildPageMetadata } from "@/lib/seo/metadata";
+import { FaArrowRight, FaFileContract, FaHome } from "react-icons/fa";
+
+export const metadata = buildPageMetadata({
+  title: "Services | Commercial Licensing & Real Estate Media | OpenÉire Studios",
+  description:
+    "Choose between commercial aerial licensing and real estate photography, drone video, and virtual tour services from OpenÉire Studios.",
+  path: "/services",
+  image: PUBLIC_IMAGES.heroPoster,
+});
+
+const serviceCards = [
+  {
+    title: "Commercial Licensing",
+    eyebrow: "Rights-managed aerial visuals",
+    description:
+      "License premium aerial photography and footage for campaigns, editorial projects, brand films, tourism, hospitality, and production work.",
+    href: "/licensing",
+    cta: "Explore Licensing",
+    icon: <FaFileContract aria-hidden="true" />,
+    image: PUBLIC_IMAGES.heroPoster,
+    points: [
+      "Commercial and editorial licence scopes",
+      "Photo and video assets for campaign use",
+      "Clear usage, territory, duration, and approval terms",
+    ],
+  },
+  {
+    title: "Real Estate Services",
+    eyebrow: "Property media across Connacht",
+    description:
+      "Book professional real estate photography, aerial drone video, social cuts, and 3D virtual tours for property listings and developments.",
+    href: "/real-estate",
+    cta: "View Real Estate Services",
+    icon: <FaHome aria-hidden="true" />,
+    image: PUBLIC_IMAGES.irelandGallery,
+    points: [
+      "Interior, exterior, and aerial property media",
+      "Clear package pricing for listings",
+      "Listing-ready delivery for agents, developers, and sellers",
+    ],
+  },
+] as const;
+
+const servicesSchema = [
+  buildBreadcrumbJsonLd([
+    { name: "Home", url: buildAbsoluteUrl("/") },
+    { name: "Services", url: buildAbsoluteUrl("/services") },
+  ]),
+  {
+    "@context": "https://schema.org",
+    "@type": "ItemList",
+    name: `${SITE_NAME} services`,
+    url: buildAbsoluteUrl("/services"),
+    itemListElement: serviceCards.map((service, index) => ({
+      "@type": "ListItem",
+      position: index + 1,
+      item: {
+        "@type": "Service",
+        name: service.title,
+        description: service.description,
+        provider: {
+          "@type": "Organization",
+          name: SITE_NAME,
+          url: buildAbsoluteUrl("/"),
+        },
+        url: buildAbsoluteUrl(service.href),
+      },
+    })),
+  },
+];
+
+export default function ServicesPage() {
+  return (
+    <main className="min-h-screen bg-black text-white">
+      <JsonLd data={servicesSchema} />
+
+      <section className="page-top-offset relative isolate overflow-hidden border-b border-white/10">
+        <div
+          className="absolute inset-0 -z-20 bg-cover bg-center opacity-25"
+          style={{ backgroundImage: `url(${PUBLIC_IMAGES.heroPoster})` }}
+          aria-hidden="true"
+        />
+        <div
+          className="absolute inset-0 -z-10 bg-[radial-gradient(circle_at_top,rgba(22,163,74,0.22),transparent_34%),linear-gradient(180deg,rgba(0,0,0,0.38),#000)]"
+          aria-hidden="true"
+        />
+        <div className="container mx-auto px-4 py-12 text-center sm:py-16 lg:px-8">
+          <p className="mx-auto w-fit rounded-full border border-accent/30 bg-accent/10 px-4 py-2 text-xs font-bold uppercase tracking-[0.28em] text-accent">
+            Services
+          </p>
+          <h1 className="mx-auto mt-6 max-w-4xl font-serif text-4xl font-bold leading-tight md:text-6xl">
+            Choose your service path
+          </h1>
+          <p className="mx-auto mt-5 max-w-2xl text-base leading-relaxed text-gray-300 md:text-lg">
+            Start with the route that matches your project: licence existing
+            OpenÉire visuals, or commission new property media for a listing.
+          </p>
+        </div>
+      </section>
+
+      <section className="grid border-b border-white/10 lg:min-h-[62vh] lg:grid-cols-2">
+        {serviceCards.map((service, index) => (
+          <Link
+            key={service.href}
+            href={service.href}
+            className={`group relative isolate flex min-h-[34rem] overflow-hidden ${
+              index === 0 ? "lg:border-r lg:border-white/10" : ""
+            } focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-offset-2 focus:ring-offset-black`}
+            aria-label={`${service.cta}: ${service.title}`}
+          >
+            <div
+              className="absolute inset-0 -z-20 bg-cover bg-center opacity-[0.28] transition duration-500 group-hover:scale-105 group-hover:opacity-[0.35]"
+              style={{ backgroundImage: `url(${service.image})` }}
+              aria-hidden="true"
+            />
+            <div
+              className={`absolute inset-0 -z-10 ${
+                index === 0
+                  ? "bg-[linear-gradient(135deg,rgba(0,0,0,0.9),rgba(8,47,73,0.74)),radial-gradient(circle_at_top_left,rgba(255,196,0,0.18),transparent_38%)]"
+                  : "bg-[linear-gradient(135deg,rgba(0,0,0,0.9),rgba(5,46,22,0.75)),radial-gradient(circle_at_top_right,rgba(22,163,74,0.25),transparent_42%)]"
+              }`}
+              aria-hidden="true"
+            />
+            <div className="flex w-full flex-col justify-between p-6 sm:p-8 lg:p-12 xl:p-16">
+              <div>
+                <div className="mb-8 flex h-14 w-14 items-center justify-center rounded-2xl border border-white/10 bg-white/10 text-2xl text-accent shadow-xl shadow-black/25 backdrop-blur">
+                  {service.icon}
+                </div>
+                <p className="text-xs font-bold uppercase tracking-[0.28em] text-accent">
+                  {service.eyebrow}
+                </p>
+                <h2 className="mt-4 max-w-xl font-serif text-4xl font-bold leading-tight text-white md:text-5xl">
+                  {service.title}
+                </h2>
+                <p className="mt-6 max-w-xl text-base leading-relaxed text-gray-200 md:text-lg">
+                  {service.description}
+                </p>
+                <ul className="mt-8 grid max-w-xl gap-4 text-sm text-gray-200 md:text-base">
+                  {service.points.map((point) => (
+                    <li key={point} className="flex gap-3">
+                      <span className="mt-2 h-2 w-2 shrink-0 rounded-full bg-brand-500 shadow-[0_0_18px_rgba(22,163,74,0.65)]" />
+                      <span>{point}</span>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+              <span
+                className="mt-10 inline-flex w-fit items-center gap-3 rounded-full bg-brand-500 px-7 py-3 text-sm font-bold text-black transition-all group-hover:-translate-y-0.5 group-hover:bg-accent"
+              >
+                {service.cta} <FaArrowRight className="text-xs" />
+              </span>
+            </div>
+          </Link>
+        ))}
+      </section>
+
+      <section className="container mx-auto px-4 py-10 text-center text-sm text-gray-400 lg:px-8">
+        <p>
+          Need help choosing?{" "}
+          <Link href="/contact" className="font-semibold text-accent hover:text-accent-hover">
+            Contact OpenÉire Studios
+          </Link>{" "}
+          and we will point you to the right path.
+        </p>
+      </section>
+    </main>
+  );
+}

--- a/openeire-next/app/sitemap.ts
+++ b/openeire-next/app/sitemap.ts
@@ -5,6 +5,7 @@ import { buildAbsoluteUrl } from "@/lib/site";
 
 const staticPublicRoutes = [
   "/",
+  "/services",
   "/licensing",
   "/art-prints",
   "/footage",

--- a/openeire-next/components/home/HomeSections.tsx
+++ b/openeire-next/components/home/HomeSections.tsx
@@ -108,17 +108,10 @@ export function HomeHeroSection() {
             </Link>
 
             <Link
-              href="/gallery-gate?next=/gallery/digital"
+              href="/services"
               className="w-full max-w-xs rounded-full border border-white/20 bg-black/20 px-8 py-4 font-medium text-white backdrop-blur-sm transition-all hover:border-white hover:bg-white/30 sm:w-auto"
             >
-              Browse Footage
-            </Link>
-
-            <Link
-              href="/licensing"
-              className="w-full max-w-xs rounded-full border border-white/40 bg-white/5 px-8 py-4 font-medium text-white backdrop-blur-sm transition-all hover:border-white hover:bg-white/20 sm:w-auto"
-            >
-              Explore Licensing
+              Explore Services
             </Link>
           </div>
         </div>

--- a/openeire-next/components/layout/Footer.tsx
+++ b/openeire-next/components/layout/Footer.tsx
@@ -97,7 +97,7 @@ export function Footer() {
               <FooterLink href="/art-prints">Art Prints</FooterLink>
               <FooterLink href="/licensing">Licensing</FooterLink>
               <FooterLink href="/gallery-gate?next=/gallery/digital">Stock Footage</FooterLink>
-              <FooterLink href="/real-estate">Services</FooterLink>
+              <FooterLink href="/services">Services</FooterLink>
               <FooterLink href="/blog">Journal</FooterLink>
               <FooterLink href="/about">Our Story</FooterLink>
             </ul>

--- a/openeire-next/components/layout/Navbar.tsx
+++ b/openeire-next/components/layout/Navbar.tsx
@@ -11,13 +11,15 @@ import {
   FREE_SHIPPING_PROMO_ENABLED,
 } from "@/lib/freeShipping";
 
-const navItems = [
+const primaryNavItems = [
   { href: "/art-prints", label: "Art Prints" },
-  { href: "/licensing", label: "Licensing" },
-  { href: "/footage", label: "Footage" },
-  { href: "/real-estate", label: "Services" },
   { href: "/blog", label: "Blog" },
   { href: "/contact", label: "Contact" },
+];
+
+const serviceNavItems = [
+  { href: "/licensing", label: "Commercial Licensing" },
+  { href: "/real-estate", label: "Real Estate Services" },
 ];
 
 const isActivePath = (pathname: string, href: string) =>
@@ -101,8 +103,13 @@ export function Navbar() {
   const headerRef = useRef<HTMLDivElement | null>(null);
   const [showBanner, setShowBanner] = useState(true);
   const [isMobileMenuOpen, setIsMobileMenuOpen] = useState(false);
+  const [isMobileServicesOpen, setIsMobileServicesOpen] = useState(false);
+  const [isDesktopServicesOpen, setIsDesktopServicesOpen] = useState(false);
   const [scrolled, setScrolled] = useState(false);
   const isHome = pathname === "/";
+  const isServicesActive =
+    isActivePath(pathname, "/services") ||
+    serviceNavItems.some((item) => isActivePath(pathname, item.href));
 
   useEffect(() => {
     const handleScroll = () => setScrolled(window.scrollY > 20);
@@ -113,6 +120,8 @@ export function Navbar() {
 
   useEffect(() => {
     setIsMobileMenuOpen(false);
+    setIsMobileServicesOpen(false);
+    setIsDesktopServicesOpen(false);
   }, [pathname]);
 
   useEffect(() => {
@@ -199,7 +208,74 @@ export function Navbar() {
             </Link>
 
             <div className="hidden items-center gap-5 font-medium text-xs uppercase tracking-wide lg:flex xl:gap-8 xl:text-sm">
-              {navItems.map((item) => (
+              <Link
+                href="/art-prints"
+                className="transition-colors hover:text-accent-hover"
+                style={
+                  isActivePath(pathname, "/art-prints")
+                    ? { color: "var(--color-accent)", fontWeight: 600 }
+                    : undefined
+                }
+              >
+                Art Prints
+              </Link>
+
+              <div
+                className="group relative"
+                onMouseEnter={() => setIsDesktopServicesOpen(true)}
+                onMouseLeave={() => setIsDesktopServicesOpen(false)}
+                onFocus={() => setIsDesktopServicesOpen(true)}
+                onBlur={(event) => {
+                  if (!event.currentTarget.contains(event.relatedTarget as Node | null)) {
+                    setIsDesktopServicesOpen(false);
+                  }
+                }}
+              >
+                <button
+                  type="button"
+                  className="inline-flex items-center gap-1.5 uppercase tracking-wide transition-colors hover:text-accent-hover focus:text-accent-hover focus:outline-none"
+                  style={
+                    isServicesActive
+                      ? { color: "var(--color-accent)", fontWeight: 600 }
+                      : undefined
+                  }
+                  aria-haspopup="true"
+                  aria-expanded={isDesktopServicesOpen}
+                >
+                  Services
+                  <svg
+                    className="h-3 w-3 transition-transform group-hover:rotate-180 group-focus-within:rotate-180"
+                    viewBox="0 0 20 20"
+                    fill="currentColor"
+                    aria-hidden="true"
+                  >
+                    <path
+                      fillRule="evenodd"
+                      d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z"
+                      clipRule="evenodd"
+                    />
+                  </svg>
+                </button>
+                <div className="invisible absolute left-1/2 top-full z-20 mt-4 w-64 -translate-x-1/2 rounded-2xl border border-white/10 bg-dark/95 p-3 text-left opacity-0 shadow-2xl shadow-black/35 backdrop-blur-md transition-all duration-200 group-hover:visible group-hover:opacity-100 group-focus-within:visible group-focus-within:opacity-100">
+                  <div className="absolute -top-4 left-0 h-4 w-full" aria-hidden="true" />
+                  {serviceNavItems.map((item) => (
+                    <Link
+                      key={item.href}
+                      href={item.href}
+                      className="block rounded-xl px-4 py-3 text-xs font-semibold uppercase tracking-[0.18em] text-white/85 transition-colors hover:bg-white/10 hover:text-accent"
+                      style={
+                        isActivePath(pathname, item.href)
+                          ? { color: "var(--color-accent)" }
+                          : undefined
+                      }
+                    >
+                      {item.label}
+                    </Link>
+                  ))}
+                </div>
+              </div>
+
+              {primaryNavItems.slice(1).map((item) => (
                 <Link
                   key={item.href}
                   href={item.href}
@@ -274,7 +350,59 @@ export function Navbar() {
           {isMobileMenuOpen ? (
             <div id="mobile-nav" className="px-4 pb-4 lg:hidden">
               <div className="mt-4 space-y-4 rounded-2xl border border-white/10 bg-dark/95 p-4 shadow-lg backdrop-blur-md">
-                {navItems.map((item) => (
+                <Link
+                  href="/art-prints"
+                  className="block text-sm font-semibold uppercase tracking-wide transition-colors hover:text-accent-hover"
+                >
+                  Art Prints
+                </Link>
+                <div>
+                  <button
+                    type="button"
+                    onClick={() => setIsMobileServicesOpen((prev) => !prev)}
+                    className="flex w-full items-center justify-between text-sm font-semibold uppercase tracking-wide text-white transition-colors hover:text-accent-hover"
+                    aria-expanded={isMobileServicesOpen}
+                    aria-controls="mobile-services-nav"
+                  >
+                    Services
+                    <svg
+                      className={`h-4 w-4 transition-transform ${
+                        isMobileServicesOpen ? "rotate-180" : ""
+                      }`}
+                      viewBox="0 0 20 20"
+                      fill="currentColor"
+                      aria-hidden="true"
+                    >
+                      <path
+                        fillRule="evenodd"
+                        d="M5.23 7.21a.75.75 0 011.06.02L10 11.168l3.71-3.938a.75.75 0 111.08 1.04l-4.25 4.5a.75.75 0 01-1.08 0l-4.25-4.5a.75.75 0 01.02-1.06z"
+                        clipRule="evenodd"
+                      />
+                    </svg>
+                  </button>
+                  {isMobileServicesOpen ? (
+                    <div
+                      id="mobile-services-nav"
+                      className="mt-3 space-y-3 border-l border-white/10 pl-4"
+                    >
+                      {serviceNavItems.map((item) => (
+                        <Link
+                          key={item.href}
+                          href={item.href}
+                          className="block text-xs font-semibold uppercase tracking-[0.18em] text-white/70 transition-colors hover:text-accent-hover"
+                          style={
+                            isActivePath(pathname, item.href)
+                              ? { color: "var(--color-accent)" }
+                              : undefined
+                          }
+                        >
+                          {item.label}
+                        </Link>
+                      ))}
+                    </div>
+                  ) : null}
+                </div>
+                {primaryNavItems.slice(1).map((item) => (
                   <Link
                     key={item.href}
                     href={item.href}

--- a/openeire-next/components/newsletter/NewsletterSignupModal.tsx
+++ b/openeire-next/components/newsletter/NewsletterSignupModal.tsx
@@ -175,7 +175,7 @@ export function NewsletterSignupModal() {
 
   return (
     <div
-      className="fixed inset-0 z-80 flex items-end justify-center p-4 sm:items-center sm:p-6"
+      className="fixed inset-0 z-80 flex items-end justify-center overflow-y-auto overscroll-contain p-4 sm:items-center sm:p-6"
       role="dialog"
       aria-modal="true"
       aria-labelledby="newsletter-signup-modal-title"
@@ -186,7 +186,7 @@ export function NewsletterSignupModal() {
         onClick={closeWithDismissal}
         aria-label="Close newsletter signup"
       />
-      <div className="relative z-10 w-full max-w-xl overflow-hidden rounded-[28px] border border-white/10 bg-[radial-gradient(circle_at_top,_rgba(245,197,24,0.08),_transparent_35%),linear-gradient(180deg,_rgba(17,24,39,0.98),_rgba(5,8,14,0.98))] shadow-[0_30px_80px_rgba(0,0,0,0.45)]">
+      <div className="relative z-10 max-h-[calc(100dvh-2rem)] w-full max-w-xl overflow-y-auto overscroll-contain rounded-[28px] border border-white/10 bg-[radial-gradient(circle_at_top,_rgba(245,197,24,0.08),_transparent_35%),linear-gradient(180deg,_rgba(17,24,39,0.98),_rgba(5,8,14,0.98))] shadow-[0_30px_80px_rgba(0,0,0,0.45)]">
         <button
           type="button"
           onClick={closeWithDismissal}


### PR DESCRIPTION
## Summary

Polishes the pre-live Services navigation and new `/services` decision page. This replaces the older standalone Licensing/Footage/Services nav split with a cleaner Services dropdown and makes `/services` a focused split route-choice page.

## Why

The mobile Services menu needed to feel native to the OpenÉire navigation, and the `/services` page needed to act as a true decision page between Commercial Licensing and Real Estate Services before connecting the production domain.

## Screenshots / Demo

- [ ] Added (attach desktop/mobile nav and `/services` screenshots)

## Changes

- Backend: none
- Frontend: added `/services`, updated homepage CTA, footer link, sitemap entry, Services dropdown, Iubenda/modal scroll polish, and shared page top spacing
- Infra/Config: none

## Testing

- [ ] Django tests pass locally
- [x] React build passes locally
- [x] Manual smoke test done

### Manual smoke test checklist (quick)

- [ ] No console errors
- [ ] Forms submit correctly (success + validation errors)
- [ ] API errors handled (loading/error states)
- [x] Mobile layout checked
- [ ] Auth/permissions verified (if relevant)

## Risk & Rollback

Risk level: Low

Rollback plan:

- [x] Revert PR
- [ ] Feature flag off
- [ ] Hotfix path described:

## Notes for Reviewer (Codex/Copilot)

Focus review on:

- [x] Security (auth, permissions, file uploads, CSRF/CORS)
- [x] Performance (N+1 queries, heavy renders, unnecessary requests)
- [x] Maintainability (naming, structure, duplicated logic)

Validation run:
- `npm.cmd run lint` passed
- `npm.cmd run build` passed
- `npm.cmd audit` passed, 0 vulnerabilities
- `npm.cmd audit --omit=dev` passed, 0 vulnerabilities
- `npm.cmd ls axios plain-crypto-js` returned empty
- `git diff --check` passed