### PR TITLE
Update real-estate pricing for VAT-disabled totals

### DIFF
--- a/openeire-next/app/real-estate/page.tsx
+++ b/openeire-next/app/real-estate/page.tsx
@@ -11,6 +11,7 @@ import {
   getOfficialSameAsLinks,
 } from "@/lib/site";
 import { buildPageMetadata } from "@/lib/seo/metadata";
+import { REAL_ESTATE_VAT_NOTE } from "@/lib/realEstate";
 import {
   buildBreadcrumbJsonLd,
   buildFaqPageJsonLd,
@@ -38,7 +39,7 @@ type RealEstatePackage = {
 export const metadata = buildPageMetadata({
   title: "Real Estate Photography & Drone Video in Connacht | OpenÉire Studios",
   description:
-    "Real estate photography, drone video and 3D tours for estate agents, developers and sellers across Connacht. Packages from €175 + VAT.",
+    "Real estate photography, drone video and 3D tours for estate agents, developers and sellers across Connacht. Packages from €175 total.",
   path: "/real-estate",
   image: "/hero-poster.jpg",
 });
@@ -47,7 +48,7 @@ const packages: readonly RealEstatePackage[] = [
   {
     key: "essential",
     name: "Essential",
-    price: "€175 + VAT",
+    price: "€175 total",
     description:
       "Recommended for smaller properties, rentals, starter listings.",
     features: [
@@ -60,7 +61,7 @@ const packages: readonly RealEstatePackage[] = [
   {
     key: "starter",
     name: "Starter",
-    price: "€229 + VAT",
+    price: "€229 total",
     description: "Recommended for standard 3-4 bed residential properties.",
     features: [
       "20 professionally edited interior & exterior photographs",
@@ -73,7 +74,7 @@ const packages: readonly RealEstatePackage[] = [
   {
     key: "pro",
     name: "Pro",
-    price: "€399 + VAT",
+    price: "€399 total",
     badge: "Recommended",
     description:
       "Recommended for detached homes, larger properties, new builds, agents wanting standout listings.",
@@ -91,7 +92,7 @@ const packages: readonly RealEstatePackage[] = [
   {
     key: "premium",
     name: "Premium",
-    price: "€579 + VAT",
+    price: "€579 total",
     description:
       "Recommended for premium listings, larger homes, waterfront/rural properties, new developments, and properties where presentation is a major selling point.",
     features: [
@@ -141,7 +142,7 @@ const listingFeatures = [
   {
     icon: <FaHome />,
     title: "Clear pricing",
-    text: "Transparent packages from €175 + VAT with optional add-ons only where the listing needs them.",
+    text: "Transparent packages from €175 total with optional add-ons only where the listing needs them.",
   },
   {
     icon: <FaCheckCircle />,
@@ -153,31 +154,31 @@ const listingFeatures = [
 const addOns = [
   {
     label: "Additional edited stills",
-    price: "€10 + VAT per image",
+    price: "€10 total per image",
   },
   {
     label: "Floor plan, 2D measured (included in Premium package)",
-    price: "€75 + VAT",
+    price: "€75 total",
   },
   {
     label: "3D virtual tour, hosted (included in Premium package)",
-    price: "€150 + VAT",
+    price: "€150 total",
   },
   {
     label: "Rush same-day delivery, stills only",
-    price: "€75 + VAT",
+    price: "€75 total",
   },
   {
     label: "Extended drone video, up to 3 minutes, fully edited",
-    price: "€150 + VAT",
+    price: "€150 total",
   },
   {
     label: "Additional social media cuts, extra formats or edits",
-    price: "€50 + VAT",
+    price: "€50 total",
   },
   {
     label: "Travel supplement beyond 40 km from base",
-    price: "€0.50 + VAT per km",
+    price: "€0.50 total per km",
   },
 ] as const;
 
@@ -203,8 +204,7 @@ const processSteps = [
 const faqs = [
   {
     question: "Do prices include VAT?",
-    answer:
-      "No. Prices are quoted exclusive of VAT. VAT at 23% is added at invoicing.",
+    answer: REAL_ESTATE_VAT_NOTE,
   },
   {
     question: "How quickly will I receive the media?",
@@ -252,25 +252,25 @@ const realEstatePackageOffers = [
   {
     name: "Essential real estate media package",
     price: "175",
-    description: "€175 + VAT. Includes 10 edited photos. VAT is excluded.",
+    description: `€175 total. Includes 10 edited photos. ${REAL_ESTATE_VAT_NOTE}`,
   },
   {
     name: "Starter real estate media package",
     price: "229",
     description:
-      "€229 + VAT. Includes 20 edited photos and 5-8 aerial drone stills. VAT is excluded.",
+      `€229 total. Includes 20 edited photos and 5-8 aerial drone stills. ${REAL_ESTATE_VAT_NOTE}`,
   },
   {
     name: "Pro real estate media package",
     price: "399",
     description:
-      "€399 + VAT. Includes 25 edited photos, drone stills, a 60-90 second 4K aerial video and social cuts. VAT is excluded.",
+      `€399 total. Includes 25 edited photos, drone stills, a 60-90 second 4K aerial video and social cuts. ${REAL_ESTATE_VAT_NOTE}`,
   },
   {
     name: "Premium real estate media package",
     price: "579",
     description:
-      "€579 + VAT. Includes 30 edited photos, drone stills, a 60-90 second 4K aerial video, social cuts, 3D virtual tour and 2D measured floor plan. VAT is excluded.",
+      `€579 total. Includes 30 edited photos, drone stills, a 60-90 second 4K aerial video, social cuts, 3D virtual tour and 2D measured floor plan. ${REAL_ESTATE_VAT_NOTE}`,
   },
   {
     name: "Custom real estate media package",
@@ -392,7 +392,7 @@ export default function RealEstatePage() {
             </p>
             <div className="mt-6 grid gap-4">
               {[
-                "Photography packages from €175 + VAT",
+                "Photography packages from €175 total",
                 "Full commercial marketing licence included",
                 "24-hour delivery after the shoot",
                 "Drone capture planned around safe operating conditions",
@@ -453,7 +453,7 @@ export default function RealEstatePage() {
               Choose the media package that fits the listing.
             </h2>
             <p className="mt-5 text-lg leading-relaxed text-gray-400">
-              All prices exclude VAT. VAT at 23% is added at invoicing. Travel
+              {REAL_ESTATE_VAT_NOTE} Travel
               supplement applies beyond 40 km from base.
             </p>
           </div>

--- a/openeire-next/components/real-estate/RealEstateEnquiryForm.tsx
+++ b/openeire-next/components/real-estate/RealEstateEnquiryForm.tsx
@@ -22,6 +22,7 @@ import {
   registerIubendaConsentForm,
   submitIubendaConsentForm,
 } from "@/lib/iubendaConsent";
+import { REAL_ESTATE_VAT_NOTE } from "@/lib/realEstate";
 import type {
   AddOnKey,
   ClientType,
@@ -104,28 +105,28 @@ const addOns: Array<{ key: AddOnKey; label: string; price: string }> = [
   {
     key: "additional_stills",
     label: "Additional edited stills",
-    price: "€10 + VAT per image",
+    price: "€10 total per image",
   },
-  { key: "floor_plan", label: "Floor plan, 2D measured", price: "€75 + VAT" },
+  { key: "floor_plan", label: "Floor plan, 2D measured", price: "€75 total" },
   {
     key: "rush_delivery",
     label: "Rush same-day delivery, stills only",
-    price: "€75 + VAT",
+    price: "€75 total",
   },
   {
     key: "extended_drone_video",
     label: "Extended drone video, up to 3 minutes, fully edited",
-    price: "€150 + VAT",
+    price: "€150 total",
   },
   {
     key: "additional_social_cuts",
     label: "Additional social media cuts, extra formats or edits",
-    price: "€50 + VAT",
+    price: "€50 total",
   },
   {
     key: "travel_supplement",
     label: "Travel supplement beyond 40 km from base",
-    price: "€0.50 + VAT per km",
+    price: "€0.50 total per km",
   },
 ];
 
@@ -420,7 +421,11 @@ export function RealEstateEnquiryForm() {
               ) : null}
 
               <div className="grid gap-5 md:grid-cols-2">
-                <Field inputId="real-estate-name" label="Name" error={errors.name}>
+                <Field
+                  inputId="real-estate-name"
+                  label="Name"
+                  error={errors.name}
+                >
                   <input
                     id="real-estate-name"
                     name="name"
@@ -604,6 +609,9 @@ export function RealEstateEnquiryForm() {
                     </label>
                   ))}
                 </div>
+                <p className="mt-3 text-sm text-gray-400">
+                  {REAL_ESTATE_VAT_NOTE}
+                </p>
               </div>
 
               <div className="grid gap-5 md:grid-cols-2">

--- a/openeire-next/lib/realEstate.ts
+++ b/openeire-next/lib/realEstate.ts
@@ -1,26 +1,29 @@
+export const REAL_ESTATE_VAT_NOTE =
+  "OpenÉire Studios is not currently VAT registered. No VAT is charged.";
+
 export const REAL_ESTATE_PACKAGES = [
   {
     id: "essential",
     name: "Essential",
-    price: "\u20AC175 + VAT",
+    price: "\u20AC175 total",
     text: "10 professionally edited interior and exterior photographs, full-resolution delivery, 24-hour turnaround, and listing marketing licence.",
   },
   {
     id: "starter",
     name: "Starter",
-    price: "\u20AC229 + VAT",
+    price: "\u20AC229 total",
     text: "20 professionally edited photographs for standard 3-4 bed residential properties, delivered print and web ready.",
   },
   {
     id: "pro",
     name: "Pro",
-    price: "\u20AC399 + VAT",
+    price: "\u20AC399 total",
     text: "20 edited photographs, 60-90 second 4K aerial drone video, social media cuts, 24-hour delivery, and marketing licence.",
   },
   {
     id: "premium",
     name: "Premium",
-    price: "\u20AC579 + VAT",
+    price: "\u20AC579 total",
     text: "Photography, aerial drone video, social cuts, and a 3D interactive virtual tour for premium or high-impact listings.",
   },
   {

--- a/openeire-next/lib/seo/jsonLd.ts
+++ b/openeire-next/lib/seo/jsonLd.ts
@@ -49,7 +49,7 @@ export const buildOpenEireLocalBusinessJsonLd = (input: {
   email: input.email,
   description:
     "Premium aerial photography, fine art prints, property media, commercial licensing, and curated visual assets from Ireland.",
-  priceRange: "€175+VAT to POA",
+  priceRange: "€175 total to POA",
   address: {
     "@type": "PostalAddress",
     addressLocality: "Loughrea",


### PR DESCRIPTION
## Summary

Updates the active Next.js real-estate experience so all fixed packages and add-ons are presented as final totals. Adds reusable wording explaining that OpenÉire Studios is not currently VAT registered and no VAT is charged.

## Why

Real-estate pricing previously displayed amounts as excluding VAT, including “€399 + VAT”, even though OpenÉire Studios is not currently VAT registered.

The Pro package must be presented as €399 total, consistent with the backend quote and deposit calculation.

## Screenshots / Demo

- [x] Not needed
- [ ] Added (attach screenshots / short Loom link)

## Changes

- Backend:
  - None; pricing calculations and historical snapshots are handled in the companion `openeire-api` PR.
- Frontend:
  - Replaced package pricing such as “€399 + VAT” with “€399 total”.
  - Applied final-total wording to all fixed real-estate packages.
  - Applied final-total wording to all real-estate add-ons.
  - Added a reusable VAT notice:
    - “OpenÉire Studios is not currently VAT registered. No VAT is charged.”
  - Updated the real-estate FAQ and enquiry form.
  - Updated page metadata and structured offer descriptions.
  - Updated local-business JSON-LD price-range wording.
  - Removed remaining active Next.js “VAT excluded”, “ex-VAT”, and “VAT at 23%” customer copy.
  - Did not modify or remove the legacy React application.
- Infra/Config:
  - None.

## Testing

- [ ] Django tests pass locally
- [x] React build passes locally
- [ ] Manual smoke test done

Frontend verification:

- ESLint passed.
- Next.js TypeScript validation passed.
- Next.js production build passed.
- All 53 application pages generated successfully.
- No automated Next.js test script is currently configured.

### Manual smoke test checklist (quick)

- [ ] No console errors
- [ ] Forms submit correctly (success + validation errors)
- [ ] API errors handled (loading/error states)
- [ ] Mobile layout checked
- [ ] Auth/permissions verified (if relevant)

Recommended manual checks:

- Confirm every real-estate package displays “total”.
- Confirm every add-on uses final-total wording.
- Confirm the VAT notice appears in the pricing section and enquiry form.
- Confirm the FAQ states that no VAT is charged.
- Check the real-estate page at desktop and mobile breakpoints.
- Submit a real-estate enquiry and verify success and validation states.

## Risk & Rollback

Risk level: Low

The changes are limited to active Next.js real-estate copy, metadata, structured data, and the enquiry form. No API contracts or frontend calculation logic are changed.

Rollback plan:

- [x] Revert PR
- [ ] Feature flag off
- [ ] Hotfix path described:

## Notes for Reviewer (Codex/Copilot)

Focus review on:

- [ ] Security (auth, permissions, file uploads, CSRF/CORS)
- [ ] Performance (N+1 queries, heavy renders, unnecessary requests)
- [x] Maintainability (naming, structure, duplicated logic)

Please verify:

- The reusable VAT notice is used consistently.
- No active Next.js pricing copy still states “+ VAT” or VAT-exclusive pricing.
- Metadata and JSON-LD agree with visible pricing.
- Package and add-on wording remains readable on mobile.
- No legacy React files are included in this PR.