### PR TITLE
Update real-estate package guidance

### DIFF
--- a/openeire-next/app/real-estate/page.tsx
+++ b/openeire-next/app/real-estate/page.tsx
@@ -11,7 +11,15 @@ import {
   getOfficialSameAsLinks,
 } from "@/lib/site";
 import { buildPageMetadata } from "@/lib/seo/metadata";
-import { REAL_ESTATE_VAT_NOTE } from "@/lib/realEstate";
+import {
+  REAL_ESTATE_ADDITIONAL_PHOTOGRAPH_COPY,
+  REAL_ESTATE_PACKAGES,
+  REAL_ESTATE_RUSH_DELIVERY_LABEL,
+  REAL_ESTATE_RUSH_DELIVERY_NOTE,
+  REAL_ESTATE_STANDARD_TURNAROUND_COPY,
+  REAL_ESTATE_TURNAROUND_CONTEXT,
+  REAL_ESTATE_VAT_NOTE,
+} from "@/lib/realEstate";
 import {
   buildBreadcrumbJsonLd,
   buildFaqPageJsonLd,
@@ -36,92 +44,28 @@ type RealEstatePackage = {
   features: readonly string[];
 };
 
+const realEstatePhotoAllowances = REAL_ESTATE_PACKAGES.flatMap(
+  ({ includedPhotographs }) =>
+    includedPhotographs === null ? [] : [includedPhotographs],
+).join(", ");
+
 export const metadata = buildPageMetadata({
   title: "Real Estate Photography & Drone Video in Connacht | OpenÉire Studios",
-  description:
-    "Real estate photography, drone video and 3D tours for estate agents, developers and sellers across Connacht. Packages from €175 total.",
+  description: `Real estate photography packages with ${realEstatePhotoAllowances} professionally edited photographs, drone video and 3D tours across Connacht, with package-aware business-day turnaround.`,
   path: "/real-estate",
   image: "/hero-poster.jpg",
 });
 
-const packages: readonly RealEstatePackage[] = [
-  {
-    key: "essential",
-    name: "Essential",
-    price: "€175 total",
-    description:
-      "Recommended for smaller properties, rentals, starter listings.",
-    features: [
-      "10 professionally edited interior & exterior photographs",
-      "Full resolution delivery, print & web ready",
-      "24-hour delivery (in normal operating conditions)",
-      "Commercial marketing licence for this specific property listing, including Daft.ie, MyHome.ie, agency websites, social media, email campaigns and print brochures, for the duration of the active listing (up to 2 years, non-transferable).",
-    ],
-  },
-  {
-    key: "starter",
-    name: "Starter",
-    price: "€229 total",
-    description: "Recommended for standard 3-4 bed residential properties.",
-    features: [
-      "20 professionally edited interior & exterior photographs",
-      "5-8 high-quality aerial drone stills",
-      "Full resolution delivery, print & web ready",
-      "24-hour delivery (in normal operating conditions)",
-      "Commercial marketing licence",
-    ],
-  },
-  {
-    key: "pro",
-    name: "Pro",
-    price: "€399 total",
-    badge: "Recommended",
-    description:
-      "Recommended for detached homes, larger properties, new builds, agents wanting standout listings.",
-    features: [
-      "25 professionally edited interior & exterior photographs",
-      "5-8 high-quality aerial drone stills",
-      "60-90 seconds of interior & exterior video, fully edited with music",
-      "Aerial drone video, 60-90 seconds, 4K, edited with music",
-      "Social media cuts included, portrait 9:16 and square 1:1 formatted reels",
-      "Full resolution delivery, print & web ready",
-      "24-hour delivery (in normal operating conditions)",
-      "Commercial marketing licence",
-    ],
-  },
-  {
-    key: "premium",
-    name: "Premium",
-    price: "€579 total",
-    description:
-      "Recommended for premium listings, larger homes, waterfront/rural properties, new developments, and properties where presentation is a major selling point.",
-    features: [
-      "30 professionally edited interior & exterior photographs",
-      "5-8 high-quality aerial drone stills",
-      "60-90 seconds of interior & exterior video, fully edited with music",
-      "Aerial drone video, 60-90 seconds, 4K, edited with music",
-      "Social media cuts included, portrait 9:16 and square 1:1 formatted reels",
-      "3D interactive virtual tour, hosted, shareable link",
-      "Floor plan, 2D measured",
-      "Full resolution delivery, print & web ready",
-      "24-hour delivery (in normal operating conditions)",
-      "Commercial marketing licence",
-    ],
-  },
-  {
-    key: "custom",
-    name: "Custom",
-    price: "POA",
-    description:
-      "For multi-property shoots, large developments, commercial properties, agricultural properties and bespoke bundles.",
-    features: [
-      "Multiple properties in a single booking",
-      "Cinematic property films",
-      "Commercial or agricultural properties",
-      "Developer packages",
-    ],
-  },
-] as const;
+const packages: readonly RealEstatePackage[] = REAL_ESTATE_PACKAGES.map(
+  (packageItem) => ({
+    key: packageItem.id,
+    name: packageItem.name,
+    price: packageItem.price,
+    badge: "badge" in packageItem ? packageItem.badge : undefined,
+    description: packageItem.description,
+    features: packageItem.features,
+  }),
+);
 
 const listingFeatures = [
   {
@@ -136,8 +80,8 @@ const listingFeatures = [
   },
   {
     icon: <FaCalendarAlt />,
-    title: "Fast delivery",
-    text: "Listing‑ready files delivered within 24 hours after the shoot, once access and brief details have been provided and conditions allow safe and lawful capture.",
+    title: "Package-aware turnaround",
+    text: REAL_ESTATE_STANDARD_TURNAROUND_COPY,
   },
   {
     icon: <FaHome />,
@@ -153,8 +97,8 @@ const listingFeatures = [
 
 const addOns = [
   {
-    label: "Additional edited stills",
-    price: "€10 total per image",
+    label: "Additional edited photographs",
+    price: "€10 total per photograph",
   },
   {
     label: "Floor plan, 2D measured (included in Premium package)",
@@ -165,7 +109,7 @@ const addOns = [
     price: "€150 total",
   },
   {
-    label: "Rush same-day delivery, stills only",
+    label: REAL_ESTATE_RUSH_DELIVERY_LABEL,
     price: "€75 total",
   },
   {
@@ -208,8 +152,7 @@ const faqs = [
   },
   {
     question: "How quickly will I receive the media?",
-    answer:
-      "All packages are delivered within 24 hours after the shoot, once access and brief details have been provided and conditions allow safe and lawful capture.",
+    answer: `${REAL_ESTATE_STANDARD_TURNAROUND_COPY} ${REAL_ESTATE_TURNAROUND_CONTEXT}`,
   },
   {
     question: "Can you fly the drone at every property?",
@@ -248,36 +191,13 @@ const faqs = [
   },
 ] as const;
 
-const realEstatePackageOffers = [
-  {
-    name: "Essential real estate media package",
-    price: "175",
-    description: `€175 total. Includes 10 edited photos. ${REAL_ESTATE_VAT_NOTE}`,
-  },
-  {
-    name: "Starter real estate media package",
-    price: "229",
-    description:
-      `€229 total. Includes 20 edited photos and 5-8 aerial drone stills. ${REAL_ESTATE_VAT_NOTE}`,
-  },
-  {
-    name: "Pro real estate media package",
-    price: "399",
-    description:
-      `€399 total. Includes 25 edited photos, drone stills, a 60-90 second 4K aerial video and social cuts. ${REAL_ESTATE_VAT_NOTE}`,
-  },
-  {
-    name: "Premium real estate media package",
-    price: "579",
-    description:
-      `€579 total. Includes 30 edited photos, drone stills, a 60-90 second 4K aerial video, social cuts, 3D virtual tour and 2D measured floor plan. ${REAL_ESTATE_VAT_NOTE}`,
-  },
-  {
-    name: "Custom real estate media package",
-    description:
-      "POA. Tailored pricing for multi-property shoots, larger developments, commercial properties and bespoke bundles.",
-  },
-] as const;
+const realEstatePackageOffers = REAL_ESTATE_PACKAGES.map((packageItem) => ({
+  name: `${packageItem.name} real estate media package`,
+  description: `${packageItem.price}. Includes ${packageItem.text} ${REAL_ESTATE_VAT_NOTE}`,
+  ...(packageItem.priceAmount !== null
+    ? { price: String(packageItem.priceAmount) }
+    : {}),
+}));
 
 const schema = [
   buildBreadcrumbJsonLd([
@@ -362,9 +282,9 @@ export default function RealEstatePage() {
               video and 3D tours with clear pricing.
             </h1>
             <p className="mt-6 max-w-2xl text-lg leading-relaxed text-gray-300 md:text-xl">
-              One visit, listing-ready media and 24-hour delivery after the
-              shoot — for estate agents, developers and private sellers across
-              Connacht.
+              One visit, listing-ready media and a clear package-aware
+              turnaround — for estate agents, developers and private sellers
+              across Connacht.
             </p>
             <p className="mt-4 max-w-2xl text-xs font-bold uppercase tracking-[0.18em] text-gray-400">
               Interior & exterior photography • Aerial drone video • Social
@@ -394,7 +314,7 @@ export default function RealEstatePage() {
               {[
                 "Photography packages from €175 total",
                 "Full commercial marketing licence included",
-                "24-hour delivery after the shoot",
+                "Next-business-day or two-business-day standard turnaround by package",
                 "Drone capture planned around safe operating conditions",
                 "Commercially insured with €6.5m cover",
               ].map((item) => (
@@ -456,6 +376,9 @@ export default function RealEstatePage() {
               {REAL_ESTATE_VAT_NOTE} Travel
               supplement applies beyond 40 km from base.
             </p>
+            <p className="mt-3 text-sm leading-relaxed text-gray-500">
+              {REAL_ESTATE_TURNAROUND_CONTEXT}
+            </p>
           </div>
 
           <SwipeHint className="md:hidden" />
@@ -516,6 +439,12 @@ export default function RealEstatePage() {
             <p className="mt-5 text-lg leading-relaxed text-gray-400">
               Build a clean scope around the property rather than paying for
               extras you do not need.
+            </p>
+            <p className="mt-4 text-sm leading-relaxed text-gray-300">
+              {REAL_ESTATE_ADDITIONAL_PHOTOGRAPH_COPY}
+            </p>
+            <p className="mt-4 text-sm leading-relaxed text-amber-100">
+              {REAL_ESTATE_RUSH_DELIVERY_NOTE}
             </p>
           </div>
           <SwipeHint className="md:hidden" />

--- a/openeire-next/components/real-estate/RealEstateEnquiryForm.tsx
+++ b/openeire-next/components/real-estate/RealEstateEnquiryForm.tsx
@@ -363,7 +363,7 @@ export function RealEstateEnquiryForm() {
         `[data-error-field="${field}"], [name="${field}"]:not([type="hidden"])`,
       );
       control?.focus();
-      control?.scrollIntoView({ block: "center", behavior: "smooth" });
+      control?.scrollIntoView?.({ block: "center", behavior: "smooth" });
     });
   };
 

--- a/openeire-next/components/real-estate/RealEstateEnquiryForm.tsx
+++ b/openeire-next/components/real-estate/RealEstateEnquiryForm.tsx
@@ -18,7 +18,14 @@ import {
   registerIubendaConsentForm,
   submitIubendaConsentForm,
 } from "@/lib/iubendaConsent";
-import { REAL_ESTATE_VAT_NOTE } from "@/lib/realEstate";
+import {
+  REAL_ESTATE_ADDITIONAL_PHOTOGRAPH_COPY,
+  REAL_ESTATE_ENQUIRY_PACKAGES,
+  REAL_ESTATE_RUSH_DELIVERY_LABEL,
+  REAL_ESTATE_RUSH_DELIVERY_NOTE,
+  REAL_ESTATE_VAT_NOTE,
+  getRealEstateTurnaround,
+} from "@/lib/realEstate";
 import type {
   AddOnKey,
   ClientType,
@@ -133,7 +140,6 @@ const initialFormData: FormData = {
   consent_to_contact: false,
 };
 
-const packages = ["essential", "starter", "pro", "premium", "custom", "not_sure"] as const;
 const counties = [
   "Carlow", "Cavan", "Clare", "Cork", "Donegal", "Dublin", "Galway", "Kerry",
   "Kildare", "Kilkenny", "Laois", "Leitrim", "Limerick", "Longford", "Louth",
@@ -141,10 +147,10 @@ const counties = [
   "Waterford", "Westmeath", "Wexford", "Wicklow",
 ];
 const addOns: Array<{ key: AddOnKey; label: string; price: string }> = [
-  { key: "additional_stills", label: "Additional edited stills", price: "€10 per image (maximum 50)" },
+  { key: "additional_stills", label: "Additional edited photographs", price: "€10 per photograph (maximum 50)" },
   { key: "floor_plan", label: "2D measured floor plan", price: "€75" },
   { key: "virtual_tour_3d", label: "Hosted 3D virtual tour", price: "€150" },
-  { key: "rush_delivery", label: "Rush same-day delivery — still photographs only", price: "€75" },
+  { key: "rush_delivery", label: REAL_ESTATE_RUSH_DELIVERY_LABEL, price: "€75" },
   { key: "extended_drone_video", label: "Extended drone video, up to 3 minutes", price: "€150" },
   { key: "additional_social_cuts", label: "Additional social formats / cuts", price: "€50" },
 ];
@@ -218,7 +224,10 @@ export function RealEstateEnquiryForm() {
 
   useEffect(() => {
     const requested = new URLSearchParams(window.location.search).get("package")?.trim();
-    if (requested && packages.includes(requested as PackageType)) {
+    if (
+      requested &&
+      REAL_ESTATE_ENQUIRY_PACKAGES.some(({ id }) => id === requested)
+    ) {
       setFormData((current) => ({ ...current, preferred_package: requested as PackageType }));
     }
   }, []);
@@ -434,6 +443,9 @@ export function RealEstateEnquiryForm() {
 
   const option = (value: string, label: string) => <option key={value} value={value}>{label}</option>;
   const shownAddOns = addOns.filter(({ key }) => !conflicts[formData.preferred_package as PackageType]?.includes(key));
+  const selectedPackage = REAL_ESTATE_ENQUIRY_PACKAGES.find(
+    ({ id }) => id === formData.preferred_package,
+  );
 
   if (status === "success") {
     return (
@@ -471,7 +483,28 @@ export function RealEstateEnquiryForm() {
               <Field inputId="real-estate-phone" label="Phone" required error={errors.phone}><input id="real-estate-phone" name="phone" type="tel" value={formData.phone} onChange={change} className={inputClass} autoComplete="tel" {...a11y("phone")} /></Field>
               <Field inputId="real-estate-client-type" label="Client type" required error={errors.client_type}><select id="real-estate-client-type" name="client_type" value={formData.client_type} onChange={change} className={inputClass} {...a11y("client_type")}><option value="">Select…</option>{option("estate_agent", "Estate agent")}{option("developer", "Developer")}{option("private_seller", "Private seller")}{option("landlord", "Landlord")}{option("other", "Other")}</select></Field>
               <Field inputId="real-estate-company-name" label="Company / agency name" required={["estate_agent", "developer"].includes(formData.client_type)} error={errors.company_name}><input id="real-estate-company-name" name="company_name" value={formData.company_name} onChange={change} className={inputClass} autoComplete="organization" {...a11y("company_name")} /></Field>
-              <Field inputId="real-estate-preferred-package" label="Preferred package" required error={errors.preferred_package}><select id="real-estate-preferred-package" name="preferred_package" value={formData.preferred_package} onChange={change} className={inputClass} {...a11y("preferred_package")}><option value="">Choose deliberately…</option>{option("essential", "Essential — €175")}{option("starter", "Starter — €229")}{option("pro", "Pro — €399")}{option("premium", "Premium — €579")}{option("custom", "Custom — POA")}{option("not_sure", "Not sure")}</select></Field>
+              <Field inputId="real-estate-preferred-package" label="Preferred package" required error={errors.preferred_package}>
+                <select id="real-estate-preferred-package" name="preferred_package" value={formData.preferred_package} onChange={change} className={inputClass} {...a11y("preferred_package")}>
+                  <option value="">Choose deliberately…</option>
+                  {REAL_ESTATE_ENQUIRY_PACKAGES.map((packageItem) =>
+                    option(
+                      packageItem.id,
+                      packageItem.id === "not_sure"
+                        ? packageItem.name
+                        : `${packageItem.name} — ${packageItem.price.replace(" total", "")}`,
+                    ),
+                  )}
+                </select>
+                {formData.preferred_package ? (
+                  <div className="mt-2 space-y-1 text-sm leading-relaxed text-gray-400">
+                    <p>{selectedPackage?.includedPhotographsLabel}.</p>
+                    <p>
+                      <strong>{getRealEstateTurnaround(formData.preferred_package).label}.</strong>
+                    </p>
+                    <p>{getRealEstateTurnaround(formData.preferred_package).detail}</p>
+                  </div>
+                ) : null}
+              </Field>
             </div>
           </Section>
 
@@ -528,8 +561,8 @@ export function RealEstateEnquiryForm() {
           <Section title="Optional add-ons">
             {packageNotice ? <p role="status" className="rounded-xl bg-amber-400/10 p-3 text-sm text-amber-100">{packageNotice}</p> : null}
             <div className="grid gap-3 md:grid-cols-2">{shownAddOns.map((item) => <label key={item.key} className="flex gap-3 rounded-xl border border-white/10 p-4"><input type="checkbox" name="add_ons" value={item.key} checked={formData.add_ons.includes(item.key)} onChange={() => toggleAddOn(item.key)} /><span><strong className="block">{item.label}</strong><span className="text-sm text-gray-500">{item.price}</span></span></label>)}</div>
-            {formData.add_ons.includes("additional_stills") ? <Field inputId="real-estate-additional-stills-quantity" label="Number of additional edited stills" required error={errors.additional_stills_quantity}><input id="real-estate-additional-stills-quantity" name="additional_stills_quantity" type="number" min="1" max="50" step="1" value={formData.additional_stills_quantity} onChange={change} className={inputClass} {...a11y("additional_stills_quantity")} /></Field> : null}
-            {formData.add_ons.includes("rush_delivery") && ["pro", "premium"].includes(formData.preferred_package) ? <p className="text-sm text-amber-200">Rush delivery applies to still photographs only. Video follows the normal agreed schedule.</p> : null}
+            {formData.add_ons.includes("additional_stills") ? <Field inputId="real-estate-additional-stills-quantity" label="Number of additional edited photographs" required error={errors.additional_stills_quantity} hint={REAL_ESTATE_ADDITIONAL_PHOTOGRAPH_COPY}><input id="real-estate-additional-stills-quantity" name="additional_stills_quantity" type="number" min="1" max="50" step="1" value={formData.additional_stills_quantity} onChange={change} className={inputClass} {...a11y("additional_stills_quantity")} /></Field> : null}
+            {formData.add_ons.includes("rush_delivery") ? <p className="text-sm text-amber-200">{REAL_ESTATE_RUSH_DELIVERY_NOTE}</p> : null}
             <p className="text-xs text-gray-500">{REAL_ESTATE_VAT_NOTE}</p>
           </Section>
 

--- a/openeire-next/lib/realEstate.ts
+++ b/openeire-next/lib/realEstate.ts
@@ -1,35 +1,194 @@
 export const REAL_ESTATE_VAT_NOTE =
   "OpenÉire Studios is not currently VAT registered. No VAT is charged.";
 
+export type RealEstatePackageId =
+  | "essential"
+  | "starter"
+  | "pro"
+  | "premium"
+  | "custom"
+  | "not_sure";
+
+export const REAL_ESTATE_TURNAROUNDS = {
+  essential: {
+    code: "next_business_day",
+    label: "Next-business-day delivery",
+    detail:
+      "This package is normally delivered by the end of the next business day.",
+  },
+  starter: {
+    code: "next_business_day",
+    label: "Next-business-day delivery",
+    detail:
+      "This package is normally delivered by the end of the next business day.",
+  },
+  pro: {
+    code: "two_business_days",
+    label: "Delivery within 2 business days",
+    detail:
+      "This package is normally delivered within two business days due to the additional video-production workload.",
+  },
+  premium: {
+    code: "two_business_days",
+    label: "Delivery within 2 business days",
+    detail:
+      "This package is normally delivered within two business days due to the additional video-production workload.",
+  },
+  custom: {
+    code: "specifically_agreed",
+    label: "Turnaround as specifically agreed",
+    detail: "Turnaround will be set out in the specifically agreed quotation.",
+  },
+  not_sure: {
+    code: "specifically_agreed",
+    label: "Turnaround as specifically agreed",
+    detail: "Turnaround will be set out in the specifically agreed quotation.",
+  },
+} as const satisfies Record<
+  RealEstatePackageId,
+  { code: string; label: string; detail: string }
+>;
+
+export const REAL_ESTATE_STANDARD_TURNAROUND_COPY =
+  "Essential and Starter packages are normally delivered by the end of the next business day. Pro and Premium packages are normally delivered within two business days due to the additional video-production workload.";
+
+export const REAL_ESTATE_TURNAROUND_CONTEXT =
+  "Turnaround begins once the shoot is complete and all required property and client information has been supplied. Weather-dependent return visits and agreed changes to the scope may affect delivery.";
+
+export const REAL_ESTATE_RUSH_DELIVERY_LABEL =
+  "Rush same-day delivery — still photography only";
+
+export const REAL_ESTATE_RUSH_DELIVERY_NOTE =
+  "The €75 rush add-on covers still photography only. It does not rush drone video, ground video, social-media video cuts, 3D virtual tours, floor plans or other Premium outputs.";
+
+export const getRealEstateTurnaround = (packageId: RealEstatePackageId) =>
+  REAL_ESTATE_TURNAROUNDS[packageId];
+
+export const REAL_ESTATE_ADDITIONAL_PHOTOGRAPH_PRICE = 10;
+export const REAL_ESTATE_ADDITIONAL_PHOTOGRAPH_COPY =
+  "Additional edited photographs may be agreed at €10 per photograph.";
+
 export const REAL_ESTATE_PACKAGES = [
   {
     id: "essential",
     name: "Essential",
     price: "\u20AC175 total",
-    text: "10 professionally edited interior and exterior photographs, full-resolution delivery, 24-hour turnaround, and listing marketing licence.",
+    priceAmount: 175,
+    includedPhotographs: 10,
+    includedPhotographsLabel:
+      "10 professionally edited interior and exterior photographs",
+    description: "Recommended for smaller properties, rentals, starter listings.",
+    features: [
+      "10 professionally edited interior & exterior photographs",
+      "Full resolution delivery, print & web ready",
+      REAL_ESTATE_TURNAROUNDS.essential.label,
+      "Commercial marketing licence for this specific property listing, including Daft.ie, MyHome.ie, agency websites, social media, email campaigns and print brochures, for the duration of the active listing (up to 2 years, non-transferable).",
+    ],
+    text: `10 professionally edited interior and exterior photographs, full-resolution delivery, ${REAL_ESTATE_TURNAROUNDS.essential.label.toLowerCase()}, and listing marketing licence.`,
+    turnaround: REAL_ESTATE_TURNAROUNDS.essential,
   },
   {
     id: "starter",
     name: "Starter",
     price: "\u20AC229 total",
-    text: "20 professionally edited photographs for standard 3-4 bed residential properties, delivered print and web ready.",
+    priceAmount: 229,
+    includedPhotographs: 25,
+    includedPhotographsLabel:
+      "25 professionally edited interior and exterior photographs",
+    description: "Recommended for standard 3-4 bed residential properties.",
+    features: [
+      "25 professionally edited interior & exterior photographs",
+      "5-8 high-quality aerial drone stills",
+      "Full resolution delivery, print & web ready",
+      REAL_ESTATE_TURNAROUNDS.starter.label,
+      "Commercial marketing licence",
+    ],
+    text: `25 professionally edited interior and exterior photographs, 5-8 aerial drone photographs, full-resolution delivery, ${REAL_ESTATE_TURNAROUNDS.starter.label.toLowerCase()}, and listing marketing licence.`,
+    turnaround: REAL_ESTATE_TURNAROUNDS.starter,
   },
   {
     id: "pro",
     name: "Pro",
     price: "\u20AC399 total",
-    text: "20 edited photographs, 60-90 second 4K aerial drone video, social media cuts, 24-hour delivery, and marketing licence.",
+    priceAmount: 399,
+    includedPhotographs: 30,
+    includedPhotographsLabel:
+      "30 professionally edited interior and exterior photographs",
+    badge: "Recommended",
+    description:
+      "Recommended for detached homes, larger properties, new builds, agents wanting standout listings.",
+    features: [
+      "30 professionally edited interior & exterior photographs",
+      "5-8 high-quality aerial drone stills",
+      "60-90 seconds of interior & exterior video, fully edited with music",
+      "Aerial drone video, 60-90 seconds, 4K, edited with music",
+      "Social media cuts included, portrait 9:16 and square 1:1 formatted reels",
+      "Full resolution delivery, print & web ready",
+      REAL_ESTATE_TURNAROUNDS.pro.label,
+      "Commercial marketing licence",
+    ],
+    text: `30 professionally edited interior and exterior photographs, 5-8 aerial drone photographs, 60-90 second ground video, 60-90 second 4K aerial drone video, portrait and square social-media cuts, ${REAL_ESTATE_TURNAROUNDS.pro.label.toLowerCase()}, and listing marketing licence.`,
+    turnaround: REAL_ESTATE_TURNAROUNDS.pro,
   },
   {
     id: "premium",
     name: "Premium",
     price: "\u20AC579 total",
-    text: "Photography, aerial drone video, social cuts, and a 3D interactive virtual tour for premium or high-impact listings.",
+    priceAmount: 579,
+    includedPhotographs: 35,
+    includedPhotographsLabel:
+      "35 professionally edited interior and exterior photographs",
+    description:
+      "Recommended for premium listings, larger homes, waterfront/rural properties, new developments, and properties where presentation is a major selling point.",
+    features: [
+      "35 professionally edited interior & exterior photographs",
+      "5-8 high-quality aerial drone stills",
+      "60-90 seconds of interior & exterior video, fully edited with music",
+      "Aerial drone video, 60-90 seconds, 4K, edited with music",
+      "Social media cuts included, portrait 9:16 and square 1:1 formatted reels",
+      "3D interactive virtual tour, hosted, shareable link",
+      "Floor plan, 2D measured",
+      "Full resolution delivery, print & web ready",
+      REAL_ESTATE_TURNAROUNDS.premium.label,
+      "Commercial marketing licence",
+    ],
+    text: `35 professionally edited interior and exterior photographs, 5-8 aerial drone photographs, ground video, aerial drone video, standard social-media cuts, hosted 3D virtual tour, 2D measured floor plan, ${REAL_ESTATE_TURNAROUNDS.premium.label.toLowerCase()}, and listing marketing licence.`,
+    turnaround: REAL_ESTATE_TURNAROUNDS.premium,
   },
   {
     id: "custom",
     name: "Custom",
     price: "POA",
-    text: "For multi-property shoots, large developments, commercial properties, agricultural properties, and bespoke bundles.",
+    priceAmount: null,
+    includedPhotographs: null,
+    includedPhotographsLabel: "Included photographs as specifically agreed",
+    description:
+      "For multi-property shoots, large developments, commercial properties, agricultural properties and bespoke bundles.",
+    features: [
+      "Included photographs as specifically agreed",
+      "Multiple properties in a single booking",
+      "Cinematic property films",
+      "Commercial or agricultural properties",
+      "Developer packages",
+      REAL_ESTATE_TURNAROUNDS.custom.label,
+    ],
+    text: `For multi-property shoots, large developments, commercial properties, agricultural properties, and bespoke bundles. ${REAL_ESTATE_TURNAROUNDS.custom.label}.`,
+    turnaround: REAL_ESTATE_TURNAROUNDS.custom,
   },
 ] as const;
+
+export const REAL_ESTATE_ENQUIRY_PACKAGES = [
+  ...REAL_ESTATE_PACKAGES,
+  {
+    id: "not_sure",
+    name: "Not sure",
+    price: "Specifically agreed",
+    priceAmount: null,
+    includedPhotographs: null,
+    includedPhotographsLabel: "Included photographs as specifically agreed",
+    turnaround: REAL_ESTATE_TURNAROUNDS.not_sure,
+  },
+] as const;
+
+export const getRealEstatePackage = (packageId: RealEstatePackageId) =>
+  REAL_ESTATE_ENQUIRY_PACKAGES.find(({ id }) => id === packageId);

--- a/openeire-next/tests/realEstateEnquiryForm.test.tsx
+++ b/openeire-next/tests/realEstateEnquiryForm.test.tsx
@@ -79,6 +79,24 @@ describe("real-estate shoot scoping form", () => {
     );
   });
 
+  it("shows package-aware turnaround without fabricating a custom deadline", () => {
+    render(<RealEstateEnquiryForm />);
+
+    select("preferred_package", "essential");
+    expect(screen.getByText("Next-business-day delivery.")).toBeTruthy();
+
+    select("preferred_package", "pro");
+    expect(screen.getByText("Delivery within 2 business days.")).toBeTruthy();
+
+    select("preferred_package", "custom");
+    expect(screen.getByText("Turnaround as specifically agreed.")).toBeTruthy();
+    expect(
+      screen.getByText(
+        "Turnaround will be set out in the specifically agreed quotation.",
+      ),
+    ).toBeTruthy();
+  });
+
   it("reveals conditional company, location, scope, access and presenter fields", () => {
     render(<RealEstateEnquiryForm />);
     select("client_type", "estate_agent");
@@ -145,13 +163,37 @@ describe("real-estate shoot scoping form", () => {
     expect(screen.queryByLabelText(/Additional social formats/)).toBeNull();
   });
 
+  it("shows catalogue-driven included-photograph guidance for the selected package", () => {
+    render(<RealEstateEnquiryForm />);
+
+    select("preferred_package", "starter");
+    expect(
+      screen.getByText(/25 professionally edited interior and exterior photographs/),
+    ).toBeTruthy();
+
+    select("preferred_package", "premium");
+    expect(
+      screen.getByText(/35 professionally edited interior and exterior photographs/),
+    ).toBeTruthy();
+  });
+
   it("requires a bounded additional-stills quantity", () => {
     render(<RealEstateEnquiryForm />);
-    fireEvent.click(screen.getByLabelText(/Additional edited stills/));
-    const quantity = screen.getByLabelText(/Number of additional edited stills/) as HTMLInputElement;
+    fireEvent.click(screen.getByLabelText(/Additional edited photographs/));
+    const quantity = screen.getByLabelText(/Number of additional edited photographs/) as HTMLInputElement;
     expect(quantity.min).toBe("1");
     expect(quantity.max).toBe("50");
     expect(quantity.step).toBe("1");
+    expect(screen.getAllByText(/€10 per photograph/)).toHaveLength(2);
+  });
+
+  it("makes clear that rush delivery does not cover video or premium outputs", () => {
+    render(<RealEstateEnquiryForm />);
+
+    fireEvent.click(screen.getByLabelText(/Rush same-day delivery/));
+
+    expect(screen.getByText(/does not rush drone video, ground video/)).toBeTruthy();
+    expect(screen.getByText(/3D virtual tours, floor plans/)).toBeTruthy();
   });
 
   it("submits the structured payload and preserves Iubenda consent handling", async () => {

--- a/openeire-next/tests/realEstatePricing.test.tsx
+++ b/openeire-next/tests/realEstatePricing.test.tsx
@@ -5,7 +5,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { RealEstateEnquiryForm } from "@/components/real-estate/RealEstateEnquiryForm";
 import {
+  REAL_ESTATE_ADDITIONAL_PHOTOGRAPH_COPY,
   REAL_ESTATE_PACKAGES,
+  REAL_ESTATE_RUSH_DELIVERY_LABEL,
+  REAL_ESTATE_RUSH_DELIVERY_NOTE,
+  REAL_ESTATE_TURNAROUNDS,
   REAL_ESTATE_VAT_NOTE,
 } from "@/lib/realEstate";
 
@@ -30,10 +34,92 @@ describe("active real-estate pricing", () => {
     window.history.replaceState({}, "", "/real-estate");
   });
 
-  it("publishes the Pro package as €399 total", () => {
-    const proPackage = REAL_ESTATE_PACKAGES.find(({ id }) => id === "pro");
+  it("publishes the authoritative package prices and photograph allowances", () => {
+    expect(
+      Object.fromEntries(
+        REAL_ESTATE_PACKAGES.map(
+          ({ id, priceAmount, includedPhotographs }) => [
+            id,
+            { priceAmount, includedPhotographs },
+          ],
+        ),
+      ),
+    ).toEqual({
+      essential: { priceAmount: 175, includedPhotographs: 10 },
+      starter: { priceAmount: 229, includedPhotographs: 25 },
+      pro: { priceAmount: 399, includedPhotographs: 30 },
+      premium: { priceAmount: 579, includedPhotographs: 35 },
+      custom: { priceAmount: null, includedPhotographs: null },
+    });
 
-    expect(proPackage?.price).toBe("€399 total");
+    const proPackage = REAL_ESTATE_PACKAGES.find(({ id }) => id === "pro");
+    expect(proPackage?.text).toContain(
+      "30 professionally edited interior and exterior photographs",
+    );
+    expect(proPackage?.text).toContain("60-90 second ground video");
+    expect(proPackage?.text).toContain("60-90 second 4K aerial drone video");
+    expect(REAL_ESTATE_ADDITIONAL_PHOTOGRAPH_COPY).toContain(
+      "€10 per photograph",
+    );
+  });
+
+  it("drives package cards and JSON-LD from the shared catalogue", () => {
+    const pageSource = fs.readFileSync(
+      path.join(process.cwd(), "app", "real-estate", "page.tsx"),
+      "utf8",
+    );
+
+    expect(pageSource).toContain(
+      "const packages: readonly RealEstatePackage[] = REAL_ESTATE_PACKAGES.map",
+    );
+    expect(pageSource).toContain(
+      "const realEstatePackageOffers = REAL_ESTATE_PACKAGES.map",
+    );
+    expect(pageSource).toContain(
+      "const realEstatePhotoAllowances = REAL_ESTATE_PACKAGES.flatMap",
+    );
+    expect(pageSource).not.toMatch(
+      /Includes (?:20|25|30) edited photos/,
+    );
+  });
+
+  it("mirrors the package-aware API turnaround contract", () => {
+    expect(REAL_ESTATE_TURNAROUNDS).toMatchObject({
+      essential: {
+        code: "next_business_day",
+        label: "Next-business-day delivery",
+      },
+      starter: {
+        code: "next_business_day",
+        label: "Next-business-day delivery",
+      },
+      pro: {
+        code: "two_business_days",
+        label: "Delivery within 2 business days",
+      },
+      premium: {
+        code: "two_business_days",
+        label: "Delivery within 2 business days",
+      },
+      custom: {
+        code: "specifically_agreed",
+        label: "Turnaround as specifically agreed",
+      },
+      not_sure: {
+        code: "specifically_agreed",
+        label: "Turnaround as specifically agreed",
+      },
+    });
+  });
+
+  it("limits the rush add-on to still photography", () => {
+    expect(REAL_ESTATE_RUSH_DELIVERY_LABEL).toContain("still photography only");
+    expect(REAL_ESTATE_RUSH_DELIVERY_NOTE).toContain(
+      "does not rush drone video, ground video, social-media video cuts",
+    );
+    expect(REAL_ESTATE_RUSH_DELIVERY_NOTE).toContain(
+      "3D virtual tours, floor plans or other Premium outputs",
+    );
   });
 
   it("renders the VAT non-registration note and active package options", () => {
@@ -76,6 +162,25 @@ describe("active real-estate pricing", () => {
     };
 
     activeDirectories.forEach((directory) => inspect(path.join(process.cwd(), directory)));
+    expect(violations).toEqual([]);
+  });
+
+  it("contains no blanket 24-hour delivery promise in active real-estate copy", () => {
+    const targets = [
+      path.join(process.cwd(), "app", "real-estate", "page.tsx"),
+      path.join(process.cwd(), "lib", "realEstate.ts"),
+    ];
+    const forbidden = [
+      /24-hour (?:delivery|turnaround)/i,
+      /delivered within 24 hours after the shoot/i,
+      /all packages are delivered within 24 hours/i,
+    ];
+
+    const violations = targets.filter((target) => {
+      const source = fs.readFileSync(target, "utf8");
+      return forbidden.some((pattern) => pattern.test(source));
+    });
+
     expect(violations).toEqual([]);
   });
 });


### PR DESCRIPTION
## What changed

- centralizes public real-estate package prices, photograph allowances, deliverables, and package-aware turnaround guidance
- updates new-work allowances to Essential 10, Starter 25, Pro 30, and Premium 35 photographs
- keeps Custom and Not sure scope specifically agreed
- updates package cards, enquiry guidance, add-on wording, metadata, and JSON-LD from the shared catalogue
- ensures the public form continues to submit schema version 2

## Deployment order

The corresponding backend PR petra66orii/openeire-api#169 has already passed CI and merged, so the API catalogue and historical-scope safeguards precede this frontend release.

## Validation

- 35 frontend tests passed
- focused package and enquiry tests passed
- ESLint passed
- TypeScript check passed
- production build passed
- `git diff --check` passed