### PR TITLE
feat(gallery): add print materials info modal and shipping note

### DIFF
--- a/openeire-next/app/gallery/physical/[id]/page.tsx
+++ b/openeire-next/app/gallery/physical/[id]/page.tsx
@@ -263,7 +263,8 @@ export default async function PhysicalProductPage({
 
               <div className="mb-8 rounded-2xl border border-white/10 bg-white/5 p-4 text-sm leading-relaxed text-gray-300">
                 Made to order as a premium fine art print. Shipping is
-                calculated at checkout.
+                calculated at checkout. All materials with the exception of Eco
+                Canvas, are shipped rolled.
               </div>
 
               {product.variants.length ? (

--- a/openeire-next/components/cart/PhysicalAddToCartPanel.tsx
+++ b/openeire-next/components/cart/PhysicalAddToCartPanel.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useMemo, useState } from "react";
-import { FaShieldAlt, FaShippingFast } from "react-icons/fa";
+import { FaInfoCircle, FaShieldAlt, FaShippingFast } from "react-icons/fa";
 import { useCart } from "@/components/cart/CartProvider";
+import { PrintMaterialsModal } from "@/components/gallery/PrintMaterialsModal";
 import { useToast } from "@/components/ui/ToastProvider";
 import { formatCartCurrency } from "@/lib/cart/pricing";
 import type { CartProductSnapshot } from "@/lib/cart/types";
@@ -32,6 +33,7 @@ export function PhysicalAddToCartPanel({
     variants[0]?.material ?? "",
   );
   const [selectedSize, setSelectedSize] = useState(variants[0]?.size ?? "");
+  const [isMaterialsModalOpen, setIsMaterialsModalOpen] = useState(false);
 
   const selectedVariant = useMemo(
     () =>
@@ -159,6 +161,17 @@ export function PhysicalAddToCartPanel({
               />
             </svg>
           </span>
+          <button
+            type="button"
+            onClick={() => setIsMaterialsModalOpen(true)}
+            className="mt-3 inline-flex items-center gap-2 text-sm font-medium text-accent transition-colors hover:text-white focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2 focus:ring-offset-black"
+            aria-haspopup="dialog"
+            aria-controls="print-materials-modal"
+            id="print-materials-modal-trigger"
+          >
+            <FaInfoCircle aria-hidden="true" />
+            <span>About our print materials</span>
+          </button>
         </div>
 
         <div className="relative">
@@ -198,6 +211,11 @@ export function PhysicalAddToCartPanel({
         </span>
         </div>
       </div>
+
+      <PrintMaterialsModal
+        isOpen={isMaterialsModalOpen}
+        onClose={() => setIsMaterialsModalOpen(false)}
+      />
 
       <div className="mt-8 border-t border-white/10 pt-6">
         <div className="mb-6 flex items-end justify-between">

--- a/openeire-next/components/gallery/PrintMaterialsModal.tsx
+++ b/openeire-next/components/gallery/PrintMaterialsModal.tsx
@@ -1,0 +1,278 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { createPortal } from "react-dom";
+import { FaTimes } from "react-icons/fa";
+import {
+  printMaterialFulfilmentNote,
+  printMaterials,
+} from "@/lib/gallery/printMaterials";
+
+interface PrintMaterialsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  id?: string;
+}
+
+const focusableSelector = [
+  "a[href]",
+  "button:not([disabled])",
+  "textarea:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "[tabindex]:not([tabindex='-1'])",
+].join(",");
+
+export function PrintMaterialsModal({
+  isOpen,
+  onClose,
+  id = "print-materials-modal",
+}: PrintMaterialsModalProps) {
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const previouslyFocusedElementRef = useRef<HTMLElement | null>(null);
+  const [isMounted, setIsMounted] = useState(false);
+
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    previouslyFocusedElementRef.current =
+      document.activeElement instanceof HTMLElement
+        ? document.activeElement
+        : null;
+
+    const scrollY = window.scrollY;
+    const originalBodyOverflow = document.body.style.overflow;
+    const originalBodyPosition = document.body.style.position;
+    const originalBodyTop = document.body.style.top;
+    const originalBodyWidth = document.body.style.width;
+
+    document.body.style.overflow = "hidden";
+    document.body.style.position = "fixed";
+    document.body.style.top = `-${scrollY}px`;
+    document.body.style.width = "100%";
+
+    window.setTimeout(() => closeButtonRef.current?.focus(), 0);
+
+    return () => {
+      document.body.style.overflow = originalBodyOverflow;
+      document.body.style.position = originalBodyPosition;
+      document.body.style.top = originalBodyTop;
+      document.body.style.width = originalBodyWidth;
+      window.scrollTo({ top: scrollY, behavior: "auto" });
+      previouslyFocusedElementRef.current?.focus();
+    };
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onClose();
+        return;
+      }
+
+      if (event.key !== "Tab" || !dialogRef.current) return;
+
+      const focusableElements = Array.from(
+        dialogRef.current.querySelectorAll<HTMLElement>(focusableSelector),
+      ).filter((element) => !element.hasAttribute("disabled"));
+
+      if (!focusableElements.length) return;
+
+      const firstElement = focusableElements[0];
+      const lastElement = focusableElements[focusableElements.length - 1];
+
+      if (event.shiftKey && document.activeElement === firstElement) {
+        event.preventDefault();
+        lastElement.focus();
+      } else if (!event.shiftKey && document.activeElement === lastElement) {
+        event.preventDefault();
+        firstElement.focus();
+      }
+    };
+
+    window.addEventListener("keydown", onKeyDown);
+    return () => window.removeEventListener("keydown", onKeyDown);
+  }, [isOpen, onClose]);
+
+  if (!isOpen || !isMounted) return null;
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-[100] flex items-stretch justify-center overflow-x-hidden p-3 sm:items-center sm:p-6"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby={`${id}-title`}
+      aria-describedby={`${id}-description`}
+    >
+      <button
+        type="button"
+        className="fixed inset-0 cursor-default bg-black/85 backdrop-blur-sm"
+        aria-label="Close print materials information"
+        onClick={onClose}
+      />
+
+<div
+      ref={dialogRef}
+      id={id}
+      className="relative flex max-h-[calc(100dvh-1.5rem)] w-full max-w-5xl flex-col overflow-hidden rounded-2xl border border-white/10 bg-gray-950 shadow-2xl sm:max-h-[90dvh]"
+    >
+        <div className="flex items-start justify-between gap-4 border-b border-white/10 bg-gray-900 p-5 sm:p-6">
+          <div>
+            <p className="text-xs font-bold uppercase tracking-widest text-accent">
+              Print Materials
+            </p>
+            <h2
+              id={`${id}-title`}
+              className="mt-2 font-serif text-2xl font-bold text-white sm:text-3xl"
+            >
+              About our print materials
+            </h2>
+            <p
+              id={`${id}-description`}
+              className="mt-2 max-w-3xl text-sm leading-6 text-gray-300"
+            >
+              A quick guide to the feel, finish and display style of each
+              OpenEire print material.
+            </p>
+          </div>
+
+          <button
+            ref={closeButtonRef}
+            type="button"
+            onClick={onClose}
+            className="shrink-0 rounded-full border border-white/10 bg-black/40 p-2 text-gray-300 transition-colors hover:bg-white/10 hover:text-white focus:outline-none focus:ring-2 focus:ring-accent"
+            aria-label="Close print materials information"
+          >
+            <FaTimes aria-hidden="true" />
+          </button>
+        </div>
+
+        <div className="custom-scrollbar overflow-y-auto overscroll-contain p-5 sm:p-6">
+          <div className="rounded-xl border border-accent/30 bg-accent/10 p-4 text-sm font-medium leading-6 text-gray-100">
+            {printMaterialFulfilmentNote}
+          </div>
+
+          <div className="mt-6 grid grid-cols-1 gap-4 lg:grid-cols-2">
+            {printMaterials.map((material) => (
+              <section
+                key={material.name}
+                className="rounded-xl border border-white/10 bg-white/[0.03] p-5"
+              >
+                <h3 className="font-serif text-xl font-bold text-white">
+                  {material.name}
+                </h3>
+                <dl className="mt-4 space-y-3 text-sm leading-6">
+                  <MaterialDetail label="Feel / texture">
+                    {material.feelTexture}
+                  </MaterialDetail>
+                  <MaterialDetail label="Finish">
+                    {material.finish}
+                  </MaterialDetail>
+                  <MaterialDetail label="Printing">
+                    {material.printingMethod}
+                  </MaterialDetail>
+                  <MaterialDetail label="Colour & contrast">
+                    {material.colourContrast}
+                  </MaterialDetail>
+                  <MaterialDetail label="Framing / display">
+                    {material.framingDisplay}
+                  </MaterialDetail>
+                  <MaterialDetail label="Shipping">
+                    {material.shippingFormat}
+                  </MaterialDetail>
+                  <MaterialDetail label="Best suited for">
+                    {material.bestSuitedFor}
+                  </MaterialDetail>
+                </dl>
+              </section>
+            ))}
+          </div>
+
+          <div className="mt-8 overflow-hidden rounded-xl border border-white/10">
+            <div className="overflow-x-auto">
+              <table className="min-w-[760px] w-full border-collapse text-left text-sm">
+                <caption className="sr-only">
+                  Print material comparison table
+                </caption>
+                <thead className="bg-brand-900/40 text-xs uppercase tracking-widest text-accent">
+                  <tr>
+                    <th scope="col" className="px-4 py-3 font-semibold">
+                      Material
+                    </th>
+                    <th scope="col" className="px-4 py-3 font-semibold">
+                      Finish
+                    </th>
+                    <th scope="col" className="px-4 py-3 font-semibold">
+                      Texture
+                    </th>
+                    <th scope="col" className="px-4 py-3 font-semibold">
+                      Colour & Contrast
+                    </th>
+                    <th scope="col" className="px-4 py-3 font-semibold">
+                      Best For
+                    </th>
+                    <th scope="col" className="px-4 py-3 font-semibold">
+                      Ships As
+                    </th>
+                  </tr>
+                </thead>
+                <tbody className="divide-y divide-white/10 bg-black/30 text-gray-300">
+                  {printMaterials.map((material) => (
+                    <tr key={material.name}>
+                      <th
+                        scope="row"
+                        className="px-4 py-4 align-top font-semibold text-white"
+                      >
+                        {material.name}
+                      </th>
+                      <td className="px-4 py-4 align-top">
+                        {material.finish}
+                      </td>
+                      <td className="px-4 py-4 align-top">
+                        {material.feelTexture}
+                      </td>
+                      <td className="px-4 py-4 align-top">
+                        {material.colourContrast}
+                      </td>
+                      <td className="px-4 py-4 align-top">
+                        {material.bestSuitedFor}
+                      </td>
+                      <td className="px-4 py-4 align-top">
+                        {material.shippingFormat}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}
+
+function MaterialDetail({
+  children,
+  label,
+}: {
+  children: string;
+  label: string;
+}) {
+  return (
+    <div>
+      <dt className="text-xs font-bold uppercase tracking-widest text-gray-500">
+        {label}
+      </dt>
+      <dd className="mt-1 text-gray-300">{children}</dd>
+    </div>
+  );
+}

--- a/openeire-next/lib/gallery/printMaterials.ts
+++ b/openeire-next/lib/gallery/printMaterials.ts
@@ -1,0 +1,70 @@
+export interface PrintMaterialInfo {
+  name: string;
+  feelTexture: string;
+  finish: string;
+  printingMethod: string;
+  colourContrast: string;
+  framingDisplay: string;
+  shippingFormat: string;
+  bestSuitedFor: string;
+}
+
+export const printMaterialFulfilmentNote =
+  "All paper prints ship rolled and ready to frame. Eco Canvas arrives stretched with built-in hanging hardware.";
+
+export const printMaterials: PrintMaterialInfo[] = [
+  {
+    name: "Eco Canvas",
+    feelTexture:
+      "A 38mm stretched canvas print on 330gsm satin-finish canvas made from recycled plastic bottles.",
+    finish: "Satin canvas finish.",
+    printingMethod: "Printed with water-based latex inks / UVgel.",
+    colourContrast:
+      "A canvas look with gentle sheen and strong display presence.",
+    framingDisplay:
+      "Arrives stretched over a recycled frame with built-in hanging hardware, so it is ready to hang.",
+    shippingFormat:
+      "Ships flat in rigid recycled cardboard boxes, not rolled.",
+    bestSuitedFor:
+      "Vegan-friendly, ready-to-hang wall art made from 100% recycled canvas and cardboard.",
+  },
+  {
+    name: "Enhanced Matte Art Paper",
+    feelTexture: "A natural white 200gsm fine art paper with a smooth texture.",
+    finish: "Matte, low-glare finish.",
+    printingMethod: "Giclee fine art print using pigment-based archival inks.",
+    colourContrast:
+      "Soft, low-glare colour with a clean matte look for detailed artwork.",
+    framingDisplay: "Ships ready to frame.",
+    shippingFormat:
+      "Generally ships rolled for OpenEire's selected sizes.",
+    bestSuitedFor: "Photography, bold graphics and illustrations.",
+  },
+  {
+    name: "Hahnemuhle Photo Rag",
+    feelTexture:
+      "A vegan-certified 308gsm fine art photo paper made from 100% cotton rag, with a soft, lightly defined felt structure.",
+    finish: "Natural white matte finish.",
+    printingMethod: "Giclee fine art photo print.",
+    colourContrast:
+      "Excellent black saturation with a refined, museum-grade feel.",
+    framingDisplay: "Ships ready to frame.",
+    shippingFormat:
+      "Generally ships rolled for OpenEire's selected sizes.",
+    bestSuitedFor:
+      "Fine art photography, refined editions and images that benefit from deep blacks on a matte surface.",
+  },
+  {
+    name: "Lustre Photo Paper",
+    feelTexture:
+      "A bright white 240gsm photo paper with a subtle pearl-like texture.",
+    finish: "Satin finish.",
+    printingMethod: "Giclee fine art photo print.",
+    colourContrast:
+      "Deeper colour saturation than matte photo prints, with intense blacks and crisp detail.",
+    framingDisplay: "Ships ready to frame.",
+    shippingFormat:
+      "Generally ships rolled for OpenEire's selected sizes.",
+    bestSuitedFor: "Dramatic landscapes and photographic prints.",
+  },
+];


### PR DESCRIPTION
## Summary

Adds an accessible modal with detailed print material information to physical product pages, plus a shipping clarification note.

## Why

Customers need to understand the differences between print materials (texture, finish, shipping format) before purchasing. The modal provides a comprehensive comparison. Related to improving product page conversion.

## Screenshots / Demo

- Not needed
- Added (attach screenshots / short Loom link)

## Changes

- Frontend:
- openeire-next/components/cart/PhysicalAddToCartPanel.tsx - Added info button trigger
- openeire-next/components/gallery/PrintMaterialsModal.tsx - New accessible modal component
- openeire-next/lib/gallery/printMaterials.ts - New material data library
- openeire-next/app/gallery/physical/[id]/page.tsx - Updated shipping note
- Backend: N/A
- Infra/Config: N/A

## Testing

- React build passes locally
- Manual smoke test done

### Manual smoke test checklist (quick)

- No console errors
- Forms submit correctly (success + validation errors)
- API errors handled (loading/error states)
- Mobile layout checked
- Auth/permissions verified (if relevant)

## Risk & Rollback

Risk level: Low

## Rollback plan:

- Revert PR
- Feature flag off
- Hotfix path described:

## Notes for Reviewer (Codex/Copilot)

Focus review on:
- Security (auth, permissions, file uploads, CSRF/CORS)
- Performance (N+1 queries, heavy renders, unnecessary requests)
- Maintainability (naming, structure, duplicated logic)