### PR TITLE
Add V2 real-estate shoot scoping form

### DIFF
--- a/openeire-next/components/real-estate/RealEstateEnquiryForm.tsx
+++ b/openeire-next/components/real-estate/RealEstateEnquiryForm.tsx
@@ -7,15 +7,11 @@ import {
   type FormEvent,
   type ReactNode,
 } from "react";
-import {
-  FaCalendarAlt,
-  FaCheckCircle,
-  FaMapMarkerAlt,
-  FaPaperPlane,
-} from "react-icons/fa";
+import { FaCalendarAlt, FaCheckCircle, FaMapMarkerAlt, FaPaperPlane } from "react-icons/fa";
 import { useToast } from "@/components/ui/ToastProvider";
 import {
   getApiErrorMessage,
+  getApiFieldErrors,
   submitRealEstateEnquiry,
 } from "@/lib/api/publicForms";
 import {
@@ -28,33 +24,72 @@ import type {
   ClientType,
   HowHeard,
   PackageType,
+  PropertyCategory,
   RealEstateEnquiryPayload,
+  YesNoNotSure,
 } from "@/types/publicForms";
 
 const FORM_ID = "real-estate-enquiry-form";
 const SUBMIT_ID = "real-estate-enquiry-submit";
+const EIRCODE_RE = /^(?:[AC-FHKNPRTV-Y]\d{2}|D6W)\s?[0-9AC-FHKNPRTV-Y]{4}$/i;
 
-type RealEstateFormData = {
-  name: string;
-  email: string;
-  phone: string;
-  company_name: string;
+type FormData = Omit<
+  RealEstateEnquiryPayload,
+  | "form_schema_version"
+  | "client_type"
+  | "preferred_package"
+  | "property_type"
+  | "bedroom_count"
+  | "floor_count"
+  | "secondary_accommodation"
+  | "outbuildings"
+  | "grounds_size"
+  | "occupancy_status"
+  | "access_provider"
+  | "scheduling_preference"
+  | "preferred_time_window"
+  | "on_camera"
+  | "how_heard"
+  | "internal_floor_area"
+  | "additional_stills_quantity"
+> & {
   client_type: "" | ClientType;
-  property_address: string;
+  preferred_package: "" | PackageType;
+  property_type: "" | PropertyCategory;
+  bedroom_count: "" | RealEstateEnquiryPayload["bedroom_count"];
+  floor_count: "" | RealEstateEnquiryPayload["floor_count"];
+  secondary_accommodation: "" | YesNoNotSure;
+  outbuildings: "" | YesNoNotSure;
+  grounds_size: "" | RealEstateEnquiryPayload["grounds_size"];
+  occupancy_status: "" | RealEstateEnquiryPayload["occupancy_status"];
+  access_provider: "" | RealEstateEnquiryPayload["access_provider"];
+  scheduling_preference: "" | RealEstateEnquiryPayload["scheduling_preference"];
+  preferred_time_window: "" | RealEstateEnquiryPayload["preferred_time_window"];
+  on_camera: "" | YesNoNotSure;
+  internal_floor_area: string;
+  additional_stills_quantity: string;
   eircode: string;
-  county: string;
-  property_type: string;
-  preferred_package: PackageType;
-  add_ons: AddOnKey[];
+  location_details: string;
+  property_type_details: string;
+  secondary_accommodation_details: string;
+  outbuildings_details: string;
+  property_features: string;
+  access_contact_name: string;
+  access_contact_phone: string;
+  access_notes: string;
   preferred_date: string;
+  alternative_date: string;
+  on_camera_people: string;
+  audio_requirements: string;
+  company_name: string;
   how_heard: "" | HowHeard;
   message: string;
-  consent_to_contact: boolean;
+  add_ons: AddOnKey[];
 };
 
-type FormErrors = Partial<Record<keyof RealEstateFormData | "submit", string>>;
+type FormErrors = Partial<Record<keyof FormData | "submit", string>>;
 
-const initialFormData: RealEstateFormData = {
+const initialFormData: FormData = {
   name: "",
   email: "",
   phone: "",
@@ -62,650 +97,450 @@ const initialFormData: RealEstateFormData = {
   client_type: "",
   property_address: "",
   eircode: "",
+  no_eircode: false,
+  location_details: "",
   county: "",
   property_type: "",
-  preferred_package: "not_sure",
+  property_type_details: "",
+  bedroom_count: "",
+  floor_count: "",
+  secondary_accommodation: "",
+  secondary_accommodation_details: "",
+  outbuildings: "",
+  outbuildings_details: "",
+  grounds_size: "",
+  internal_floor_area: "",
+  internal_floor_area_unit: undefined,
+  property_features: "",
+  occupancy_status: "",
+  access_provider: "",
+  access_contact_name: "",
+  access_contact_phone: "",
+  access_notes: "",
+  readiness_acknowledged: false,
+  preferred_package: "",
   add_ons: [],
+  additional_stills_quantity: "",
+  scheduling_preference: "",
   preferred_date: "",
+  alternative_date: "",
+  preferred_time_window: "",
+  on_camera: "",
+  on_camera_people: "",
+  audio_requirements: "",
   how_heard: "",
   message: "",
   consent_to_contact: false,
 };
 
-const clientTypeOptions = [
-  "estate_agent",
-  "developer",
-  "private_seller",
-  "landlord",
-  "other",
-] as const satisfies readonly ClientType[];
-
-const packageOptions = [
-  "essential",
-  "starter",
-  "pro",
-  "premium",
-  "custom",
-  "not_sure",
-] as const satisfies readonly PackageType[];
-
-const howHeardOptions = [
-  "google",
-  "instagram",
-  "facebook",
-  "linkedin",
-  "referral",
-  "estate_agent_colleague",
-  "openeire_website",
-  "other",
-  "not_sure",
-] as const satisfies readonly HowHeard[];
-
+const packages = ["essential", "starter", "pro", "premium", "custom", "not_sure"] as const;
+const counties = [
+  "Carlow", "Cavan", "Clare", "Cork", "Donegal", "Dublin", "Galway", "Kerry",
+  "Kildare", "Kilkenny", "Laois", "Leitrim", "Limerick", "Longford", "Louth",
+  "Mayo", "Meath", "Monaghan", "Offaly", "Roscommon", "Sligo", "Tipperary",
+  "Waterford", "Westmeath", "Wexford", "Wicklow",
+];
 const addOns: Array<{ key: AddOnKey; label: string; price: string }> = [
-  {
-    key: "additional_stills",
-    label: "Additional edited stills",
-    price: "€10 total per image",
-  },
-  { key: "floor_plan", label: "Floor plan, 2D measured", price: "€75 total" },
-  {
-    key: "rush_delivery",
-    label: "Rush same-day delivery, stills only",
-    price: "€75 total",
-  },
-  {
-    key: "extended_drone_video",
-    label: "Extended drone video, up to 3 minutes, fully edited",
-    price: "€150 total",
-  },
-  {
-    key: "additional_social_cuts",
-    label: "Additional social media cuts, extra formats or edits",
-    price: "€50 total",
-  },
-  {
-    key: "travel_supplement",
-    label: "Travel supplement beyond 40 km from base",
-    price: "€0.50 total per km",
-  },
+  { key: "additional_stills", label: "Additional edited stills", price: "€10 per image (maximum 50)" },
+  { key: "floor_plan", label: "2D measured floor plan", price: "€75" },
+  { key: "virtual_tour_3d", label: "Hosted 3D virtual tour", price: "€150" },
+  { key: "rush_delivery", label: "Rush same-day delivery — still photographs only", price: "€75" },
+  { key: "extended_drone_video", label: "Extended drone video, up to 3 minutes", price: "€150" },
+  { key: "additional_social_cuts", label: "Additional social formats / cuts", price: "€50" },
 ];
-
-const requiredFields: Array<keyof RealEstateFormData> = [
-  "name",
-  "email",
-  "phone",
-  "client_type",
-  "property_address",
-  "county",
-  "property_type",
-  "preferred_package",
-];
-
-const fieldLabels: Partial<Record<keyof RealEstateFormData, string>> = {
-  name: "Name",
-  email: "Email",
-  phone: "Phone",
-  client_type: "Client type",
-  property_address: "Property address",
-  county: "County",
-  property_type: "Property type",
-  preferred_package: "Preferred package",
-  consent_to_contact: "Consent to contact",
+const conflicts: Partial<Record<PackageType, AddOnKey[]>> = {
+  pro: ["additional_social_cuts"],
+  premium: ["floor_plan", "virtual_tour_3d", "additional_social_cuts"],
 };
 
 const inputClass =
-  "w-full rounded-xl border border-white/15 bg-black/60 px-4 py-3 text-white placeholder-gray-600 outline-none transition-all focus:border-[#16a34a] focus:ring-1 focus:ring-[#16a34a]";
-const labelClass =
-  "mb-2 block text-xs font-bold uppercase tracking-[0.22em] text-gray-500";
+  "w-full rounded-xl border border-white/15 bg-black/60 px-4 py-3 text-white outline-none transition focus:border-[#16a34a] focus:ring-1 focus:ring-[#16a34a]";
+const labelClass = "mb-2 block text-xs font-bold uppercase tracking-[0.18em] text-gray-400";
 
-const trimOrUndefined = (value: string): string | undefined => {
-  const trimmed = value.trim();
-  return trimmed ? trimmed : undefined;
+const localToday = () => {
+  const now = new Date();
+  const month = String(now.getMonth() + 1).padStart(2, "0");
+  const day = String(now.getDate()).padStart(2, "0");
+  return `${now.getFullYear()}-${month}-${day}`;
 };
-
-const isOneOf = <T extends string>(
-  value: string,
-  options: readonly T[],
-): value is T => options.includes(value as T);
+const trim = (value: string) => value.trim();
+const optional = (value: string) => trim(value) || undefined;
 
 function Field({
   inputId,
   label,
+  required = false,
   error,
+  hint,
   children,
 }: {
   inputId: string;
   label: string;
+  required?: boolean;
   error?: string;
+  hint?: string;
   children: ReactNode;
 }) {
   return (
     <div>
       <label htmlFor={inputId} className={labelClass}>
-        {label}
+        {label} {required ? <span className="text-red-300">*</span> : <span className="normal-case tracking-normal text-gray-500">(Optional)</span>}
       </label>
       {children}
-      {error ? <p className="mt-2 text-sm text-red-300">{error}</p> : null}
+      {hint ? <p id={`${inputId}-hint`} className="mt-2 text-xs text-gray-500">{hint}</p> : null}
+      {error ? <p id={`${inputId}-error`} className="mt-2 text-sm text-red-300">{error}</p> : null}
     </div>
   );
 }
 
-export function RealEstateEnquiryForm() {
-  const [formData, setFormData] = useState<RealEstateFormData>(initialFormData);
-  const [errors, setErrors] = useState<FormErrors>({});
-  const [status, setStatus] = useState<"idle" | "submitting" | "success">(
-    "idle",
+function Section({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <fieldset className="space-y-5 rounded-2xl border border-white/10 p-5">
+      <legend className="px-2 font-serif text-xl font-bold">{title}</legend>
+      {children}
+    </fieldset>
   );
+}
+
+export function RealEstateEnquiryForm() {
+  const [formData, setFormData] = useState<FormData>(initialFormData);
+  const [errors, setErrors] = useState<FormErrors>({});
+  const [status, setStatus] = useState<"idle" | "submitting" | "success">("idle");
+  const [packageNotice, setPackageNotice] = useState("");
   const { showToast } = useToast();
 
-  useEffect(() => {
-    return registerIubendaConsentForm({
-      formId: FORM_ID,
-      submitButtonId: SUBMIT_ID,
-      subject: {
-        full_name: "name",
-        email: "email",
-      },
-      preferences: {
-        real_estate_enquiry: "consent_to_contact",
-      },
-    });
-  }, []);
+  useEffect(() => registerIubendaConsentForm({
+    formId: FORM_ID,
+    submitButtonId: SUBMIT_ID,
+    subject: { full_name: "name", email: "email" },
+    preferences: { real_estate_enquiry: "consent_to_contact" },
+  }), []);
 
   useEffect(() => {
-    const requestedPackage = new URLSearchParams(window.location.search)
-      .get("package")
-      ?.trim();
-
-    if (requestedPackage && isOneOf(requestedPackage, packageOptions)) {
-      setFormData((current) => ({
-        ...current,
-        preferred_package: requestedPackage,
-      }));
+    const requested = new URLSearchParams(window.location.search).get("package")?.trim();
+    if (requested && packages.includes(requested as PackageType)) {
+      setFormData((current) => ({ ...current, preferred_package: requested as PackageType }));
     }
   }, []);
 
-  const handleFieldChange = (
-    event: ChangeEvent<
-      HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement
-    >,
-  ) => {
+  const a11y = (field: keyof FormData, hint = false) => ({
+    "aria-invalid": errors[field] ? true : undefined,
+    "aria-describedby": [
+      hint ? `real-estate-${String(field).replaceAll("_", "-")}-hint` : "",
+      errors[field] ? `real-estate-${String(field).replaceAll("_", "-")}-error` : "",
+    ].filter(Boolean).join(" ") || undefined,
+  });
+
+  const change = (event: ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>) => {
     const { name, value } = event.target;
-    setFormData((current) => ({ ...current, [name]: value }));
-    setErrors((current) => ({
-      ...current,
-      [name]: undefined,
-      submit: undefined,
-    }));
+    if (name === "preferred_package") {
+      const nextPackage = value as PackageType;
+      const blocked = conflicts[nextPackage] ?? [];
+      const removed = formData.add_ons.filter((item) => blocked.includes(item));
+      setFormData((current) => ({
+        ...current,
+        preferred_package: nextPackage,
+        add_ons: current.add_ons.filter((item) => !blocked.includes(item)),
+        additional_stills_quantity: blocked.includes("additional_stills")
+          ? ""
+          : current.additional_stills_quantity,
+      }));
+      setPackageNotice(removed.length
+        ? "Add-ons already included in the new package were removed."
+        : "");
+    } else {
+      setFormData((current) => ({ ...current, [name]: value }));
+    }
+    setErrors((current) => ({ ...current, [name]: undefined, submit: undefined }));
   };
 
-  const handleConsentChange = (event: ChangeEvent<HTMLInputElement>) => {
-    setFormData((current) => ({
-      ...current,
-      consent_to_contact: event.target.checked,
-    }));
-    setErrors((current) => ({
-      ...current,
-      consent_to_contact: undefined,
-      submit: undefined,
-    }));
-  };
+  const checkbox = (field: "no_eircode" | "readiness_acknowledged" | "consent_to_contact") =>
+    (event: ChangeEvent<HTMLInputElement>) => {
+      const checked = event.target.checked;
+      setFormData((current) => ({
+        ...current,
+        [field]: checked,
+        ...(field === "no_eircode" && checked ? { eircode: "" } : {}),
+      }));
+      setErrors((current) => ({ ...current, [field]: undefined, eircode: undefined, submit: undefined }));
+    };
 
   const toggleAddOn = (key: AddOnKey) => {
     setFormData((current) => {
-      const exists = current.add_ons.includes(key);
+      const selected = current.add_ons.includes(key);
       return {
         ...current,
-        add_ons: exists
-          ? current.add_ons.filter((item) => item !== key)
-          : [...current.add_ons, key],
+        add_ons: selected ? current.add_ons.filter((item) => item !== key) : [...current.add_ons, key],
+        additional_stills_quantity:
+          key === "additional_stills" && selected ? "" : current.additional_stills_quantity,
       };
+    });
+    setErrors((current) => ({ ...current, add_ons: undefined, additional_stills_quantity: undefined }));
+  };
+
+  const validate = () => {
+    const next: FormErrors = {};
+    const required: Array<[keyof FormData, string]> = [
+      ["name", "Name"], ["email", "Email"], ["phone", "Phone"],
+      ["client_type", "Client type"], ["preferred_package", "Preferred package"],
+      ["property_address", "Property address"], ["county", "County"],
+      ["property_type", "Property category"], ["bedroom_count", "Bedroom count"],
+      ["floor_count", "Number of floors"], ["secondary_accommodation", "Secondary accommodation"],
+      ["outbuildings", "Outbuildings"], ["grounds_size", "Grounds / site size"],
+      ["occupancy_status", "Occupancy status"], ["access_provider", "Access provider"],
+      ["scheduling_preference", "Scheduling preference"],
+      ["preferred_time_window", "Preferred time window"], ["on_camera", "On-camera choice"],
+    ];
+    for (const [field, label] of required) {
+      if (!String(formData[field] ?? "").trim()) next[field] = `${label} is required.`;
+    }
+    if (!/^\S+@\S+\.\S+$/.test(formData.email)) next.email = "Enter a valid email address.";
+    const phoneDigits = formData.phone.replace(/\D/g, "");
+    if (phoneDigits.length < 7 || phoneDigits.length > 15) next.phone = "Enter a plausible phone number.";
+    if (["estate_agent", "developer"].includes(formData.client_type) && !trim(formData.company_name)) {
+      next.company_name = "Company or agency name is required for this client type.";
+    }
+    if (formData.no_eircode) {
+      if (!trim(formData.location_details)) next.location_details = "Provide precise directions or a Google Maps link.";
+    } else if (!EIRCODE_RE.test(trim(formData.eircode))) {
+      next.eircode = "Enter a valid Eircode or confirm that the property has none.";
+    }
+    if (formData.property_type === "other" && !trim(formData.property_type_details)) {
+      next.property_type_details = "Describe the property category.";
+    }
+    if (formData.secondary_accommodation === "yes" && !trim(formData.secondary_accommodation_details)) {
+      next.secondary_accommodation_details = "Describe the secondary accommodation.";
+    }
+    if (formData.outbuildings === "yes" && !trim(formData.outbuildings_details)) {
+      next.outbuildings_details = "Describe the outbuildings.";
+    }
+    if (formData.internal_floor_area && (!Number.isInteger(Number(formData.internal_floor_area)) || Number(formData.internal_floor_area) < 1)) {
+      next.internal_floor_area = "Enter a positive whole number.";
+    }
+    if (formData.internal_floor_area && !formData.internal_floor_area_unit) {
+      next.internal_floor_area_unit = "Choose a floor-area unit.";
+    }
+    if (formData.access_provider && formData.access_provider !== "enquirer") {
+      if (!trim(formData.access_contact_name)) next.access_contact_name = "Provide the access contact's name.";
+      const digits = formData.access_contact_phone.replace(/\D/g, "");
+      if (digits.length < 7 || digits.length > 15) next.access_contact_phone = "Provide a plausible access contact number.";
+    }
+    const today = localToday();
+    if (formData.scheduling_preference === "request_date" && !formData.preferred_date) {
+      next.preferred_date = "Choose a preferred date.";
+    }
+    if (formData.preferred_date && formData.preferred_date < today) next.preferred_date = "Preferred date cannot be in the past.";
+    if (formData.alternative_date && formData.alternative_date < today) next.alternative_date = "Alternative date cannot be in the past.";
+    if (formData.on_camera === "yes") {
+      if (!trim(formData.on_camera_people)) next.on_camera_people = "Tell us who will appear on camera.";
+      if (!trim(formData.audio_requirements)) next.audio_requirements = "Describe spoken-audio or microphone requirements.";
+    }
+    if (formData.add_ons.includes("additional_stills")) {
+      const quantity = Number(formData.additional_stills_quantity);
+      if (!Number.isInteger(quantity) || quantity < 1 || quantity > 50) {
+        next.additional_stills_quantity = "Choose a whole number from 1 to 50.";
+      }
+    }
+    if (!formData.readiness_acknowledged) next.readiness_acknowledged = "Please acknowledge the readiness requirement.";
+    if (!formData.consent_to_contact) next.consent_to_contact = "Please confirm we may contact you about this enquiry.";
+    return next;
+  };
+
+  const focusFirstError = (next: FormErrors) => {
+    const field = Object.keys(next).find((key) => key !== "submit");
+    if (!field) return;
+    requestAnimationFrame(() => {
+      const control = document.querySelector<HTMLElement>(
+        `[data-error-field="${field}"], [name="${field}"]:not([type="hidden"])`,
+      );
+      control?.focus();
+      control?.scrollIntoView({ block: "center", behavior: "smooth" });
     });
   };
 
-  const validateForm = (): FormErrors => {
-    const nextErrors: FormErrors = {};
+  const buildPayload = (): RealEstateEnquiryPayload => ({
+    form_schema_version: 2,
+    name: trim(formData.name),
+    email: trim(formData.email),
+    phone: trim(formData.phone),
+    client_type: formData.client_type as ClientType,
+    company_name: optional(formData.company_name),
+    property_address: trim(formData.property_address),
+    county: formData.county,
+    eircode: optional(formData.eircode),
+    no_eircode: formData.no_eircode,
+    location_details: optional(formData.location_details),
+    property_type: formData.property_type as PropertyCategory,
+    property_type_details: optional(formData.property_type_details),
+    bedroom_count: formData.bedroom_count as RealEstateEnquiryPayload["bedroom_count"],
+    floor_count: formData.floor_count as RealEstateEnquiryPayload["floor_count"],
+    secondary_accommodation: formData.secondary_accommodation as YesNoNotSure,
+    secondary_accommodation_details: optional(formData.secondary_accommodation_details),
+    outbuildings: formData.outbuildings as YesNoNotSure,
+    outbuildings_details: optional(formData.outbuildings_details),
+    grounds_size: formData.grounds_size as RealEstateEnquiryPayload["grounds_size"],
+    internal_floor_area: formData.internal_floor_area ? Number(formData.internal_floor_area) : undefined,
+    internal_floor_area_unit: formData.internal_floor_area ? formData.internal_floor_area_unit : undefined,
+    property_features: optional(formData.property_features),
+    occupancy_status: formData.occupancy_status as RealEstateEnquiryPayload["occupancy_status"],
+    access_provider: formData.access_provider as RealEstateEnquiryPayload["access_provider"],
+    access_contact_name: formData.access_provider === "enquirer" ? undefined : optional(formData.access_contact_name),
+    access_contact_phone: formData.access_provider === "enquirer" ? undefined : optional(formData.access_contact_phone),
+    access_notes: optional(formData.access_notes),
+    readiness_acknowledged: formData.readiness_acknowledged,
+    preferred_package: formData.preferred_package as PackageType,
+    add_ons: formData.add_ons,
+    additional_stills_quantity: formData.add_ons.includes("additional_stills")
+      ? Number(formData.additional_stills_quantity)
+      : undefined,
+    scheduling_preference: formData.scheduling_preference as RealEstateEnquiryPayload["scheduling_preference"],
+    preferred_date: formData.scheduling_preference === "request_date" ? optional(formData.preferred_date) : undefined,
+    alternative_date: optional(formData.alternative_date),
+    preferred_time_window: formData.preferred_time_window as RealEstateEnquiryPayload["preferred_time_window"],
+    on_camera: formData.on_camera as YesNoNotSure,
+    on_camera_people: formData.on_camera === "yes" ? optional(formData.on_camera_people) : undefined,
+    audio_requirements: formData.on_camera === "yes" ? optional(formData.audio_requirements) : undefined,
+    how_heard: formData.how_heard || undefined,
+    message: optional(formData.message),
+    consent_to_contact: formData.consent_to_contact,
+  });
 
-    for (const field of requiredFields) {
-      const value = formData[field];
-      if (typeof value === "string" && !value.trim()) {
-        nextErrors[field] =
-          `${fieldLabels[field] ?? "This field"} is required.`;
-      }
-    }
-
-    if (formData.email && !/^\S+@\S+\.\S+$/.test(formData.email)) {
-      nextErrors.email = "Please enter a valid email address.";
-    }
-
-    if (!formData.consent_to_contact) {
-      nextErrors.consent_to_contact =
-        "Please confirm we can contact you about this enquiry.";
-    }
-
-    return nextErrors;
-  };
-
-  const buildPayload = (): RealEstateEnquiryPayload => {
-    const clientType = formData.client_type.trim();
-    const preferredPackage = formData.preferred_package.trim();
-    const howHeard = formData.how_heard.trim();
-
-    if (!isOneOf(clientType, clientTypeOptions)) {
-      throw new Error("Please choose a valid client type.");
-    }
-    if (!isOneOf(preferredPackage, packageOptions)) {
-      throw new Error("Please choose a valid package.");
-    }
-    if (howHeard && !isOneOf(howHeard, howHeardOptions)) {
-      throw new Error("Please choose a valid referral source.");
-    }
-
-    const companyName = trimOrUndefined(formData.company_name);
-    const eircode = trimOrUndefined(formData.eircode);
-    const preferredDate = trimOrUndefined(formData.preferred_date);
-    const message = trimOrUndefined(formData.message);
-    const howHeardValue: HowHeard | undefined = howHeard
-      ? (howHeard as HowHeard)
-      : undefined;
-
-    return {
-      name: formData.name.trim(),
-      email: formData.email.trim(),
-      phone: formData.phone.trim(),
-      client_type: clientType,
-      property_address: formData.property_address.trim(),
-      county: formData.county.trim(),
-      property_type: formData.property_type.trim(),
-      preferred_package: preferredPackage,
-      consent_to_contact: formData.consent_to_contact,
-      ...(companyName ? { company_name: companyName } : {}),
-      ...(eircode ? { eircode } : {}),
-      ...(formData.add_ons.length ? { add_ons: formData.add_ons } : {}),
-      ...(preferredDate ? { preferred_date: preferredDate } : {}),
-      ...(howHeardValue ? { how_heard: howHeardValue } : {}),
-      ...(message ? { message } : {}),
-    };
-  };
-
-  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+  const submit = async (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    const nextErrors = validateForm();
-    if (Object.keys(nextErrors).length > 0) {
-      setErrors(nextErrors);
+    const next = validate();
+    if (Object.keys(next).length) {
+      setErrors(next);
+      focusFirstError(next);
       return;
     }
-
     setStatus("submitting");
     setErrors({});
-
     try {
-      const payload = buildPayload();
-      await submitRealEstateEnquiry(payload);
+      await submitRealEstateEnquiry(buildPayload());
       submitIubendaConsentForm(FORM_ID);
       setStatus("success");
       setFormData(initialFormData);
       showToast("Property enquiry sent successfully.", "success");
     } catch (error) {
-      const message =
-        error instanceof Error
-          ? error.message
-          : getApiErrorMessage(
-              error,
-              "We could not send the enquiry. Please try again or email studio@openeire.ie.",
-            );
-      setErrors({ submit: message });
+      const fieldErrors = getApiFieldErrors(error) as FormErrors;
+      const message = getApiErrorMessage(error, "We could not send the enquiry. Please try again or email studio@openeire.ie.");
+      const nextErrors = Object.keys(fieldErrors).length ? fieldErrors : { submit: message };
+      setErrors(nextErrors);
+      focusFirstError(nextErrors);
       setStatus("idle");
       showToast(message, "error");
     }
   };
 
+  const option = (value: string, label: string) => <option key={value} value={value}>{label}</option>;
+  const shownAddOns = addOns.filter(({ key }) => !conflicts[formData.preferred_package as PackageType]?.includes(key));
+
+  if (status === "success") {
+    return (
+      <section id="enquiry" className="scroll-mt-32 bg-gray-950 py-20">
+        <div className="container mx-auto max-w-3xl px-4 text-center">
+          <FaCheckCircle className="mx-auto mb-5 text-5xl text-accent" />
+          <h2 className="font-serif text-3xl font-bold">Thanks — enquiry received.</h2>
+          <p className="mt-4 text-gray-400">We’ll review the requested scope and contact you before confirming a quote or date.</p>
+          <button type="button" onClick={() => setStatus("idle")} className="mt-8 rounded-full border border-white/20 px-6 py-3">Send another enquiry</button>
+        </div>
+      </section>
+    );
+  }
+
   return (
     <section id="enquiry" className="scroll-mt-32 bg-gray-950 py-20">
-      <div className="container mx-auto grid max-w-7xl gap-10 px-4 lg:grid-cols-[0.82fr_1.18fr] lg:px-8">
+      <div className="container mx-auto grid max-w-7xl gap-10 px-4 lg:grid-cols-[0.7fr_1.3fr] lg:px-8">
         <div>
-          <p className="mb-3 text-xs font-bold uppercase tracking-[0.24em] text-accent">
-            Enquiry
-          </p>
-          <h2 className="font-serif text-3xl font-bold md:text-5xl">
-            Request a property shoot.
-          </h2>
-          <p className="mt-5 text-lg leading-relaxed text-gray-400">
-            Tell us what you need and we will review the details before
-            confirming the cleanest scope for your listing.
-          </p>
-          <div className="mt-8 space-y-4 text-sm text-gray-300">
-            <p className="flex items-center gap-3">
-              <FaCalendarAlt className="text-[#16a34a]" aria-hidden="true" />
-              Preferred dates are treated as requests until confirmed.
-            </p>
-            <p className="flex items-center gap-3">
-              <FaMapMarkerAlt className="text-[#16a34a]" aria-hidden="true" />
-              Serving Galway, Mayo, Roscommon, Sligo and Leitrim.
-            </p>
-          </div>
+          <p className="mb-3 text-xs font-bold uppercase tracking-[0.24em] text-accent">Enquiry</p>
+          <h2 className="font-serif text-3xl font-bold md:text-5xl">Scope your property shoot.</h2>
+          <p className="mt-5 text-gray-400">These details help us quote, schedule and arrive with the right equipment.</p>
+          <p className="mt-6 flex gap-3 text-sm text-gray-300"><FaCalendarAlt className="mt-1 text-[#16a34a]" />Dates are requests until confirmed.</p>
+          <p className="mt-3 flex gap-3 text-sm text-gray-300"><FaMapMarkerAlt className="mt-1 text-[#16a34a]" />Travel is reviewed internally from the exact location.</p>
         </div>
 
-        <div className="rounded-[2rem] border border-white/10 bg-black p-6 shadow-2xl md:p-8">
-          {status === "success" ? (
-            <div className="flex min-h-[420px] flex-col items-center justify-center text-center">
-              <FaCheckCircle className="mb-5 text-5xl text-accent" />
-              <h3 className="font-serif text-3xl font-bold">
-                Thanks — enquiry received.
-              </h3>
-              <p className="mt-4 max-w-xl text-gray-400">
-                Thanks — we’ve received your property shoot request. We’ll
-                review the details and come back to you within 24 hours.
-              </p>
-              <button
-                type="button"
-                onClick={() => setStatus("idle")}
-                className="mt-8 rounded-full border border-white/20 px-6 py-3 text-sm font-bold uppercase tracking-[0.16em] transition hover:border-[#16a34a] hover:text-[#16a34a]"
-              >
-                Send another enquiry
-              </button>
+        <form id={FORM_ID} onSubmit={submit} noValidate className="space-y-6 rounded-[2rem] border border-white/10 bg-black p-6 md:p-8">
+          <input type="hidden" name="consent_to_contact" value={String(formData.consent_to_contact)} readOnly />
+          <p className="text-sm text-gray-400">Fields marked <span className="text-red-300">*</span> are required.</p>
+          {errors.submit ? <div role="alert" className="rounded-xl bg-red-500/10 p-4 text-red-100">{errors.submit}</div> : null}
+
+          <Section title="Your details">
+            <div className="grid gap-5 md:grid-cols-2">
+              <Field inputId="real-estate-name" label="Name" required error={errors.name}><input id="real-estate-name" name="name" value={formData.name} onChange={change} className={inputClass} autoComplete="name" {...a11y("name")} /></Field>
+              <Field inputId="real-estate-email" label="Email" required error={errors.email}><input id="real-estate-email" name="email" type="email" value={formData.email} onChange={change} className={inputClass} autoComplete="email" {...a11y("email")} /></Field>
+              <Field inputId="real-estate-phone" label="Phone" required error={errors.phone}><input id="real-estate-phone" name="phone" type="tel" value={formData.phone} onChange={change} className={inputClass} autoComplete="tel" {...a11y("phone")} /></Field>
+              <Field inputId="real-estate-client-type" label="Client type" required error={errors.client_type}><select id="real-estate-client-type" name="client_type" value={formData.client_type} onChange={change} className={inputClass} {...a11y("client_type")}><option value="">Select…</option>{option("estate_agent", "Estate agent")}{option("developer", "Developer")}{option("private_seller", "Private seller")}{option("landlord", "Landlord")}{option("other", "Other")}</select></Field>
+              <Field inputId="real-estate-company-name" label="Company / agency name" required={["estate_agent", "developer"].includes(formData.client_type)} error={errors.company_name}><input id="real-estate-company-name" name="company_name" value={formData.company_name} onChange={change} className={inputClass} autoComplete="organization" {...a11y("company_name")} /></Field>
+              <Field inputId="real-estate-preferred-package" label="Preferred package" required error={errors.preferred_package}><select id="real-estate-preferred-package" name="preferred_package" value={formData.preferred_package} onChange={change} className={inputClass} {...a11y("preferred_package")}><option value="">Choose deliberately…</option>{option("essential", "Essential — €175")}{option("starter", "Starter — €229")}{option("pro", "Pro — €399")}{option("premium", "Premium — €579")}{option("custom", "Custom — POA")}{option("not_sure", "Not sure")}</select></Field>
             </div>
-          ) : (
-            <form id={FORM_ID} onSubmit={handleSubmit} className="space-y-6">
-              <input
-                type="hidden"
-                name="consent_to_contact"
-                value={formData.consent_to_contact ? "true" : "false"}
-                readOnly
-              />
+          </Section>
 
-              {errors.submit ? (
-                <div className="rounded-2xl border border-red-500/30 bg-red-500/10 p-4 text-sm text-red-100">
-                  {errors.submit}
-                </div>
-              ) : null}
+          <Section title="Exact property location">
+            <Field inputId="real-estate-property-address" label="Property address" required error={errors.property_address}><textarea id="real-estate-property-address" name="property_address" value={formData.property_address} onChange={change} className={inputClass} rows={2} {...a11y("property_address")} /></Field>
+            <div className="grid gap-5 md:grid-cols-2">
+              <Field inputId="real-estate-county" label="County" required error={errors.county}><select id="real-estate-county" name="county" value={formData.county} onChange={change} className={inputClass} {...a11y("county")}><option value="">Select county…</option>{counties.map((county) => option(county, county))}</select></Field>
+              {!formData.no_eircode ? <Field inputId="real-estate-eircode" label="Eircode" required error={errors.eircode}><input id="real-estate-eircode" name="eircode" value={formData.eircode} onChange={change} className={inputClass} autoComplete="postal-code" {...a11y("eircode")} /></Field> : null}
+            </div>
+            <label className="flex items-center gap-3 text-sm"><input type="checkbox" name="no_eircode" checked={formData.no_eircode} onChange={checkbox("no_eircode")} />Property has no Eircode</label>
+            {formData.no_eircode ? <Field inputId="real-estate-location-details" label="Precise location details or Google Maps link" required error={errors.location_details}><textarea id="real-estate-location-details" name="location_details" value={formData.location_details} onChange={change} className={inputClass} rows={2} {...a11y("location_details")} /></Field> : null}
+          </Section>
 
-              <div className="grid gap-5 md:grid-cols-2">
-                <Field
-                  inputId="real-estate-name"
-                  label="Name"
-                  error={errors.name}
-                >
-                  <input
-                    id="real-estate-name"
-                    name="name"
-                    value={formData.name}
-                    onChange={handleFieldChange}
-                    className={inputClass}
-                    autoComplete="name"
-                    required
-                  />
-                </Field>
-                <Field
-                  inputId="real-estate-email"
-                  label="Email"
-                  error={errors.email}
-                >
-                  <input
-                    id="real-estate-email"
-                    name="email"
-                    type="email"
-                    value={formData.email}
-                    onChange={handleFieldChange}
-                    className={inputClass}
-                    autoComplete="email"
-                    required
-                  />
-                </Field>
-                <Field
-                  inputId="real-estate-phone"
-                  label="Phone"
-                  error={errors.phone}
-                >
-                  <input
-                    id="real-estate-phone"
-                    name="phone"
-                    type="tel"
-                    value={formData.phone}
-                    onChange={handleFieldChange}
-                    className={inputClass}
-                    autoComplete="tel"
-                    required
-                  />
-                </Field>
-                <Field inputId="real-estate-company" label="Company name">
-                  <input
-                    id="real-estate-company"
-                    name="company_name"
-                    value={formData.company_name}
-                    onChange={handleFieldChange}
-                    className={inputClass}
-                    autoComplete="organization"
-                  />
-                </Field>
-              </div>
+          <Section title="Property scope">
+            <div className="grid gap-5 md:grid-cols-2">
+              <Field inputId="real-estate-property-type" label="Property category" required error={errors.property_type}><select id="real-estate-property-type" name="property_type" value={formData.property_type} onChange={change} className={inputClass} {...a11y("property_type")}><option value="">Select…</option>{option("house", "House")}{option("apartment", "Apartment")}{option("new_build", "New build / development")}{option("site_land", "Site / land")}{option("commercial", "Commercial property")}{option("agricultural", "Agricultural property")}{option("other", "Other")}</select></Field>
+              {formData.property_type === "other" ? <Field inputId="real-estate-property-type-details" label="Property category details" required error={errors.property_type_details}><input id="real-estate-property-type-details" name="property_type_details" value={formData.property_type_details} onChange={change} className={inputClass} {...a11y("property_type_details")} /></Field> : null}
+              <Field inputId="real-estate-bedroom-count" label="Bedroom count" required error={errors.bedroom_count}><select id="real-estate-bedroom-count" name="bedroom_count" value={formData.bedroom_count} onChange={change} className={inputClass} {...a11y("bedroom_count")}><option value="">Select…</option>{["studio", "1", "2", "3", "4", "5", "6_plus", "not_applicable"].map((v) => option(v, v === "6_plus" ? "6+" : v === "not_applicable" ? "Not applicable" : v[0].toUpperCase() + v.slice(1)))}</select></Field>
+              <Field inputId="real-estate-floor-count" label="Number of floors" required error={errors.floor_count}><select id="real-estate-floor-count" name="floor_count" value={formData.floor_count} onChange={change} className={inputClass} {...a11y("floor_count")}><option value="">Select…</option>{option("1", "1")}{option("2", "2")}{option("3", "3")}{option("4_plus", "4+")}{option("not_applicable", "Not applicable")}</select></Field>
+              <Field inputId="real-estate-secondary-accommodation" label="Secondary accommodation" required error={errors.secondary_accommodation}><select id="real-estate-secondary-accommodation" name="secondary_accommodation" value={formData.secondary_accommodation} onChange={change} className={inputClass} {...a11y("secondary_accommodation")}><option value="">Select…</option>{option("yes", "Yes")}{option("no", "No")}{option("not_sure", "Not sure")}</select></Field>
+              <Field inputId="real-estate-outbuildings" label="Outbuildings" required error={errors.outbuildings}><select id="real-estate-outbuildings" name="outbuildings" value={formData.outbuildings} onChange={change} className={inputClass} {...a11y("outbuildings")}><option value="">Select…</option>{option("yes", "Yes")}{option("no", "No")}{option("not_sure", "Not sure")}</select></Field>
+            </div>
+            {formData.secondary_accommodation === "yes" ? <Field inputId="real-estate-secondary-accommodation-details" label="Secondary accommodation description" required error={errors.secondary_accommodation_details}><textarea id="real-estate-secondary-accommodation-details" name="secondary_accommodation_details" value={formData.secondary_accommodation_details} onChange={change} className={inputClass} rows={2} {...a11y("secondary_accommodation_details")} /></Field> : null}
+            {formData.outbuildings === "yes" ? <Field inputId="real-estate-outbuildings-details" label="Outbuilding description" required error={errors.outbuildings_details}><textarea id="real-estate-outbuildings-details" name="outbuildings_details" value={formData.outbuildings_details} onChange={change} className={inputClass} rows={2} {...a11y("outbuildings_details")} /></Field> : null}
+            <Field inputId="real-estate-grounds-size" label="Grounds / site size" required error={errors.grounds_size}><select id="real-estate-grounds-size" name="grounds_size" value={formData.grounds_size} onChange={change} className={inputClass} {...a11y("grounds_size")}><option value="">Select…</option>{option("no_grounds", "No grounds")}{option("normal_garden", "Normal garden")}{option("large_garden", "Large garden")}{option("under_1_acre", "Under 1 acre")}{option("1_to_5_acres", "1–5 acres")}{option("over_5_acres", "Over 5 acres")}{option("not_sure", "Not sure")}{option("not_applicable", "Not applicable")}</select></Field>
+            <div className="grid gap-5 md:grid-cols-2">
+              <Field inputId="real-estate-internal-floor-area" label="Approximate internal floor area" error={errors.internal_floor_area}><input id="real-estate-internal-floor-area" name="internal_floor_area" type="number" min="1" step="1" value={formData.internal_floor_area} onChange={change} className={inputClass} {...a11y("internal_floor_area")} /></Field>
+              <Field inputId="real-estate-internal-floor-area-unit" label="Floor area unit" required={Boolean(formData.internal_floor_area)} error={errors.internal_floor_area_unit}><select id="real-estate-internal-floor-area-unit" name="internal_floor_area_unit" value={formData.internal_floor_area_unit ?? ""} onChange={change} className={inputClass} {...a11y("internal_floor_area_unit")}><option value="">Select…</option>{option("sqm", "m²")}{option("sqft", "sq ft")}</select></Field>
+            </div>
+            <Field inputId="real-estate-property-features" label="Other features affecting coverage" error={errors.property_features}><textarea id="real-estate-property-features" name="property_features" value={formData.property_features} onChange={change} className={inputClass} rows={2} {...a11y("property_features")} /></Field>
+          </Section>
 
-              <div className="grid gap-5 md:grid-cols-2">
-                <Field
-                  inputId="real-estate-client-type"
-                  label="Client type"
-                  error={errors.client_type}
-                >
-                  <select
-                    id="real-estate-client-type"
-                    name="client_type"
-                    value={formData.client_type}
-                    onChange={handleFieldChange}
-                    className={inputClass}
-                    required
-                  >
-                    <option value="">Select...</option>
-                    <option value="estate_agent">Estate agent</option>
-                    <option value="developer">Developer</option>
-                    <option value="private_seller">Private seller</option>
-                    <option value="landlord">Landlord</option>
-                    <option value="other">Other</option>
-                  </select>
-                </Field>
-                <Field
-                  inputId="real-estate-package"
-                  label="Preferred package"
-                  error={errors.preferred_package}
-                >
-                  <select
-                    id="real-estate-package"
-                    name="preferred_package"
-                    value={formData.preferred_package}
-                    onChange={handleFieldChange}
-                    className={inputClass}
-                    required
-                  >
-                    <option value="not_sure">Not sure</option>
-                    <option value="essential">Essential</option>
-                    <option value="starter">Starter</option>
-                    <option value="pro">Pro</option>
-                    <option value="premium">Premium</option>
-                    <option value="custom">Custom</option>
-                  </select>
-                </Field>
-              </div>
+          <Section title="Access & shoot readiness">
+            <div className="grid gap-5 md:grid-cols-2">
+              <Field inputId="real-estate-occupancy-status" label="Occupancy status" required error={errors.occupancy_status}><select id="real-estate-occupancy-status" name="occupancy_status" value={formData.occupancy_status} onChange={change} className={inputClass} {...a11y("occupancy_status")}><option value="">Select…</option>{option("vacant", "Vacant")}{option("owner_occupied", "Owner occupied")}{option("tenant_occupied", "Tenant occupied")}{option("new_build_site", "New build / site")}{option("other", "Other")}</select></Field>
+              <Field inputId="real-estate-access-provider" label="Who will provide access?" required error={errors.access_provider}><select id="real-estate-access-provider" name="access_provider" value={formData.access_provider} onChange={change} className={inputClass} {...a11y("access_provider")}><option value="">Select…</option>{option("enquirer", "I will — reuse my contact details")}{option("owner", "Property owner / vendor")}{option("tenant", "Tenant")}{option("agent_colleague", "Agent / colleague")}{option("other", "Other")}</select></Field>
+            </div>
+            {formData.access_provider && formData.access_provider !== "enquirer" ? <div className="grid gap-5 md:grid-cols-2"><Field inputId="real-estate-access-contact-name" label="Access contact name" required error={errors.access_contact_name}><input id="real-estate-access-contact-name" name="access_contact_name" value={formData.access_contact_name} onChange={change} className={inputClass} {...a11y("access_contact_name")} /></Field><Field inputId="real-estate-access-contact-phone" label="Access contact phone" required error={errors.access_contact_phone}><input id="real-estate-access-contact-phone" name="access_contact_phone" type="tel" value={formData.access_contact_phone} onChange={change} className={inputClass} {...a11y("access_contact_phone")} /></Field></div> : null}
+            <Field inputId="real-estate-access-notes" label="Access restrictions or instructions" error={errors.access_notes}><textarea id="real-estate-access-notes" name="access_notes" value={formData.access_notes} onChange={change} className={inputClass} rows={2} {...a11y("access_notes")} /></Field>
+            <div><label className="flex items-start gap-3 text-sm"><input type="checkbox" name="readiness_acknowledged" checked={formData.readiness_acknowledged} onChange={checkbox("readiness_acknowledged")} aria-invalid={errors.readiness_acknowledged ? true : undefined} aria-describedby={errors.readiness_acknowledged ? "real-estate-readiness-acknowledged-error" : "real-estate-readiness-note"} /><span><strong>I acknowledge *</strong> the property should be cleaned, staged and ready at the agreed arrival time.</span></label><p id="real-estate-readiness-note" className="mt-2 text-xs text-gray-500">Substantial preparation delays may reduce coverage, require rescheduling or incur agreed additional time charges.</p>{errors.readiness_acknowledged ? <p id="real-estate-readiness-acknowledged-error" className="mt-2 text-sm text-red-300">{errors.readiness_acknowledged}</p> : null}</div>
+          </Section>
 
-              <Field
-                inputId="real-estate-address"
-                label="Property address"
-                error={errors.property_address}
-              >
-                <input
-                  id="real-estate-address"
-                  name="property_address"
-                  value={formData.property_address}
-                  onChange={handleFieldChange}
-                  className={inputClass}
-                  autoComplete="street-address"
-                  required
-                />
-              </Field>
+          <Section title="Preferred scheduling">
+            <Field inputId="real-estate-scheduling-preference" label="Scheduling choice" required error={errors.scheduling_preference}><select id="real-estate-scheduling-preference" name="scheduling_preference" value={formData.scheduling_preference} onChange={change} className={inputClass} {...a11y("scheduling_preference")}><option value="">Select…</option>{option("request_date", "Request a preferred date")}{option("flexible", "Flexible / please contact me")}</select></Field>
+            {formData.scheduling_preference === "request_date" ? <div className="grid gap-5 md:grid-cols-2"><Field inputId="real-estate-preferred-date" label="Preferred date" required error={errors.preferred_date}><input id="real-estate-preferred-date" name="preferred_date" type="date" min={localToday()} value={formData.preferred_date} onChange={change} className={inputClass} {...a11y("preferred_date")} /></Field><Field inputId="real-estate-alternative-date" label="Alternative date" error={errors.alternative_date}><input id="real-estate-alternative-date" name="alternative_date" type="date" min={localToday()} value={formData.alternative_date} onChange={change} className={inputClass} {...a11y("alternative_date")} /></Field></div> : null}
+            <Field inputId="real-estate-preferred-time-window" label="Preferred time window" required error={errors.preferred_time_window}><select id="real-estate-preferred-time-window" name="preferred_time_window" value={formData.preferred_time_window} onChange={change} className={inputClass} {...a11y("preferred_time_window")}><option value="">Select…</option>{option("morning", "Morning")}{option("afternoon", "Afternoon")}{option("flexible", "Flexible")}</select></Field>
+          </Section>
 
-              <div className="grid gap-5 md:grid-cols-3">
-                <Field inputId="real-estate-eircode" label="Eircode">
-                  <input
-                    id="real-estate-eircode"
-                    name="eircode"
-                    value={formData.eircode}
-                    onChange={handleFieldChange}
-                    className={inputClass}
-                    autoComplete="postal-code"
-                  />
-                </Field>
-                <Field
-                  inputId="real-estate-county"
-                  label="County"
-                  error={errors.county}
-                >
-                  <input
-                    id="real-estate-county"
-                    name="county"
-                    value={formData.county}
-                    onChange={handleFieldChange}
-                    className={inputClass}
-                    autoComplete="address-level1"
-                    required
-                  />
-                </Field>
-                <Field
-                  inputId="real-estate-property-type"
-                  label="Property type"
-                  error={errors.property_type}
-                >
-                  <input
-                    id="real-estate-property-type"
-                    name="property_type"
-                    value={formData.property_type}
-                    onChange={handleFieldChange}
-                    className={inputClass}
-                    placeholder="House, apartment, site..."
-                    required
-                  />
-                </Field>
-              </div>
+          <Section title="On-camera presentation & audio">
+            <Field inputId="real-estate-on-camera" label="Will anyone present or speak on camera?" required error={errors.on_camera}><select id="real-estate-on-camera" name="on_camera" value={formData.on_camera} onChange={change} className={inputClass} {...a11y("on_camera")}><option value="">Select…</option>{option("yes", "Yes")}{option("no", "No")}{option("not_sure", "Not sure")}</select></Field>
+            {formData.on_camera === "yes" ? <><Field inputId="real-estate-on-camera-people" label="Who will appear?" required error={errors.on_camera_people}><input id="real-estate-on-camera-people" name="on_camera_people" value={formData.on_camera_people} onChange={change} className={inputClass} {...a11y("on_camera_people")} /></Field><Field inputId="real-estate-audio-requirements" label="Spoken-audio / microphone requirements" required error={errors.audio_requirements} hint="Presenter and audio requirements must be agreed before the shoot; scripting, extra editing and retakes are not automatically included."><textarea id="real-estate-audio-requirements" name="audio_requirements" value={formData.audio_requirements} onChange={change} className={inputClass} rows={2} {...a11y("audio_requirements", true)} /></Field></> : null}
+          </Section>
 
-              <div>
-                <span className={labelClass}>Add-ons</span>
-                <div className="grid gap-3 md:grid-cols-2">
-                  {addOns.map((item) => (
-                    <label
-                      key={item.key}
-                      className="flex cursor-pointer gap-3 rounded-2xl border border-white/10 bg-gray-950 p-4 text-sm transition hover:border-[#16a34a]/50"
-                    >
-                      <input
-                        type="checkbox"
-                        checked={formData.add_ons.includes(item.key)}
-                        onChange={() => toggleAddOn(item.key)}
-                        className="mt-1 h-4 w-4 rounded border-white/30 bg-black text-[#16a34a] focus:ring-[#16a34a]"
-                      />
-                      <span>
-                        <span className="block font-bold text-white">
-                          {item.label}
-                        </span>
-                        <span className="mt-1 block text-gray-400">
-                          {item.price}
-                        </span>
-                      </span>
-                    </label>
-                  ))}
-                </div>
-                <p className="mt-3 text-sm text-gray-400">
-                  {REAL_ESTATE_VAT_NOTE}
-                </p>
-              </div>
+          <Section title="Optional add-ons">
+            {packageNotice ? <p role="status" className="rounded-xl bg-amber-400/10 p-3 text-sm text-amber-100">{packageNotice}</p> : null}
+            <div className="grid gap-3 md:grid-cols-2">{shownAddOns.map((item) => <label key={item.key} className="flex gap-3 rounded-xl border border-white/10 p-4"><input type="checkbox" name="add_ons" value={item.key} checked={formData.add_ons.includes(item.key)} onChange={() => toggleAddOn(item.key)} /><span><strong className="block">{item.label}</strong><span className="text-sm text-gray-500">{item.price}</span></span></label>)}</div>
+            {formData.add_ons.includes("additional_stills") ? <Field inputId="real-estate-additional-stills-quantity" label="Number of additional edited stills" required error={errors.additional_stills_quantity}><input id="real-estate-additional-stills-quantity" name="additional_stills_quantity" type="number" min="1" max="50" step="1" value={formData.additional_stills_quantity} onChange={change} className={inputClass} {...a11y("additional_stills_quantity")} /></Field> : null}
+            {formData.add_ons.includes("rush_delivery") && ["pro", "premium"].includes(formData.preferred_package) ? <p className="text-sm text-amber-200">Rush delivery applies to still photographs only. Video follows the normal agreed schedule.</p> : null}
+            <p className="text-xs text-gray-500">{REAL_ESTATE_VAT_NOTE}</p>
+          </Section>
 
-              <div className="grid gap-5 md:grid-cols-2">
-                <Field inputId="real-estate-date" label="Preferred date">
-                  <input
-                    id="real-estate-date"
-                    name="preferred_date"
-                    type="date"
-                    value={formData.preferred_date}
-                    onChange={handleFieldChange}
-                    className={inputClass}
-                  />
-                </Field>
-                <Field
-                  inputId="real-estate-how-heard"
-                  label="How did you hear about us?"
-                >
-                  <select
-                    id="real-estate-how-heard"
-                    name="how_heard"
-                    value={formData.how_heard}
-                    onChange={handleFieldChange}
-                    className={inputClass}
-                  >
-                    <option value="">Select...</option>
-                    <option value="google">Google</option>
-                    <option value="instagram">Instagram</option>
-                    <option value="facebook">Facebook</option>
-                    <option value="linkedin">LinkedIn</option>
-                    <option value="referral">Referral</option>
-                    <option value="estate_agent_colleague">
-                      Estate agent colleague
-                    </option>
-                    <option value="openeire_website">OpenÉire website</option>
-                    <option value="other">Other</option>
-                    <option value="not_sure">Not sure</option>
-                  </select>
-                </Field>
-              </div>
+          <Section title="Anything else">
+            <Field inputId="real-estate-how-heard" label="How did you hear about us?" error={errors.how_heard}><select id="real-estate-how-heard" name="how_heard" value={formData.how_heard} onChange={change} className={inputClass} {...a11y("how_heard")}><option value="">Select…</option>{option("google", "Google")}{option("instagram", "Instagram")}{option("facebook", "Facebook")}{option("linkedin", "LinkedIn")}{option("referral", "Referral")}{option("estate_agent_colleague", "Estate agent colleague")}{option("openeire_website", "OpenÉire website")}{option("other", "Other")}{option("not_sure", "Not sure")}</select></Field>
+            <Field inputId="real-estate-message" label="Client message" error={errors.message}><textarea id="real-estate-message" name="message" value={formData.message} onChange={change} className={inputClass} rows={3} {...a11y("message")} /></Field>
+          </Section>
 
-              <Field
-                inputId="real-estate-message"
-                label="Message / access notes / special requirements"
-              >
-                <textarea
-                  id="real-estate-message"
-                  name="message"
-                  rows={5}
-                  value={formData.message}
-                  onChange={handleFieldChange}
-                  className={`${inputClass} resize-none`}
-                />
-              </Field>
-
-              <div>
-                <label className="flex items-start gap-3 rounded-2xl border border-white/10 bg-gray-950 p-4 text-sm text-gray-300">
-                  <input
-                    type="checkbox"
-                    checked={formData.consent_to_contact}
-                    onChange={handleConsentChange}
-                    className="mt-1 h-4 w-4 rounded border-white/30 bg-black text-[#16a34a] focus:ring-[#16a34a]"
-                    required
-                  />
-                  <span>
-                    I consent to OpenÉire Studios contacting me about this
-                    property media enquiry.
-                  </span>
-                </label>
-                {errors.consent_to_contact ? (
-                  <p className="mt-2 text-sm text-red-300">
-                    {errors.consent_to_contact}
-                  </p>
-                ) : null}
-              </div>
-
-              <button
-                id={SUBMIT_ID}
-                name="submit-button"
-                type="submit"
-                disabled={status === "submitting"}
-                className="flex w-full items-center justify-center gap-3 rounded-2xl bg-[#16a34a] px-6 py-4 font-bold text-white shadow-lg shadow-[#16a34a]/20 transition hover:bg-[#15803d] disabled:cursor-not-allowed disabled:opacity-60"
-              >
-                {status === "submitting" ? (
-                  <span className="h-5 w-5 animate-spin rounded-full border-2 border-brand-900 border-t-transparent" />
-                ) : (
-                  <>
-                    Send property enquiry
-                    <FaPaperPlane aria-hidden="true" />
-                  </>
-                )}
-              </button>
-            </form>
-          )}
-        </div>
+          <div><label className="flex items-start gap-3 text-sm"><input type="checkbox" data-error-field="consent_to_contact" checked={formData.consent_to_contact} onChange={checkbox("consent_to_contact")} aria-invalid={errors.consent_to_contact ? true : undefined} aria-describedby={errors.consent_to_contact ? "real-estate-consent-to-contact-error" : undefined} /><span>I consent to OpenÉire Studios contacting me about this operational enquiry. *</span></label>{errors.consent_to_contact ? <p id="real-estate-consent-to-contact-error" className="mt-2 text-sm text-red-300">{errors.consent_to_contact}</p> : null}</div>
+          <button id={SUBMIT_ID} type="submit" disabled={status === "submitting"} className="flex w-full items-center justify-center gap-3 rounded-full bg-[#16a34a] px-6 py-4 font-bold text-white disabled:opacity-60"><FaPaperPlane />{status === "submitting" ? "Sending…" : "Send shoot enquiry"}</button>
+        </form>
       </div>
     </section>
   );

--- a/openeire-next/lib/api/publicForms.ts
+++ b/openeire-next/lib/api/publicForms.ts
@@ -43,6 +43,26 @@ export const getApiErrorMessage = (
   return fieldMessage ?? fallback;
 };
 
+export const getApiFieldErrors = (error: unknown): Record<string, string> => {
+  const payload = isApiError(error) ? error.response?.data : error;
+  if (!payload || typeof payload !== "object" || Array.isArray(payload)) {
+    return {};
+  }
+
+  return Object.fromEntries(
+    Object.entries(payload as Record<string, unknown>).flatMap(
+      ([field, value]) => {
+        const message = Array.isArray(value)
+          ? value.filter(Boolean).join(" ")
+          : typeof value === "string"
+            ? value.trim()
+            : "";
+        return message ? [[field, message]] : [];
+      },
+    ),
+  );
+};
+
 export const sendContactMessage = async (payload: ContactData) => {
   const response = await api.post("home/contact/", payload);
   return response.data;

--- a/openeire-next/tests/realEstateEnquiryForm.test.tsx
+++ b/openeire-next/tests/realEstateEnquiryForm.test.tsx
@@ -1,0 +1,187 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { RealEstateEnquiryForm } from "@/components/real-estate/RealEstateEnquiryForm";
+
+const mocks = vi.hoisted(() => ({
+  submit: vi.fn(),
+  consent: vi.fn(),
+}));
+
+vi.mock("@/components/ui/ToastProvider", () => ({
+  useToast: () => ({ showToast: vi.fn() }),
+}));
+vi.mock("@/lib/api/publicForms", () => ({
+  submitRealEstateEnquiry: mocks.submit,
+  getApiErrorMessage: () => "Request failed",
+  getApiFieldErrors: (error: { fieldErrors?: Record<string, string> }) =>
+    error.fieldErrors ?? {},
+}));
+vi.mock("@/lib/iubendaConsent", () => ({
+  registerIubendaConsentForm: () => vi.fn(),
+  submitIubendaConsentForm: mocks.consent,
+}));
+
+const select = (name: string, value: string) =>
+  fireEvent.change(document.querySelector(`[name="${name}"]`)!, {
+    target: { value },
+  });
+const type = (name: string, value: string) =>
+  fireEvent.change(document.querySelector(`[name="${name}"]`)!, {
+    target: { value },
+  });
+
+function completeRequiredForm() {
+  type("name", "Jane Agent");
+  type("email", "jane@example.com");
+  type("phone", "+353 87 123 4567");
+  select("client_type", "estate_agent");
+  type("company_name", "Example Agency");
+  select("preferred_package", "starter");
+  type("property_address", "Example House, Galway");
+  select("county", "Galway");
+  type("eircode", "H91 X4K8");
+  select("property_type", "house");
+  select("bedroom_count", "3");
+  select("floor_count", "2");
+  select("secondary_accommodation", "no");
+  select("outbuildings", "no");
+  select("grounds_size", "normal_garden");
+  select("occupancy_status", "owner_occupied");
+  select("access_provider", "enquirer");
+  select("scheduling_preference", "flexible");
+  select("preferred_time_window", "morning");
+  select("on_camera", "no");
+  fireEvent.click(document.querySelector('[name="readiness_acknowledged"]')!);
+  fireEvent.click(screen.getByText(/I consent to Open/).closest("label")!.querySelector("input")!);
+}
+
+describe("real-estate shoot scoping form", () => {
+  afterEach(cleanup);
+  beforeEach(() => {
+    mocks.submit.mockReset().mockResolvedValue({ id: 1 });
+    mocks.consent.mockReset();
+    window.history.replaceState({}, "", "/real-estate");
+  });
+
+  it("shows required guidance and starts with no silently selected package", () => {
+    render(<RealEstateEnquiryForm />);
+    expect(screen.getByText(/Fields marked/)).toBeTruthy();
+    expect((document.querySelector('[name="preferred_package"]') as HTMLSelectElement).value).toBe("");
+    expect(screen.getByLabelText(/Approximate internal floor area/).closest("div")?.textContent).toContain("Optional");
+  });
+
+  it("preserves valid package query preselection", async () => {
+    window.history.replaceState({}, "", "/real-estate?package=premium");
+    render(<RealEstateEnquiryForm />);
+    await waitFor(() =>
+      expect((document.querySelector('[name="preferred_package"]') as HTMLSelectElement).value).toBe("premium"),
+    );
+  });
+
+  it("reveals conditional company, location, scope, access and presenter fields", () => {
+    render(<RealEstateEnquiryForm />);
+    select("client_type", "estate_agent");
+    fireEvent.click(document.querySelector('[name="no_eircode"]')!);
+    select("secondary_accommodation", "yes");
+    select("outbuildings", "yes");
+    select("access_provider", "tenant");
+    select("on_camera", "yes");
+
+    expect(screen.getByLabelText(/Company \/ agency name/)).toBeTruthy();
+    expect(screen.getByLabelText(/Precise location details/)).toBeTruthy();
+    expect(screen.getByLabelText(/Secondary accommodation description/)).toBeTruthy();
+    expect(screen.getByLabelText(/Outbuilding description/)).toBeTruthy();
+    expect(screen.getByLabelText(/Access contact name/)).toBeTruthy();
+    expect(screen.getByLabelText(/Spoken-audio/)).toBeTruthy();
+  });
+
+  it("validates conditional company, location, scope, access and presenter details", () => {
+    render(<RealEstateEnquiryForm />);
+    select("client_type", "estate_agent");
+    fireEvent.click(document.querySelector('[name="no_eircode"]')!);
+    select("property_type", "other");
+    select("secondary_accommodation", "yes");
+    select("outbuildings", "yes");
+    select("access_provider", "tenant");
+    select("on_camera", "yes");
+    fireEvent.submit(document.getElementById("real-estate-enquiry-form")!);
+
+    expect(screen.getByText(/Company or agency name is required/)).toBeTruthy();
+    expect(screen.getByText(/precise directions or a Google Maps link/)).toBeTruthy();
+    expect(screen.getByText(/Describe the property category/)).toBeTruthy();
+    expect(screen.getByText(/Describe the secondary accommodation/)).toBeTruthy();
+    expect(screen.getByText(/Describe the outbuildings/)).toBeTruthy();
+    expect(screen.getByText(/access contact's name/)).toBeTruthy();
+    expect(screen.getByText(/spoken-audio or microphone requirements/)).toBeTruthy();
+  });
+
+  it("requires a future date only when a date is requested", () => {
+    render(<RealEstateEnquiryForm />);
+    select("scheduling_preference", "request_date");
+    expect(screen.getByLabelText(/Preferred date/)).toBeTruthy();
+    expect((document.querySelector('[name="preferred_date"]') as HTMLInputElement).min).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    select("scheduling_preference", "flexible");
+    expect(document.querySelector('[name="preferred_date"]')).toBeNull();
+  });
+
+  it("rejects a manually entered past preferred date", () => {
+    render(<RealEstateEnquiryForm />);
+    select("scheduling_preference", "request_date");
+    type("preferred_date", "2000-01-01");
+    fireEvent.submit(document.getElementById("real-estate-enquiry-form")!);
+    expect(screen.getByText("Preferred date cannot be in the past.")).toBeTruthy();
+  });
+
+  it("offers 3D tours where compatible and clears them after switching to Premium", () => {
+    render(<RealEstateEnquiryForm />);
+    select("preferred_package", "starter");
+    fireEvent.click(screen.getByLabelText(/Hosted 3D virtual tour/));
+    expect((screen.getByLabelText(/Hosted 3D virtual tour/) as HTMLInputElement).checked).toBe(true);
+    select("preferred_package", "premium");
+    expect(screen.queryByLabelText(/Hosted 3D virtual tour/)).toBeNull();
+    expect(screen.getByText(/already included in the new package/)).toBeTruthy();
+    expect(screen.queryByLabelText(/2D measured floor plan/)).toBeNull();
+    expect(screen.queryByLabelText(/Additional social formats/)).toBeNull();
+  });
+
+  it("requires a bounded additional-stills quantity", () => {
+    render(<RealEstateEnquiryForm />);
+    fireEvent.click(screen.getByLabelText(/Additional edited stills/));
+    const quantity = screen.getByLabelText(/Number of additional edited stills/) as HTMLInputElement;
+    expect(quantity.min).toBe("1");
+    expect(quantity.max).toBe("50");
+    expect(quantity.step).toBe("1");
+  });
+
+  it("submits the structured payload and preserves Iubenda consent handling", async () => {
+    render(<RealEstateEnquiryForm />);
+    completeRequiredForm();
+    fireEvent.submit(document.getElementById("real-estate-enquiry-form")!);
+
+    await waitFor(() => expect(mocks.submit).toHaveBeenCalledTimes(1));
+    expect(mocks.submit.mock.calls[0][0]).toMatchObject({
+      form_schema_version: 2,
+      client_type: "estate_agent",
+      company_name: "Example Agency",
+      preferred_package: "starter",
+      property_type: "house",
+      bedroom_count: "3",
+      access_provider: "enquirer",
+      scheduling_preference: "flexible",
+      on_camera: "no",
+      readiness_acknowledged: true,
+      consent_to_contact: true,
+    });
+    expect(mocks.consent).toHaveBeenCalledWith("real-estate-enquiry-form");
+  });
+
+  it("maps backend field errors to their individual controls", async () => {
+    mocks.submit.mockRejectedValueOnce({ fieldErrors: { eircode: "Backend Eircode error." } });
+    render(<RealEstateEnquiryForm />);
+    completeRequiredForm();
+    fireEvent.submit(document.getElementById("real-estate-enquiry-form")!);
+    expect(await screen.findByText("Backend Eircode error.")).toBeTruthy();
+    expect(document.querySelector('[name="eircode"]')?.getAttribute("aria-invalid")).toBe("true");
+  });
+});

--- a/openeire-next/tests/realEstatePricing.test.tsx
+++ b/openeire-next/tests/realEstatePricing.test.tsx
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
-import { render, screen } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RealEstateEnquiryForm } from "@/components/real-estate/RealEstateEnquiryForm";
 import {
@@ -15,6 +15,7 @@ vi.mock("@/components/ui/ToastProvider", () => ({
 
 vi.mock("@/lib/api/publicForms", () => ({
   getApiErrorMessage: () => "Request failed",
+  getApiFieldErrors: () => ({}),
   submitRealEstateEnquiry: vi.fn(),
 }));
 
@@ -24,6 +25,7 @@ vi.mock("@/lib/iubendaConsent", () => ({
 }));
 
 describe("active real-estate pricing", () => {
+  afterEach(cleanup);
   beforeEach(() => {
     window.history.replaceState({}, "", "/real-estate");
   });
@@ -39,17 +41,18 @@ describe("active real-estate pricing", () => {
 
     expect(screen.getByText(REAL_ESTATE_VAT_NOTE)).toBeTruthy();
 
-    const packageSelect = screen.getByLabelText("Preferred package");
+    const packageSelect = screen.getByLabelText(/Preferred package/);
     const optionLabels = Array.from(packageSelect.querySelectorAll("option")).map(
       (option) => option.textContent,
     );
     expect(optionLabels).toEqual([
+      "Choose deliberately\u2026",
+      "Essential \u2014 \u20ac175",
+      "Starter \u2014 \u20ac229",
+      "Pro \u2014 \u20ac399",
+      "Premium \u2014 \u20ac579",
+      "Custom \u2014 POA",
       "Not sure",
-      "Essential",
-      "Starter",
-      "Pro",
-      "Premium",
-      "Custom",
     ]);
   });
 

--- a/openeire-next/types/publicForms.ts
+++ b/openeire-next/types/publicForms.ts
@@ -40,12 +40,25 @@ export type HowHeard =
 export type AddOnKey =
   | "additional_stills"
   | "floor_plan"
+  | "virtual_tour_3d"
   | "rush_delivery"
   | "extended_drone_video"
   | "additional_social_cuts"
   | "travel_supplement";
 
+export type PropertyCategory =
+  | "house"
+  | "apartment"
+  | "new_build"
+  | "site_land"
+  | "commercial"
+  | "agricultural"
+  | "other";
+
+export type YesNoNotSure = "yes" | "no" | "not_sure";
+
 export interface RealEstateEnquiryPayload {
+  form_schema_version: 2;
   name: string;
   email: string;
   phone: string;
@@ -53,11 +66,63 @@ export interface RealEstateEnquiryPayload {
   client_type: ClientType;
   property_address: string;
   eircode?: string;
+  no_eircode: boolean;
+  location_details?: string;
   county: string;
-  property_type: string;
+  property_type: PropertyCategory;
+  property_type_details?: string;
+  bedroom_count:
+    | "studio"
+    | "1"
+    | "2"
+    | "3"
+    | "4"
+    | "5"
+    | "6_plus"
+    | "not_applicable";
+  floor_count: "1" | "2" | "3" | "4_plus" | "not_applicable";
+  secondary_accommodation: YesNoNotSure;
+  secondary_accommodation_details?: string;
+  outbuildings: YesNoNotSure;
+  outbuildings_details?: string;
+  grounds_size:
+    | "no_grounds"
+    | "normal_garden"
+    | "large_garden"
+    | "under_1_acre"
+    | "1_to_5_acres"
+    | "over_5_acres"
+    | "not_sure"
+    | "not_applicable";
+  internal_floor_area?: number;
+  internal_floor_area_unit?: "sqm" | "sqft";
+  property_features?: string;
+  occupancy_status:
+    | "vacant"
+    | "owner_occupied"
+    | "tenant_occupied"
+    | "new_build_site"
+    | "other";
+  access_provider:
+    | "enquirer"
+    | "owner"
+    | "tenant"
+    | "agent_colleague"
+    | "other";
+  access_contact_name?: string;
+  access_contact_phone?: string;
+  access_notes?: string;
+  readiness_acknowledged: boolean;
   preferred_package: PackageType;
   add_ons?: AddOnKey[];
+  additional_stills_quantity?: number;
+  scheduling_preference: "request_date" | "flexible";
   preferred_date?: string;
+  alternative_date?: string;
+  preferred_time_window: "morning" | "afternoon" | "flexible";
+  on_camera: YesNoNotSure;
+  on_camera_people?: string;
+  audio_requirements?: string;
   how_heard?: HowHeard;
   message?: string;
   consent_to_contact: boolean;


### PR DESCRIPTION
## What changed
- replace the lightweight enquiry form with progressive client, location, property scope, readiness/access, scheduling, presenter/audio, and add-on sections
- always send `form_schema_version: 2`
- add accessible per-field errors, first-invalid focus, deliberate package selection, controlled county/category values, and local-date validation
- add 3D tour selection, bounded additional-stills quantities, and package-aware add-on cleanup
- remove public travel selection while preserving Iubenda consent behavior
- map backend field errors back to individual controls

## Why
The existing form did not expose enough scope to quote or prepare reliably. The backend V2 contract is already deployed and retains legacy compatibility, so this frontend can now safely activate strict shoot-scoping validation.

## Impact
New public submissions are explicitly V2 and receive the complete strict backend validation matrix. Existing `?package=` preselection and consent tracking are preserved.

## Validation
- ESLint passed
- TypeScript check passed
- focused real-estate tests: 13 passed
- complete frontend suite: 25 passed
- production Next.js build passed
- `git diff --check` passed