### PR TITLE
Add property media to the main contact form

### DIFF
--- a/openeire-next/app/contact/page.tsx
+++ b/openeire-next/app/contact/page.tsx
@@ -17,9 +17,10 @@ import {
 } from "@/lib/site";
 
 export const metadata: Metadata = buildPageMetadata({
-  title: "Contact OpenEire Studios | Prints, Licensing & Drone Work",
+  title:
+    "Contact OpenEire Studios | Property Media, Prints, Licensing & Drone Work",
   description:
-    "Get in touch about fine art print enquiries, commercial licensing, or bespoke drone capture projects in Ireland.",
+    "Get in touch about real-estate and property-media enquiries, fine art prints, commercial licensing, or bespoke drone work in Ireland.",
   path: "/contact",
 });
 
@@ -50,9 +51,9 @@ export default function ContactPage() {
             Get in Touch
           </h1>
           <p className="mx-auto max-w-2xl text-lg font-light leading-relaxed text-gray-400">
-            Have a question about a specific print, commercial licensing rights,
-            or a custom drone shot? We are here to help bring your vision to
-            life.
+            Have a question about real-estate or property media, a specific
+            print, commercial licensing rights, or custom drone work? We are
+            here to help bring your vision to life.
           </p>
         </div>
 

--- a/openeire-next/components/contact/ContactForm.tsx
+++ b/openeire-next/components/contact/ContactForm.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useEffect, useState, type ChangeEvent, type FormEvent } from "react";
 import {
   FaCheckCircle,
@@ -99,7 +100,8 @@ export function ContactForm() {
           <div className="min-w-0">
             <h2 className="mb-1 text-lg font-bold text-white">Email Us</h2>
             <p className="mb-2 text-sm text-gray-400">
-              For print enquiries, commercial licensing, and custom drone work.
+              For property-media enquiries, prints, commercial licensing, and
+              custom drone work.
             </p>
             <a
               href="mailto:contact@openeire.ie"
@@ -213,12 +215,27 @@ export function ContactForm() {
                   <option value="" disabled>
                     Select a topic...
                   </option>
+                  <option value="Real Estate">
+                    Real Estate / Property Media
+                  </option>
                   <option value="Licensing">Commercial Licensing</option>
                   <option value="Prints">Fine Art Prints</option>
                   <option value="Commission">Commission / Drone Work</option>
                   <option value="Support">Technical Support</option>
                   <option value="Other">Other Inquiry</option>
                 </select>
+                {formData.subject === "Real Estate" ? (
+                  <p className="mt-2 text-sm leading-relaxed text-gray-400">
+                    For a detailed property shoot request, you can also use our{" "}
+                    <Link
+                      href="/real-estate"
+                      className="font-medium text-brand-500 hover:underline"
+                    >
+                      Real Estate Enquiry Form
+                    </Link>
+                    .
+                  </p>
+                ) : null}
               </div>
 
               <div>

--- a/openeire-next/tests/contactForm.test.tsx
+++ b/openeire-next/tests/contactForm.test.tsx
@@ -1,0 +1,91 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ContactForm } from "@/components/contact/ContactForm";
+
+const mocks = vi.hoisted(() => ({
+  send: vi.fn(),
+  consent: vi.fn(),
+}));
+
+vi.mock("@/components/ui/ToastProvider", () => ({
+  useToast: () => ({ showToast: vi.fn() }),
+}));
+vi.mock("@/lib/api/publicForms", () => ({
+  sendContactMessage: mocks.send,
+  getApiErrorMessage: () => "Request failed",
+}));
+vi.mock("@/lib/iubendaConsent", () => ({
+  registerIubendaConsentForm: () => vi.fn(),
+  submitIubendaConsentForm: mocks.consent,
+}));
+
+describe("main contact form topics", () => {
+  afterEach(cleanup);
+
+  beforeEach(() => {
+    mocks.send.mockReset().mockResolvedValue({ message: "Email sent successfully" });
+    mocks.consent.mockReset();
+  });
+
+  it("keeps existing topics and offers a real-estate topic", () => {
+    render(<ContactForm />);
+
+    const topic = screen.getByLabelText("Topic") as HTMLSelectElement;
+    const options = Array.from(topic.options).map(({ text, value }) => ({
+      text,
+      value,
+    }));
+
+    expect(options).toEqual(
+      expect.arrayContaining([
+        { text: "Real Estate / Property Media", value: "Real Estate" },
+        { text: "Commercial Licensing", value: "Licensing" },
+        { text: "Fine Art Prints", value: "Prints" },
+        { text: "Commission / Drone Work", value: "Commission" },
+        { text: "Technical Support", value: "Support" },
+        { text: "Other Inquiry", value: "Other" },
+      ]),
+    );
+  });
+
+  it("shows a non-blocking link to the detailed real-estate form", () => {
+    render(<ContactForm />);
+
+    expect(screen.queryByText("Real Estate Enquiry Form")).toBeNull();
+    fireEvent.change(screen.getByLabelText("Topic"), {
+      target: { value: "Real Estate" },
+    });
+
+    const helperLink = screen.getByText("Real Estate Enquiry Form");
+    expect(helperLink.getAttribute("href")).toBe("/real-estate");
+    expect(screen.getByRole("button", { name: "Send Message" })).toBeTruthy();
+  });
+
+  it("submits the existing contact payload with the stable real-estate value", async () => {
+    render(<ContactForm />);
+
+    fireEvent.change(screen.getByLabelText("Your Name"), {
+      target: { value: "Jane Owner" },
+    });
+    fireEvent.change(screen.getByLabelText("Email Address"), {
+      target: { value: "jane@example.com" },
+    });
+    fireEvent.change(screen.getByLabelText("Topic"), {
+      target: { value: "Real Estate" },
+    });
+    fireEvent.change(screen.getByLabelText("Message"), {
+      target: { value: "  I have a quick property-media question.  " },
+    });
+    fireEvent.submit(document.getElementById("contact-form")!);
+
+    await waitFor(() => expect(mocks.send).toHaveBeenCalledTimes(1));
+    expect(mocks.send).toHaveBeenCalledWith({
+      name: "Jane Owner",
+      email: "jane@example.com",
+      subject: "Real Estate",
+      message: "I have a quick property-media question.",
+    });
+    expect(mocks.consent).toHaveBeenCalledWith("contact-form");
+  });
+});


### PR DESCRIPTION
## What changed
- add a visible `Real Estate / Property Media` topic that submits the stable value `Real Estate`
- show a non-blocking helper link to the detailed `/real-estate` enquiry form when that topic is selected
- update contact-page introduction, email guidance, metadata title, and description to cover property media, prints, commercial licensing, and drone work
- add tests for the new value, helper link, unchanged existing topics, payload shape, and Iubenda consent submission

## Why
The main contact form should support quick general property-media questions while keeping detailed shoot requests in the dedicated real-estate flow.

## Impact
The existing contact API payload shape and email workflow are unchanged apart from the new accepted subject value. The dedicated real-estate enquiry form remains available and is not replaced or redirected.

## Validation
- focused contact-form tests: 3 passed
- complete frontend suite: 28 passed
- ESLint passed
- TypeScript check passed
- production Next.js build passed
- `git diff --check` passed