### PR TITLE
Improve mobile swipe cues and restore licensing step grid

### DIFF
--- a/openeire-next/app/blog/[slug]/page.tsx
+++ b/openeire-next/app/blog/[slug]/page.tsx
@@ -188,19 +188,19 @@ export default async function BlogDetailPage({
           {post.title}
         </h1>
 
-        <div className="mb-8 flex flex-wrap items-center gap-6 border-b border-white/10 pb-8 font-mono text-sm text-gray-400">
-          <div className="flex items-center gap-2">
+        <div className="mb-8 flex min-w-0 flex-wrap items-center gap-6 overflow-hidden border-b border-white/10 pb-8 font-mono text-sm text-gray-400">
+          <div className="flex min-w-0 items-center gap-2">
             <FaUser className="text-accent" /> {post.author}
           </div>
-          <div className="flex items-center gap-2">
+          <div className="flex min-w-0 items-center gap-2">
             <FaCalendar className="text-accent" /> {visiblePublishedDate}
           </div>
-          <div className="flex gap-2">
+          <div className="flex min-w-0 flex-wrap gap-2">
             {post.tags.map((tag) => (
               <Link
                 key={tag}
                 href={`/blog?tag=${encodeURIComponent(tag)}`}
-                className="text-accent hover:underline"
+                className="max-w-full break-words text-accent [overflow-wrap:anywhere] hover:underline"
               >
                 #{tag}
               </Link>
@@ -263,7 +263,7 @@ export default async function BlogDetailPage({
             <h2 className="mb-8 font-serif text-2xl font-bold text-white">
               Read Next
             </h2>
-            <div className="grid grid-cols-1 gap-6 md:grid-cols-3">
+            <div className="mobile-snap-row grid grid-cols-1 gap-6 md:grid-cols-3">
               {post.related_posts.map((related) => {
                 const relatedImage = resolveMediaUrl(related.featured_image);
 
@@ -271,7 +271,7 @@ export default async function BlogDetailPage({
                   <Link
                     key={related.slug}
                     href={`/blog/${related.slug}`}
-                    className="group block overflow-hidden rounded-xl border border-white/10 bg-gray-900 transition-all hover:border-accent/50"
+                    className="mobile-snap-card group block overflow-hidden rounded-xl border border-white/10 bg-gray-900 transition-all hover:border-accent/50"
                   >
                     <div className="relative h-40 overflow-hidden">
                       <img

--- a/openeire-next/app/globals.css
+++ b/openeire-next/app/globals.css
@@ -102,12 +102,16 @@
 
 html {
   background: var(--color-paper);
+  overflow-x: hidden;
+  overflow-x: clip;
 }
 
 body {
   @apply bg-paper font-sans text-dark antialiased;
   margin: 0;
   min-height: 100vh;
+  overflow-x: hidden;
+  overflow-x: clip;
 }
 
 h1,
@@ -265,4 +269,58 @@ a {
 .blog-content pre,
 .blog-content code {
   @apply rounded bg-white/5;
+}
+
+@media (max-width: 767px) {
+  .mobile-snap-row {
+    display: flex;
+    gap: 1rem;
+    margin-inline: -1rem;
+    overflow-x: auto;
+    overflow-y: hidden;
+    overscroll-behavior-x: contain;
+    padding-inline: 1rem;
+    scroll-padding-inline: 1rem;
+    scroll-snap-type: x mandatory;
+    scrollbar-width: none;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .mobile-snap-row::-webkit-scrollbar {
+    display: none;
+  }
+
+  .mobile-snap-card {
+    flex: 0 0 min(84vw, 22rem);
+    min-width: 0;
+    scroll-snap-align: start;
+  }
+
+  .mobile-snap-card-wide {
+    flex-basis: min(88vw, 24rem);
+  }
+}
+
+@media (max-width: 1024px) {
+  .services-snap-row {
+    display: flex;
+    gap: 1rem;
+    overflow-x: auto;
+    overflow-y: hidden;
+    overscroll-behavior-x: contain;
+    scroll-padding-inline: 1rem;
+    scroll-snap-type: x mandatory;
+    scrollbar-width: none;
+    -webkit-overflow-scrolling: touch;
+  }
+
+  .services-snap-row::-webkit-scrollbar {
+    display: none;
+  }
+
+  .services-snap-card {
+    flex: 0 0 min(88vw, 40rem);
+    min-width: 0;
+    scroll-snap-align: start;
+  }
 }

--- a/openeire-next/app/licensing/page.tsx
+++ b/openeire-next/app/licensing/page.tsx
@@ -174,7 +174,7 @@ export default function LicensingPage() {
               Process
             </span>
           </div>
-          <NumberedSteps steps={steps} />
+          <NumberedSteps steps={steps} mobileSwipe={false} />
         </TextPanel>
       </PageSection>
       <PageSection title="Licence routes">

--- a/openeire-next/app/real-estate/page.tsx
+++ b/openeire-next/app/real-estate/page.tsx
@@ -1,4 +1,5 @@
 import { JsonLd } from "@/components/JsonLd";
+import { SwipeHint } from "@/components/marketing/MarketingPage";
 import { RealEstateEnquiryForm } from "@/components/real-estate/RealEstateEnquiryForm";
 import { SITE_NAME, buildAbsoluteUrl } from "@/lib/site";
 import { buildPageMetadata } from "@/lib/seo/metadata";
@@ -328,11 +329,12 @@ export default function RealEstatePage() {
               Give every listing a stronger first impression.
             </h2>
           </div>
-          <div className="grid gap-5 md:grid-cols-2 lg:grid-cols-5">
+          <SwipeHint className="md:hidden" />
+          <div className="mobile-snap-row grid gap-5 md:grid-cols-2 lg:grid-cols-5">
             {listingFeatures.map((item) => (
               <div
                 key={item.title}
-                className="rounded-3xl border border-white/10 bg-gray-950 p-6"
+                className="mobile-snap-card rounded-3xl border border-white/10 bg-gray-950 p-6"
               >
                 <div className="mb-5 flex h-12 w-12 items-center justify-center rounded-2xl bg-[#16a34a]/15 text-xl text-[#16a34a]">
                   {item.icon}
@@ -362,11 +364,12 @@ export default function RealEstatePage() {
             </p>
           </div>
 
-          <div className="grid gap-5 lg:grid-cols-2 xl:grid-cols-5">
+          <SwipeHint className="md:hidden" />
+          <div className="mobile-snap-row grid gap-5 lg:grid-cols-2 xl:grid-cols-5">
             {packages.map((item) => (
               <div
                 key={item.key}
-                className={`relative flex flex-col rounded-[1.75rem] border p-6 ${
+                className={`mobile-snap-card mobile-snap-card-wide relative flex flex-col rounded-[1.75rem] border p-6 ${
                   item.badge
                     ? "border-[#16a34a] bg-[#16a34a]/10 shadow-2xl shadow-[#16a34a]/10"
                     : "border-white/10 bg-black"
@@ -421,11 +424,12 @@ export default function RealEstatePage() {
               extras you do not need.
             </p>
           </div>
-          <div className="grid gap-4 md:grid-cols-2">
+          <SwipeHint className="md:hidden" />
+          <div className="mobile-snap-row grid gap-4 md:grid-cols-2">
             {addOns.map((item) => (
               <div
                 key={item.label}
-                className="rounded-2xl border border-white/10 bg-gray-950 p-5"
+                className="mobile-snap-card rounded-2xl border border-white/10 bg-gray-950 p-5"
               >
                 <h3 className="font-bold">{item.label}</h3>
                 <p className="mt-2 text-sm text-[#16a34a]">{item.price}</p>
@@ -437,11 +441,12 @@ export default function RealEstatePage() {
 
       <section className="py-20">
         <div className="container mx-auto max-w-7xl px-4 lg:px-8">
-          <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-4">
+          <SwipeHint className="md:hidden" />
+          <div className="mobile-snap-row grid gap-6 md:grid-cols-2 lg:grid-cols-4">
             {processSteps.map((item) => (
               <div
                 key={item.title}
-                className="rounded-3xl border border-white/10 bg-gray-950 p-7"
+                className="mobile-snap-card rounded-3xl border border-white/10 bg-gray-950 p-7"
               >
                 <h2 className="font-serif text-2xl font-bold">{item.title}</h2>
                 <p className="mt-3 leading-relaxed text-gray-400">

--- a/openeire-next/app/services/page.tsx
+++ b/openeire-next/app/services/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { JsonLd } from "@/components/JsonLd";
+import { SwipeHint } from "@/components/marketing/MarketingPage";
 import { PUBLIC_IMAGES } from "@/lib/assets";
 import { SITE_NAME, buildAbsoluteUrl } from "@/lib/site";
 import { buildBreadcrumbJsonLd } from "@/lib/seo/jsonLd";
@@ -16,21 +17,6 @@ export const metadata = buildPageMetadata({
 
 const serviceCards = [
   {
-    title: "Commercial Licensing",
-    eyebrow: "Rights-managed aerial visuals",
-    description:
-      "License premium aerial photography and footage for campaigns, editorial projects, brand films, tourism, hospitality, and production work.",
-    href: "/licensing",
-    cta: "Explore Licensing",
-    icon: <FaFileContract aria-hidden="true" />,
-    image: PUBLIC_IMAGES.heroPoster,
-    points: [
-      "Commercial and editorial licence scopes",
-      "Photo and video assets for campaign use",
-      "Clear usage, territory, duration, and approval terms",
-    ],
-  },
-  {
     title: "Real Estate Services",
     eyebrow: "Property media across Connacht",
     description:
@@ -44,6 +30,23 @@ const serviceCards = [
       "Clear package pricing for listings",
       "Listing-ready delivery for agents, developers, and sellers",
     ],
+    tone: "property",
+  },
+  {
+    title: "Commercial Licensing",
+    eyebrow: "Rights-managed aerial visuals",
+    description:
+      "License premium aerial photography and footage for campaigns, editorial projects, brand films, tourism, hospitality, and production work.",
+    href: "/licensing",
+    cta: "Explore Licensing",
+    icon: <FaFileContract aria-hidden="true" />,
+    image: PUBLIC_IMAGES.heroPoster,
+    points: [
+      "Commercial and editorial licence scopes",
+      "Photo and video assets for campaign use",
+      "Clear usage, territory, duration, and approval terms",
+    ],
+    tone: "licensing",
   },
 ] as const;
 
@@ -104,12 +107,16 @@ export default function ServicesPage() {
         </div>
       </section>
 
-      <section className="grid border-b border-white/10 lg:min-h-[62vh] lg:grid-cols-2">
+      <section className="border-b border-white/10">
+        <div className="container mx-auto px-4 pt-6 lg:hidden lg:px-8">
+          <SwipeHint className="lg:hidden" label="Swipe between services" />
+        </div>
+        <div className="services-snap-row grid lg:min-h-[62vh] lg:grid-cols-2">
         {serviceCards.map((service, index) => (
           <Link
             key={service.href}
             href={service.href}
-            className={`group relative isolate flex min-h-[34rem] overflow-hidden ${
+            className={`services-snap-card group relative isolate flex min-h-[34rem] overflow-hidden ${
               index === 0 ? "lg:border-r lg:border-white/10" : ""
             } focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-offset-2 focus:ring-offset-black`}
             aria-label={`${service.cta}: ${service.title}`}
@@ -121,7 +128,7 @@ export default function ServicesPage() {
             />
             <div
               className={`absolute inset-0 -z-10 ${
-                index === 0
+                service.tone === "licensing"
                   ? "bg-[linear-gradient(135deg,rgba(0,0,0,0.9),rgba(8,47,73,0.74)),radial-gradient(circle_at_top_left,rgba(255,196,0,0.18),transparent_38%)]"
                   : "bg-[linear-gradient(135deg,rgba(0,0,0,0.9),rgba(5,46,22,0.75)),radial-gradient(circle_at_top_right,rgba(22,163,74,0.25),transparent_42%)]"
               }`}
@@ -158,6 +165,7 @@ export default function ServicesPage() {
             </div>
           </Link>
         ))}
+        </div>
       </section>
 
       <section className="container mx-auto px-4 py-10 text-center text-sm text-gray-400 lg:px-8">

--- a/openeire-next/components/home/HomeSections.tsx
+++ b/openeire-next/components/home/HomeSections.tsx
@@ -1,5 +1,6 @@
 /* eslint-disable @next/next/no-img-element */
 import Link from "next/link";
+import { SwipeHint } from "@/components/marketing/MarketingPage";
 import {
   FaFileContract,
   FaHome,
@@ -140,11 +141,12 @@ export function HomeServicesSection() {
           </p>
         </div>
 
-        <div className="grid grid-cols-1 gap-8 md:grid-cols-2 xl:grid-cols-4 lg:gap-8">
+        <SwipeHint className="md:hidden" />
+        <div className="mobile-snap-row grid grid-cols-1 gap-8 md:grid-cols-2 xl:grid-cols-4 lg:gap-8">
           {services.map((service) => (
             <div
               key={service.title}
-              className="group rounded-2xl border border-gray-700 bg-dark p-8 shadow-sm transition-all duration-300 hover:-translate-y-2 hover:shadow-xl"
+              className="mobile-snap-card group rounded-2xl border border-gray-700 bg-dark p-8 shadow-sm transition-all duration-300 hover:-translate-y-2 hover:shadow-xl"
             >
               <div className="mb-6 inline-block rounded-2xl bg-brand-500 p-4 transition-colors duration-300 group-hover:bg-accent-hover">
                 <div className="transition-colors duration-300 group-hover:text-white">

--- a/openeire-next/components/marketing/MarketingPage.tsx
+++ b/openeire-next/components/marketing/MarketingPage.tsx
@@ -120,48 +120,88 @@ export function CardGrid({
   columns?: 2 | 3;
 }) {
   return (
+    <>
+      <SwipeHint className="md:hidden" />
+      <div
+        className={
+          columns === 2
+            ? "mobile-snap-row grid gap-5 md:grid-cols-2"
+            : "mobile-snap-row grid gap-5 md:grid-cols-3"
+        }
+      >
+        {items.map((item, index) => (
+          <article
+            key={item.id ?? `${item.title}-${index}`}
+            className="mobile-snap-card rounded-3xl border border-white/10 bg-white/5 p-6 backdrop-blur-md"
+          >
+            {item.icon ? (
+              <div className="p-2 text-2xl text-accent">{item.icon}</div>
+            ) : null}
+            <h3 className="font-serif text-xl font-bold text-white">
+              {item.title}
+            </h3>
+            <p className="mt-3 text-sm leading-relaxed text-gray-300">
+              {item.text}
+            </p>
+          </article>
+        ))}
+      </div>
+    </>
+  );
+}
+
+export function SwipeHint({
+  className = "md:hidden",
+  label = "Swipe to explore",
+}: {
+  className?: string;
+  label?: string;
+}) {
+  return (
     <div
-      className={
-        columns === 2
-          ? "grid gap-5 md:grid-cols-2"
-          : "grid gap-5 md:grid-cols-3"
-      }
+      className={`mb-4 flex items-center justify-end gap-2 text-[11px] font-semibold uppercase tracking-[0.24em] text-gray-400 ${className}`}
     >
-      {items.map((item, index) => (
-        <article
-          key={item.id ?? `${item.title}-${index}`}
-          className="rounded-3xl border border-white/10 bg-white/5 p-6 backdrop-blur-md"
-        >
-          {item.icon ? (
-            <div className="text-2xl text-accent p-2">{item.icon}</div>
-          ) : null}
-          <h3 className="font-serif text-xl font-bold text-white">
-            {item.title}
-          </h3>
-          <p className="mt-3 text-sm leading-relaxed text-gray-300">
-            {item.text}
-          </p>
-        </article>
-      ))}
+      <span aria-hidden="true" className="text-sm leading-none">
+        {"<"}
+      </span>
+      <span>{label}</span>
+      <span aria-hidden="true" className="text-sm leading-none">
+        {">"}
+      </span>
     </div>
   );
 }
 
-export function NumberedSteps({ steps }: { steps: string[] }) {
+export function NumberedSteps({
+  steps,
+  mobileSwipe = true,
+}: {
+  steps: string[];
+  mobileSwipe?: boolean;
+}) {
   return (
-    <div className="grid gap-5 md:grid-cols-3">
-      {steps.map((step, index) => (
-        <article
-          key={`${step}-${index}`}
-          className="rounded-2xl border border-white/10 bg-black/35 p-5"
-        >
-          <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-accent">
-            Step {index + 1}
-          </p>
-          <p className="mt-3 text-sm leading-relaxed text-gray-300">{step}</p>
-        </article>
-      ))}
-    </div>
+    <>
+      {mobileSwipe ? <SwipeHint className="md:hidden" /> : null}
+      <div
+        className={
+          mobileSwipe
+            ? "mobile-snap-row grid gap-5 md:grid-cols-3"
+            : "grid gap-5 md:grid-cols-3"
+        }
+      >
+        {steps.map((step, index) => (
+          <article
+            key={`${step}-${index}`}
+            className={`${mobileSwipe ? "mobile-snap-card" : ""} rounded-2xl border border-white/10 bg-black/35 p-5`}
+          >
+            <p className="text-[11px] font-semibold uppercase tracking-[0.24em] text-accent">
+              Step {index + 1}
+            </p>
+            <p className="mt-3 text-sm leading-relaxed text-gray-300">{step}</p>
+          </article>
+        ))}
+      </div>
+    </>
   );
 }
 


### PR DESCRIPTION
## Summary
- add clearer mobile swipe hints to shared card carousel sections
- keep mobile swipe browsing on homepage, real estate, and services sections
- disable mobile swipe for the “How licensing works” section on `/licensing`

## What Changed
- introduced a shared `SwipeHint` helper in `components/marketing/MarketingPage.tsx`
- updated shared card grids to show a mobile swipe cue
- applied the swipe hint to homepage services, real estate card sections, and the services split page
- kept `/services` using swipe on smaller screens with a specific “Swipe between services” cue
- changed the licensing process steps back to a standard grid on mobile by passing `mobileSwipe={false}`

## Files Changed
- `openeire-next/components/marketing/MarketingPage.tsx`
- `openeire-next/components/home/HomeSections.tsx`
- `openeire-next/app/real-estate/page.tsx`
- `openeire-next/app/services/page.tsx`
- `openeire-next/app/licensing/page.tsx`

## Validation
- `git diff --check`
- `npm.cmd run lint`
- `npm.cmd audit`
- `npm.cmd audit --omit=dev`
- `npm.cmd run build`

## Manual Checks
- confirm mobile swipe arrows/hints are visible and clear on homepage service cards
- confirm mobile swipe arrows/hints are visible on real estate card sections
- confirm `/services` shows the swipe hint on smaller screens
- confirm `/licensing` “How licensing works” is no longer swipeable on mobile
- confirm desktop layouts remain unchanged