### PR TITLE
Publish real-estate property media portfolio

### DIFF
--- a/openeire-next/app/layout.tsx
+++ b/openeire-next/app/layout.tsx
@@ -44,12 +44,12 @@ export default function RootLayout({
         <Script
           id="openeire-iubenda-widget"
           src="https://embeds.iubenda.com/widgets/b39f0cd0-25d9-49f2-9306-1258615676f2.js"
-          strategy="beforeInteractive"
+          strategy="afterInteractive"
         />
         <Script
           id={GA_SCRIPT_ID}
           src={GA_SCRIPT_SRC}
-          strategy="beforeInteractive"
+          strategy="afterInteractive"
         />
         <Providers>
           <div className="flex min-h-screen flex-col">

--- a/openeire-next/app/real-estate/page.tsx
+++ b/openeire-next/app/real-estate/page.tsx
@@ -488,6 +488,29 @@ export default function RealEstatePage() {
         </div>
       </section>
 
+      <section className="border-y border-white/10 bg-brand-900/40 py-16">
+        <div className="container mx-auto flex max-w-7xl flex-col items-start justify-between gap-8 px-4 md:flex-row md:items-center lg:px-8">
+          <div className="max-w-3xl">
+            <p className="text-xs font-bold uppercase tracking-[0.24em] text-accent">
+              Real estate media portfolio
+            </p>
+            <h2 className="mt-3 font-serif text-3xl font-bold md:text-4xl">
+              See how photography, film and listing assets work together.
+            </h2>
+            <p className="mt-4 leading-7 text-gray-300">
+              Explore the portfolio area for selected property work and the
+              media formats available for future listing briefs.
+            </p>
+          </div>
+          <a
+            href="/real-estate/portfolio"
+            className="inline-flex min-h-12 shrink-0 items-center justify-center rounded-full border border-white/25 px-7 py-3 text-center text-sm font-bold uppercase tracking-[0.16em] text-white hover:border-accent hover:text-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+          >
+            View the portfolio
+          </a>
+        </div>
+      </section>
+
       <section className="bg-gray-950 py-20">
         <div className="container mx-auto max-w-5xl px-4 text-center lg:px-8">
           <FaHome

--- a/openeire-next/app/real-estate/page.tsx
+++ b/openeire-next/app/real-estate/page.tsx
@@ -1,5 +1,7 @@
+import Link from "next/link";
 import { JsonLd } from "@/components/JsonLd";
 import { SwipeHint } from "@/components/marketing/MarketingPage";
+import { RealEstateHeroImage } from "@/components/real-estate/RealEstateHeroImage";
 import { RealEstateEnquiryForm } from "@/components/real-estate/RealEstateEnquiryForm";
 import {
   DEFAULT_SOCIAL_IMAGE_PATH,
@@ -20,6 +22,7 @@ import {
   REAL_ESTATE_TURNAROUND_CONTEXT,
   REAL_ESTATE_VAT_NOTE,
 } from "@/lib/realEstate";
+import { REAL_ESTATE_PORTFOLIO_PATH } from "@/lib/realEstatePresentation";
 import {
   buildBreadcrumbJsonLd,
   buildFaqPageJsonLd,
@@ -53,7 +56,6 @@ export const metadata = buildPageMetadata({
   title: "Real Estate Photography & Drone Video in Connacht | OpenÉire Studios",
   description: `Real estate photography packages with ${realEstatePhotoAllowances} professionally edited photographs, drone video and 3D tours across Connacht, with package-aware business-day turnaround.`,
   path: "/real-estate",
-  image: "/hero-poster.jpg",
 });
 
 const packages: readonly RealEstatePackage[] = REAL_ESTATE_PACKAGES.map(
@@ -225,7 +227,6 @@ const schema = [
     "@id": buildAbsoluteUrl("/real-estate#service"),
     name: `${SITE_NAME} Real Estate Media`,
     url: buildAbsoluteUrl("/real-estate"),
-    image: buildAbsoluteUrl("/hero-poster.jpg"),
     description:
       "Professional real estate photography, aerial drone video and 3D virtual tours for estate agents, developers and private sellers across Connacht.",
     serviceType: [
@@ -265,14 +266,17 @@ export default function RealEstatePage() {
       <JsonLd data={schema} />
 
       <section className="relative isolate overflow-hidden pt-[calc(var(--site-header-height,96px)+2rem)]">
+        <RealEstateHeroImage objectPositionClassName="object-[64%_center] sm:object-[68%_center] lg:object-[72%_center]" />
         <div
-          className="absolute inset-0 -z-20 bg-cover bg-center opacity-35"
-          style={{ backgroundImage: "url('/hero-poster.jpg')" }}
+          className="absolute inset-0 -z-10 bg-linear-to-r from-black/95 via-black/75 to-black/45 md:from-black/90 md:via-black/60 md:to-black/25"
           aria-hidden="true"
         />
-        <div className="absolute inset-0 -z-10 bg-linear-to-b from-black/80 via-black/80 to-black" />
-        <div className="container mx-auto grid min-h-[78vh] max-w-7xl items-center gap-12 px-4 py-20 lg:grid-cols-[1.08fr_0.92fr] lg:px-8">
-          <div className="max-w-4xl">
+        <div
+          className="absolute inset-0 -z-10 bg-linear-to-b from-transparent via-transparent to-black/65"
+          aria-hidden="true"
+        />
+        <div className="container mx-auto flex min-h-[78vh] max-w-7xl items-center px-4 py-20 lg:px-8">
+          <div className="max-w-3xl">
             <span className="mb-6 inline-flex items-center gap-2 rounded-full border border-accent/40 bg-accent/10 px-4 py-2 text-xs font-bold uppercase tracking-[0.24em] text-accent">
               <FaMapMarkerAlt aria-hidden="true" />
               Real estate media across Connacht
@@ -290,46 +294,52 @@ export default function RealEstatePage() {
               Interior & exterior photography • Aerial drone video • Social
               media cuts • 3D virtual tours
             </p>
-            <div className="mt-8 flex flex-col gap-3 sm:flex-row">
+            <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:flex-wrap">
               <a
                 href="#enquiry"
                 className="rounded-full bg-brand-500 px-7 py-4 text-center text-sm font-bold uppercase tracking-[0.18em] text-white shadow-lg shadow-brand-500/20 transition hover:bg-brand-600 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-offset-2 focus:ring-offset-black"
               >
                 Request a Property Shoot
               </a>
-              <a
-                href="#packages"
-                className="rounded-full border border-white/20 px-7 py-4 text-center text-sm font-bold uppercase tracking-[0.18em] text-white transition hover:border-brand-500 hover:text-brand-500 focus:outline-none focus:ring-2 focus:ring-brand-500 focus:ring-offset-2 focus:ring-offset-black"
+              <Link
+                href={REAL_ESTATE_PORTFOLIO_PATH}
+                className="rounded-full border border-white/30 bg-black/25 px-7 py-4 text-center text-sm font-bold uppercase tracking-[0.18em] text-white backdrop-blur transition hover:border-accent hover:text-accent focus:outline-none focus:ring-2 focus:ring-accent focus:ring-offset-2 focus:ring-offset-black"
               >
-                View Packages
-              </a>
+                View property portfolio
+              </Link>
             </div>
+            <a
+              href="#packages"
+              className="mt-5 inline-flex text-sm font-bold text-gray-200 underline decoration-white/35 underline-offset-4 transition hover:text-accent hover:decoration-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+            >
+              Compare packages and pricing
+            </a>
           </div>
+        </div>
+      </section>
 
-          <div className="rounded-4xl border border-white/10 bg-brand-500/6 p-6 shadow-2xl backdrop-blur md:p-8">
-            <p className="text-xs font-bold uppercase tracking-[0.24em] text-gray-400">
-              Launch-ready listing media
-            </p>
-            <div className="mt-6 grid gap-4">
-              {[
-                "Photography packages from €175 total",
-                "Full commercial marketing licence included",
-                "Next-business-day or two-business-day standard turnaround by package",
-                "Drone capture planned around safe operating conditions",
-                "Commercially insured with €6.5m cover",
-              ].map((item) => (
-                <div key={item} className="flex items-start gap-3">
-                  <FaCheckCircle
-                    className="mt-1 shrink-0 text-brand-500"
-                    aria-hidden="true"
-                  />
-                  <span className="text-sm leading-relaxed text-gray-200">
-                    {item}
-                  </span>
-                </div>
-              ))}
+      <section
+        aria-label="Property media service assurances"
+        className="border-y border-white/10 bg-gray-950"
+      >
+        <div className="container mx-auto grid max-w-7xl gap-px px-4 py-5 sm:grid-cols-2 lg:grid-cols-4 lg:px-8">
+          {[
+            "Photography packages from €175 total",
+            "Commercial marketing licence included",
+            "Package-aware business-day turnaround",
+            "Drone capture subject to safe conditions",
+          ].map((item) => (
+            <div
+              key={item}
+              className="flex items-start gap-3 border-white/10 py-3 sm:px-4 sm:odd:border-r lg:border-r lg:last:border-r-0"
+            >
+              <FaCheckCircle
+                className="mt-0.5 shrink-0 text-brand-500"
+                aria-hidden="true"
+              />
+              <span className="text-sm leading-6 text-gray-300">{item}</span>
             </div>
-          </div>
+          ))}
         </div>
       </section>
 
@@ -485,29 +495,6 @@ export default function RealEstatePage() {
             unsuitable, OpenÉire will offer one reschedule at no additional
             cost. Further reschedules may incur a fee.
           </div>
-        </div>
-      </section>
-
-      <section className="border-y border-white/10 bg-brand-900/40 py-16">
-        <div className="container mx-auto flex max-w-7xl flex-col items-start justify-between gap-8 px-4 md:flex-row md:items-center lg:px-8">
-          <div className="max-w-3xl">
-            <p className="text-xs font-bold uppercase tracking-[0.24em] text-accent">
-              Real estate media portfolio
-            </p>
-            <h2 className="mt-3 font-serif text-3xl font-bold md:text-4xl">
-              See how photography, film and listing assets work together.
-            </h2>
-            <p className="mt-4 leading-7 text-gray-300">
-              Explore the portfolio area for selected property work and the
-              media formats available for future listing briefs.
-            </p>
-          </div>
-          <a
-            href="/real-estate/portfolio"
-            className="inline-flex min-h-12 shrink-0 items-center justify-center rounded-full border border-white/25 px-7 py-3 text-center text-sm font-bold uppercase tracking-[0.16em] text-white hover:border-accent hover:text-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
-          >
-            View the portfolio
-          </a>
         </div>
       </section>
 

--- a/openeire-next/app/real-estate/portfolio/page.tsx
+++ b/openeire-next/app/real-estate/portfolio/page.tsx
@@ -1,0 +1,252 @@
+import Image from "next/image";
+import Link from "next/link";
+import {
+  FaCamera,
+  FaDraftingCompass,
+  FaFilm,
+  FaHelicopter,
+  FaMobileAlt,
+  FaPhotoVideo,
+} from "react-icons/fa";
+import { JsonLd } from "@/components/JsonLd";
+import { PortfolioProject } from "@/components/real-estate/PortfolioProject";
+import { PortfolioTrackedLink } from "@/components/real-estate/PortfolioTrackedLink";
+import {
+  getPublishedPortfolioProjects,
+} from "@/lib/realEstatePortfolio";
+import { buildPageMetadata } from "@/lib/seo/metadata";
+import {
+  buildPortfolioJsonLd,
+  REAL_ESTATE_PORTFOLIO_DESCRIPTION,
+  REAL_ESTATE_PORTFOLIO_TITLE,
+} from "@/lib/seo/realEstatePortfolioJsonLd";
+
+export const metadata = buildPageMetadata({
+  title: REAL_ESTATE_PORTFOLIO_TITLE,
+  description: REAL_ESTATE_PORTFOLIO_DESCRIPTION,
+  path: "/real-estate/portfolio",
+  image: "/hero-poster.jpg",
+});
+
+const services = [
+  {
+    icon: FaCamera,
+    title: "Interior and exterior photography",
+    text: "A considered sequence of rooms, details, exterior elevations and setting.",
+  },
+  {
+    icon: FaHelicopter,
+    title: "Aerial drone stills",
+    text: "Elevated context for land, access, surroundings and wider location.",
+  },
+  {
+    icon: FaFilm,
+    title: "Aerial video",
+    text: "Controlled aerial movement that helps establish scale and setting.",
+  },
+  {
+    icon: FaPhotoVideo,
+    title: "Ground property video",
+    text: "A natural visual walkthrough shaped around the property and listing brief.",
+  },
+  {
+    icon: FaMobileAlt,
+    title: "Social-media cuts",
+    text: "Purpose-made vertical and square edits for agent and listing channels.",
+  },
+  {
+    icon: FaDraftingCompass,
+    title: "Measured 2D floor plans",
+    text: "Clear layout information supplied as an optional listing asset.",
+  },
+] as const;
+
+const publishedProjects = getPublishedPortfolioProjects();
+
+export default function RealEstatePortfolioPage() {
+  return (
+    <div className="min-h-screen overflow-x-hidden bg-black text-white">
+      <JsonLd data={buildPortfolioJsonLd(publishedProjects)} />
+
+      <section className="relative isolate overflow-hidden pt-[calc(var(--site-header-height,96px)+2rem)]">
+        <Image
+          src="/hero-poster.jpg"
+          alt=""
+          fill
+          priority
+          sizes="100vw"
+          className="-z-20 object-cover object-center opacity-30"
+        />
+        <div
+          className="absolute inset-0 -z-10 bg-linear-to-b from-black/65 via-black/85 to-black"
+          aria-hidden="true"
+        />
+        <div className="container mx-auto flex min-h-[72vh] max-w-7xl items-center px-4 py-20 lg:px-8">
+          <div className="max-w-4xl">
+            <p className="text-xs font-bold uppercase tracking-[0.26em] text-accent">
+              Real Estate Media Portfolio
+            </p>
+            <h1 className="mt-5 text-4xl font-bold leading-tight md:text-6xl lg:text-7xl">
+              Present every property with clarity, care and a strong sense of
+              place.
+            </h1>
+            <p className="mt-7 max-w-3xl text-lg leading-8 text-gray-300 md:text-xl">
+              OpenÉire provides property photography, aerial media, ground
+              video and practical listing assets for agents, auctioneers and
+              vendors across Connacht.
+            </p>
+            <div className="mt-9 flex flex-col gap-4 sm:flex-row">
+              <PortfolioTrackedLink
+                href="/real-estate#enquiry"
+                eventName="portfolio_enquiry_cta"
+                eventLocation="hero"
+                className="rounded-full bg-brand-500 px-7 py-4 text-center text-sm font-bold uppercase tracking-[0.17em] text-white shadow-xl shadow-brand-500/20 hover:bg-brand-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+              >
+                Discuss a Property
+              </PortfolioTrackedLink>
+              <PortfolioTrackedLink
+                href="/real-estate"
+                eventName="portfolio_service_cta"
+                eventLocation="hero"
+                className="rounded-full border border-white/25 bg-black/25 px-7 py-4 text-center text-sm font-bold uppercase tracking-[0.17em] text-white backdrop-blur hover:border-accent hover:text-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+              >
+                View Services &amp; Packages
+              </PortfolioTrackedLink>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="py-20">
+        <div className="container mx-auto grid max-w-7xl gap-8 px-4 md:grid-cols-[0.7fr_1.3fr] lg:px-8">
+          <p className="text-xs font-bold uppercase tracking-[0.24em] text-brand-500">
+            Coverage shaped around the listing
+          </p>
+          <div>
+            <h2 className="text-3xl font-bold leading-tight md:text-5xl">
+              The property sets the brief.
+            </h2>
+            <p className="mt-6 max-w-3xl text-lg leading-8 text-gray-400">
+              Each property receives coverage tailored to its size, features,
+              land, setting and marketing requirements. The aim is a coherent
+              set of listing assets, not a one-size-fits-all shot list.
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {publishedProjects.length ? (
+        <section aria-labelledby="featured-projects-heading">
+          <div className="container mx-auto max-w-7xl px-4 pb-6 lg:px-8">
+            <p className="text-xs font-bold uppercase tracking-[0.24em] text-accent">
+              Selected property work
+            </p>
+            <h2
+              id="featured-projects-heading"
+              className="mt-4 text-3xl font-bold md:text-5xl"
+            >
+              Featured projects
+            </h2>
+          </div>
+          {publishedProjects.map((project) => (
+            <PortfolioProject key={project.slug} project={project} />
+          ))}
+        </section>
+      ) : (
+        <section
+          aria-labelledby="portfolio-preparation-heading"
+          className="bg-gray-950 py-20"
+        >
+          <div className="container mx-auto max-w-5xl px-4 text-center lg:px-8">
+            <p className="text-xs font-bold uppercase tracking-[0.24em] text-brand-500">
+              Selected recent work
+            </p>
+            <h2
+              id="portfolio-preparation-heading"
+              className="mt-4 text-3xl font-bold md:text-5xl"
+            >
+              Our property portfolio is being prepared for publication.
+            </h2>
+            <p className="mx-auto mt-6 max-w-3xl text-lg leading-8 text-gray-400">
+              We are reviewing image selections and written permissions before
+              publishing client work. In the meantime, you can explore the
+              media available for a property brief or discuss an upcoming
+              listing directly.
+            </p>
+            <Link
+              href="/real-estate"
+              className="mt-8 inline-flex min-h-12 items-center justify-center rounded-full border border-white/20 px-7 py-3 text-sm font-bold uppercase tracking-[0.16em] text-white hover:border-accent hover:text-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+            >
+              Explore real estate services
+            </Link>
+          </div>
+        </section>
+      )}
+
+      <section className="py-20" aria-labelledby="services-demonstrated-heading">
+        <div className="container mx-auto max-w-7xl px-4 lg:px-8">
+          <div className="max-w-3xl">
+            <p className="text-xs font-bold uppercase tracking-[0.24em] text-accent">
+              Media for the complete listing
+            </p>
+            <h2
+              id="services-demonstrated-heading"
+              className="mt-4 text-3xl font-bold md:text-5xl"
+            >
+              Services the portfolio is built to demonstrate.
+            </h2>
+            <p className="mt-5 text-lg leading-8 text-gray-400">
+              Select only the formats that support the property and its
+              marketing plan.
+            </p>
+          </div>
+
+          <div className="mt-10 grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
+            {services.map(({ icon: Icon, title: serviceTitle, text }) => (
+              <article
+                key={serviceTitle}
+                className="rounded-3xl border border-white/10 bg-gray-950 p-7"
+              >
+                <Icon className="text-2xl text-brand-500" aria-hidden="true" />
+                <h3 className="mt-5 text-xl font-bold">{serviceTitle}</h3>
+                <p className="mt-3 text-sm leading-7 text-gray-400">{text}</p>
+              </article>
+            ))}
+          </div>
+
+          <PortfolioTrackedLink
+            href="/real-estate"
+            eventName="portfolio_service_cta"
+            eventLocation="services"
+            className="mt-10 inline-flex min-h-12 items-center justify-center rounded-full border border-white/20 px-7 py-3 text-sm font-bold uppercase tracking-[0.16em] text-white hover:border-accent hover:text-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+          >
+            Compare services and packages
+          </PortfolioTrackedLink>
+        </div>
+      </section>
+
+      <section className="border-t border-white/10 bg-brand-900 py-20">
+        <div className="container mx-auto max-w-5xl px-4 text-center lg:px-8">
+          <p className="text-xs font-bold uppercase tracking-[0.24em] text-accent">
+            Scope the next listing
+          </p>
+          <h2 className="mt-4 text-3xl font-bold md:text-5xl">
+            Planning the next property listing?
+          </h2>
+          <p className="mx-auto mt-6 max-w-3xl text-lg leading-8 text-brand-100/80">
+            Agents, auctioneers and vendors can submit the property details to
+            receive a scope recommendation and an accurate quotation.
+          </p>
+          <PortfolioTrackedLink
+            href="/real-estate#enquiry"
+            eventName="portfolio_enquiry_cta"
+            eventLocation="closing_cta"
+            className="mt-9 inline-flex min-h-12 items-center justify-center rounded-full bg-accent px-8 py-4 text-sm font-bold uppercase tracking-[0.17em] text-black hover:bg-accent-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-white"
+          >
+            Send Property Details
+          </PortfolioTrackedLink>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/openeire-next/app/real-estate/portfolio/page.tsx
+++ b/openeire-next/app/real-estate/portfolio/page.tsx
@@ -1,5 +1,5 @@
-import Image from "next/image";
 import Link from "next/link";
+import type { IconType } from "react-icons";
 import {
   FaCamera,
   FaDraftingCompass,
@@ -9,11 +9,19 @@ import {
   FaPhotoVideo,
 } from "react-icons/fa";
 import { JsonLd } from "@/components/JsonLd";
+import { RealEstateHeroImage } from "@/components/real-estate/RealEstateHeroImage";
 import { PortfolioProject } from "@/components/real-estate/PortfolioProject";
 import { PortfolioTrackedLink } from "@/components/real-estate/PortfolioTrackedLink";
 import {
+  getDemonstratedPortfolioFormats,
   getPublishedPortfolioProjects,
 } from "@/lib/realEstatePortfolio";
+import {
+  PORTFOLIO_FORMAT_DEFINITIONS,
+  REAL_ESTATE_PORTFOLIO_HERO_IMAGE,
+  REAL_ESTATE_PORTFOLIO_PATH,
+  type PortfolioFormat,
+} from "@/lib/realEstatePresentation";
 import { buildPageMetadata } from "@/lib/seo/metadata";
 import {
   buildPortfolioJsonLd,
@@ -24,44 +32,20 @@ import {
 export const metadata = buildPageMetadata({
   title: REAL_ESTATE_PORTFOLIO_TITLE,
   description: REAL_ESTATE_PORTFOLIO_DESCRIPTION,
-  path: "/real-estate/portfolio",
-  image: "/hero-poster.jpg",
+  path: REAL_ESTATE_PORTFOLIO_PATH,
 });
 
-const services = [
-  {
-    icon: FaCamera,
-    title: "Interior and exterior photography",
-    text: "A considered sequence of rooms, details, exterior elevations and setting.",
-  },
-  {
-    icon: FaHelicopter,
-    title: "Aerial drone stills",
-    text: "Elevated context for land, access, surroundings and wider location.",
-  },
-  {
-    icon: FaFilm,
-    title: "Aerial video",
-    text: "Controlled aerial movement that helps establish scale and setting.",
-  },
-  {
-    icon: FaPhotoVideo,
-    title: "Ground property video",
-    text: "A natural visual walkthrough shaped around the property and listing brief.",
-  },
-  {
-    icon: FaMobileAlt,
-    title: "Social-media cuts",
-    text: "Purpose-made vertical and square edits for agent and listing channels.",
-  },
-  {
-    icon: FaDraftingCompass,
-    title: "Measured 2D floor plans",
-    text: "Clear layout information supplied as an optional listing asset.",
-  },
-] as const;
+const formatIcons: Record<PortfolioFormat, IconType> = {
+  photography: FaCamera,
+  aerialStills: FaHelicopter,
+  groundVideo: FaPhotoVideo,
+  aerialVideo: FaFilm,
+  socialMediaCuts: FaMobileAlt,
+  floorPlan: FaDraftingCompass,
+};
 
 const publishedProjects = getPublishedPortfolioProjects();
+const demonstratedFormats = getDemonstratedPortfolioFormats();
 
 export default function RealEstatePortfolioPage() {
   return (
@@ -69,16 +53,16 @@ export default function RealEstatePortfolioPage() {
       <JsonLd data={buildPortfolioJsonLd(publishedProjects)} />
 
       <section className="relative isolate overflow-hidden pt-[calc(var(--site-header-height,96px)+2rem)]">
-        <Image
-          src="/hero-poster.jpg"
-          alt=""
-          fill
-          priority
-          sizes="100vw"
-          className="-z-20 object-cover object-center opacity-30"
+        <RealEstateHeroImage
+          image={REAL_ESTATE_PORTFOLIO_HERO_IMAGE}
+          objectPositionClassName="object-[64%_center] sm:object-[70%_center] lg:object-[74%_center]"
         />
         <div
-          className="absolute inset-0 -z-10 bg-linear-to-b from-black/65 via-black/85 to-black"
+          className="absolute inset-0 -z-10 bg-linear-to-r from-black/95 via-black/75 to-black/45 md:from-black/90 md:via-black/60 md:to-black/25"
+          aria-hidden="true"
+        />
+        <div
+          className="absolute inset-0 -z-10 bg-linear-to-b from-transparent via-transparent to-black/65"
           aria-hidden="true"
         />
         <div className="container mx-auto flex min-h-[72vh] max-w-7xl items-center px-4 py-20 lg:px-8">
@@ -165,12 +149,12 @@ export default function RealEstatePortfolioPage() {
               id="portfolio-preparation-heading"
               className="mt-4 text-3xl font-bold md:text-5xl"
             >
-              Our property portfolio is being prepared for publication.
+              Approved property work is being prepared for publication.
             </h2>
             <p className="mx-auto mt-6 max-w-3xl text-lg leading-8 text-gray-400">
-              We are reviewing image selections and written permissions before
-              publishing client work. In the meantime, you can explore the
-              media available for a property brief or discuss an upcoming
+              Selected photography and video are undergoing final web
+              optimisation and privacy review. In the meantime, you can explore
+              the media available for a property brief or discuss an upcoming
               listing directly.
             </p>
             <Link
@@ -183,47 +167,64 @@ export default function RealEstatePortfolioPage() {
         </section>
       )}
 
-      <section className="py-20" aria-labelledby="services-demonstrated-heading">
-        <div className="container mx-auto max-w-7xl px-4 lg:px-8">
-          <div className="max-w-3xl">
-            <p className="text-xs font-bold uppercase tracking-[0.24em] text-accent">
-              Media for the complete listing
-            </p>
-            <h2
-              id="services-demonstrated-heading"
-              className="mt-4 text-3xl font-bold md:text-5xl"
-            >
-              Services the portfolio is built to demonstrate.
-            </h2>
-            <p className="mt-5 text-lg leading-8 text-gray-400">
-              Select only the formats that support the property and its
-              marketing plan.
-            </p>
-          </div>
-
-          <div className="mt-10 grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
-            {services.map(({ icon: Icon, title: serviceTitle, text }) => (
-              <article
-                key={serviceTitle}
-                className="rounded-3xl border border-white/10 bg-gray-950 p-7"
+      {demonstratedFormats.length ? (
+        <section
+          className="py-20"
+          aria-labelledby="services-demonstrated-heading"
+        >
+          <div className="container mx-auto max-w-7xl px-4 lg:px-8">
+            <div className="max-w-3xl">
+              <p className="text-xs font-bold uppercase tracking-[0.24em] text-accent">
+                Published portfolio evidence
+              </p>
+              <h2
+                id="services-demonstrated-heading"
+                className="mt-4 text-3xl font-bold md:text-5xl"
               >
-                <Icon className="text-2xl text-brand-500" aria-hidden="true" />
-                <h3 className="mt-5 text-xl font-bold">{serviceTitle}</h3>
-                <p className="mt-3 text-sm leading-7 text-gray-400">{text}</p>
-              </article>
-            ))}
-          </div>
+                Media demonstrated in published work.
+              </h2>
+              <p className="mt-5 text-lg leading-8 text-gray-400">
+                These formats appear in authorised projects currently visible
+                in the portfolio.
+              </p>
+            </div>
 
-          <PortfolioTrackedLink
-            href="/real-estate"
-            eventName="portfolio_service_cta"
-            eventLocation="services"
-            className="mt-10 inline-flex min-h-12 items-center justify-center rounded-full border border-white/20 px-7 py-3 text-sm font-bold uppercase tracking-[0.16em] text-white hover:border-accent hover:text-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
-          >
-            Compare services and packages
-          </PortfolioTrackedLink>
-        </div>
-      </section>
+            <div className="mt-10 grid gap-5 sm:grid-cols-2 lg:grid-cols-3">
+              {demonstratedFormats.map((format) => {
+                const Icon = formatIcons[format];
+                const definition = PORTFOLIO_FORMAT_DEFINITIONS[format];
+
+                return (
+                  <article
+                    key={format}
+                    className="rounded-3xl border border-white/10 bg-gray-950 p-7"
+                  >
+                    <Icon
+                      className="text-2xl text-brand-500"
+                      aria-hidden="true"
+                    />
+                    <h3 className="mt-5 text-xl font-bold">
+                      {definition.title}
+                    </h3>
+                    <p className="mt-3 text-sm leading-7 text-gray-400">
+                      {definition.text}
+                    </p>
+                  </article>
+                );
+              })}
+            </div>
+
+            <PortfolioTrackedLink
+              href="/real-estate"
+              eventName="portfolio_service_cta"
+              eventLocation="services"
+              className="mt-10 inline-flex min-h-12 items-center justify-center rounded-full border border-white/20 px-7 py-3 text-sm font-bold uppercase tracking-[0.16em] text-white hover:border-accent hover:text-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+            >
+              Compare services and packages
+            </PortfolioTrackedLink>
+          </div>
+        </section>
+      ) : null}
 
       <section className="border-t border-white/10 bg-brand-900 py-20">
         <div className="container mx-auto max-w-5xl px-4 text-center lg:px-8">

--- a/openeire-next/app/sitemap.ts
+++ b/openeire-next/app/sitemap.ts
@@ -1,6 +1,7 @@
 import type { MetadataRoute } from "next";
 import { getAllPublishedBlogPostsForSitemap } from "@/lib/api/blog";
 import { getAllPublicPhysicalProductsForSitemap } from "@/lib/api/gallery";
+import { REAL_ESTATE_PORTFOLIO_PATH } from "@/lib/realEstatePresentation";
 import { buildAbsoluteUrl } from "@/lib/site";
 
 const staticPublicRoutes = [
@@ -10,7 +11,7 @@ const staticPublicRoutes = [
   "/art-prints",
   "/footage",
   "/real-estate",
-  "/real-estate/portfolio",
+  REAL_ESTATE_PORTFOLIO_PATH,
   "/about",
   "/us",
   "/us/fine-art-prints",

--- a/openeire-next/app/sitemap.ts
+++ b/openeire-next/app/sitemap.ts
@@ -10,6 +10,7 @@ const staticPublicRoutes = [
   "/art-prints",
   "/footage",
   "/real-estate",
+  "/real-estate/portfolio",
   "/about",
   "/us",
   "/us/fine-art-prints",

--- a/openeire-next/components/layout/Footer.tsx
+++ b/openeire-next/components/layout/Footer.tsx
@@ -98,6 +98,9 @@ export function Footer() {
               <FooterLink href="/licensing">Licensing</FooterLink>
               <FooterLink href="/gallery-gate?next=/gallery/digital">Stock Footage</FooterLink>
               <FooterLink href="/services">Services</FooterLink>
+              <FooterLink href="/real-estate/portfolio">
+                Real Estate Portfolio
+              </FooterLink>
               <FooterLink href="/blog">Journal</FooterLink>
               <FooterLink href="/about">Our Story</FooterLink>
             </ul>

--- a/openeire-next/components/layout/Footer.tsx
+++ b/openeire-next/components/layout/Footer.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import type { ReactNode } from "react";
 import { FaInstagram, FaYoutube } from "react-icons/fa";
 import { FooterNewsletterSignup } from "@/components/newsletter/FooterNewsletterSignup";
+import { REAL_ESTATE_PORTFOLIO_PATH } from "@/lib/realEstatePresentation";
 
 function FooterLink({ href, children }: { href: string; children: ReactNode }) {
   return (
@@ -98,7 +99,7 @@ export function Footer() {
               <FooterLink href="/licensing">Licensing</FooterLink>
               <FooterLink href="/gallery-gate?next=/gallery/digital">Stock Footage</FooterLink>
               <FooterLink href="/services">Services</FooterLink>
-              <FooterLink href="/real-estate/portfolio">
+              <FooterLink href={REAL_ESTATE_PORTFOLIO_PATH}>
                 Real Estate Portfolio
               </FooterLink>
               <FooterLink href="/blog">Journal</FooterLink>

--- a/openeire-next/components/layout/Navbar.tsx
+++ b/openeire-next/components/layout/Navbar.tsx
@@ -20,6 +20,7 @@ const primaryNavItems = [
 const serviceNavItems = [
   { href: "/licensing", label: "Commercial Licensing" },
   { href: "/real-estate", label: "Real Estate Services" },
+  { href: "/real-estate/portfolio", label: "Real Estate Portfolio" },
 ];
 
 const isActivePath = (pathname: string, href: string) =>

--- a/openeire-next/components/layout/Navbar.tsx
+++ b/openeire-next/components/layout/Navbar.tsx
@@ -10,6 +10,7 @@ import {
   formatFreeShippingThreshold,
   FREE_SHIPPING_PROMO_ENABLED,
 } from "@/lib/freeShipping";
+import { REAL_ESTATE_PORTFOLIO_PATH } from "@/lib/realEstatePresentation";
 
 const primaryNavItems = [
   { href: "/art-prints", label: "Art Prints" },
@@ -20,7 +21,7 @@ const primaryNavItems = [
 const serviceNavItems = [
   { href: "/licensing", label: "Commercial Licensing" },
   { href: "/real-estate", label: "Real Estate Services" },
-  { href: "/real-estate/portfolio", label: "Real Estate Portfolio" },
+  { href: REAL_ESTATE_PORTFOLIO_PATH, label: "Real Estate Portfolio" },
 ];
 
 const isActivePath = (pathname: string, href: string) =>

--- a/openeire-next/components/real-estate/PortfolioGallery.module.css
+++ b/openeire-next/components/real-estate/PortfolioGallery.module.css
@@ -1,0 +1,224 @@
+.gallery {
+  display: grid;
+  gap: 1rem;
+  width: 100%;
+}
+
+.row {
+  width: 100%;
+  overflow-x: auto;
+  overflow-y: hidden;
+  overscroll-behavior-x: contain;
+  padding: 0.25rem 1rem 0.75rem;
+  scroll-padding-inline: 1rem;
+  scroll-snap-type: x proximity;
+  scrollbar-width: thin;
+  scrollbar-color: rgb(255 255 255 / 25%) transparent;
+  -webkit-overflow-scrolling: touch;
+}
+
+.track,
+.sequence {
+  display: flex;
+  width: max-content;
+}
+
+.track {
+  will-change: auto;
+}
+
+.sequence {
+  align-items: stretch;
+  gap: 0.75rem;
+  padding-right: 0.75rem;
+}
+
+.cloneSequence {
+  display: none;
+  pointer-events: none;
+  user-select: none;
+}
+
+.card {
+  position: relative;
+  height: clamp(11rem, 52vw, 15rem);
+  flex: none;
+  overflow: hidden;
+  border: 1px solid rgb(255 255 255 / 10%);
+  border-radius: 1rem;
+  background: rgb(17 24 39);
+  scroll-snap-align: start;
+}
+
+.cardButton {
+  position: relative;
+  display: block;
+  width: 100%;
+  height: 100%;
+  min-width: 2.75rem;
+  min-height: 2.75rem;
+  cursor: pointer;
+  border: 0;
+  padding: 0;
+  background: transparent;
+  color: white;
+}
+
+.cardButton:disabled {
+  cursor: default;
+}
+
+.cardButton:focus {
+  outline: none;
+}
+
+.cardButton:focus-visible {
+  border-radius: inherit;
+  box-shadow: inset 0 0 0 4px var(--color-accent);
+}
+
+.galleryImage {
+  display: block;
+  width: auto;
+  max-width: none;
+  height: 100%;
+  object-fit: contain;
+  transition: filter 300ms ease;
+}
+
+.cardButton:hover .galleryImage {
+  filter: brightness(1.06);
+}
+
+.expandControl {
+  position: absolute;
+  right: 0.75rem;
+  bottom: 0.75rem;
+  display: inline-flex;
+  min-width: 2.75rem;
+  min-height: 2.75rem;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid rgb(255 255 255 / 25%);
+  border-radius: 9999px;
+  background: rgb(0 0 0 / 75%);
+  color: white;
+  backdrop-filter: blur(8px);
+}
+
+.caption {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  max-width: calc(100% - 4.5rem);
+  padding: 0.5rem 0.75rem;
+  background: rgb(0 0 0 / 75%);
+  color: rgb(229 231 235);
+  font-size: 0.75rem;
+}
+
+.imageFallback {
+  display: flex;
+  width: 100%;
+  height: 100%;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  background: rgb(17 24 39);
+  color: rgb(156 163 175);
+  text-align: center;
+  font-size: 0.875rem;
+}
+
+@media (min-width: 768px) {
+  .gallery {
+    gap: 1.25rem;
+  }
+
+  .row {
+    padding-inline: 1.5rem;
+  }
+
+  .sequence {
+    gap: 1rem;
+    padding-right: 1rem;
+  }
+
+  .card {
+    height: 16rem;
+    border-radius: 1.25rem;
+  }
+}
+
+@media (min-width: 1024px) {
+  .gallery {
+    gap: 1.5rem;
+  }
+
+  .row {
+    padding-inline: 2rem;
+  }
+
+  .card {
+    height: 18rem;
+  }
+}
+
+@media (min-width: 768px) and (prefers-reduced-motion: no-preference) {
+  .row {
+    overflow-x: hidden;
+    padding-inline: 0;
+    scroll-snap-type: none;
+    scrollbar-width: none;
+  }
+
+  .track {
+    will-change: transform;
+    animation-duration: 80s;
+    animation-timing-function: linear;
+    animation-iteration-count: infinite;
+  }
+
+  .forward {
+    animation-name: portfolio-marquee-forward;
+  }
+
+  .reverse {
+    animation-name: portfolio-marquee-reverse;
+  }
+
+  .cloneSequence {
+    display: flex;
+  }
+
+  .row:hover .track,
+  .row:focus-within .track {
+    animation-play-state: paused;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .galleryImage {
+    transition: none;
+  }
+}
+
+@keyframes portfolio-marquee-forward {
+  from {
+    transform: translateX(0);
+  }
+
+  to {
+    transform: translateX(-33.333333%);
+  }
+}
+
+@keyframes portfolio-marquee-reverse {
+  from {
+    transform: translateX(-33.333333%);
+  }
+
+  to {
+    transform: translateX(0);
+  }
+}

--- a/openeire-next/components/real-estate/PortfolioGallery.tsx
+++ b/openeire-next/components/real-estate/PortfolioGallery.tsx
@@ -3,6 +3,7 @@
 import Image from "next/image";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { FaChevronLeft, FaChevronRight, FaExpand, FaTimes } from "react-icons/fa";
+import styles from "@/components/real-estate/PortfolioGallery.module.css";
 import { trackEvent } from "@/lib/analytics";
 import type { PortfolioImage } from "@/lib/realEstatePortfolio";
 
@@ -11,8 +12,26 @@ type PortfolioGalleryProps = {
   projectSlug: string;
 };
 
+export type PortfolioGalleryEntry = {
+  image: PortfolioImage;
+  originalIndex: number;
+};
+
 const focusableSelector =
   'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+const CLONE_SEQUENCE_COUNT = 2;
+
+export const splitPortfolioGalleryRows = (
+  images: readonly PortfolioImage[],
+): readonly [readonly PortfolioGalleryEntry[], readonly PortfolioGalleryEntry[]] => {
+  const rows: [PortfolioGalleryEntry[], PortfolioGalleryEntry[]] = [[], []];
+
+  images.forEach((image, originalIndex) => {
+    rows[originalIndex % 2].push({ image, originalIndex });
+  });
+
+  return rows;
+};
 
 export function PortfolioGallery({
   images,
@@ -27,6 +46,7 @@ export function PortfolioGallery({
   const openerRef = useRef<HTMLButtonElement | null>(null);
   const triggerRefs = useRef<Array<HTMLButtonElement | null>>([]);
   const activeImage = activeIndex === null ? null : images[activeIndex];
+  const rows = splitPortfolioGalleryRows(images);
 
   const close = useCallback(() => {
     const trigger = openerRef.current;
@@ -34,12 +54,15 @@ export function PortfolioGallery({
     window.requestAnimationFrame(() => trigger?.focus());
   }, []);
 
-  const move = useCallback((direction: -1 | 1) => {
-    setActiveIndex((current) => {
-      if (current === null || images.length < 2) return current;
-      return (current + direction + images.length) % images.length;
-    });
-  }, [images.length]);
+  const move = useCallback(
+    (direction: -1 | 1) => {
+      setActiveIndex((current) => {
+        if (current === null || images.length < 2) return current;
+        return (current + direction + images.length) % images.length;
+      });
+    },
+    [images.length],
+  );
 
   const markFailed = useCallback((src: string) => {
     setFailedSources((current) => {
@@ -48,6 +71,18 @@ export function PortfolioGallery({
       return next;
     });
   }, []);
+
+  const openImage = (
+    originalIndex: number,
+    trigger: HTMLButtonElement | null,
+  ) => {
+    openerRef.current = trigger;
+    setActiveIndex(originalIndex);
+    trackEvent("portfolio_gallery_open", {
+      project_slug: projectSlug,
+      image_index: originalIndex + 1,
+    });
+  };
 
   useEffect(() => {
     if (activeIndex === null) return;
@@ -78,6 +113,7 @@ export function PortfolioGallery({
         dialogRef.current?.querySelectorAll<HTMLElement>(focusableSelector) ?? [],
       );
       if (!focusable.length) return;
+
       const first = focusable[0];
       const last = focusable[focusable.length - 1];
       if (event.shiftKey && document.activeElement === first) {
@@ -98,72 +134,127 @@ export function PortfolioGallery({
 
   if (!images.length) return null;
 
+  const renderOriginal = ({
+    image,
+    originalIndex,
+  }: PortfolioGalleryEntry) => {
+    const failed = failedSources.has(image.src);
+
+    return (
+      <figure
+        key={`${image.src}-${originalIndex}`}
+        className={styles.card}
+        style={{ aspectRatio: `${image.width} / ${image.height}` }}
+        data-gallery-original="true"
+      >
+        <button
+          ref={(node) => {
+            triggerRefs.current[originalIndex] = node;
+          }}
+          type="button"
+          disabled={failed}
+          onClick={(event) => openImage(originalIndex, event.currentTarget)}
+          className={styles.cardButton}
+          aria-label={
+            failed
+              ? `Image unavailable: ${image.alt}`
+              : `Open image ${originalIndex + 1} of ${images.length}: ${image.alt}`
+          }
+        >
+          {failed ? (
+            <span className={styles.imageFallback}>
+              Image temporarily unavailable
+            </span>
+          ) : (
+            <>
+              <Image
+                src={image.src}
+                alt={image.alt}
+                width={image.width}
+                height={image.height}
+                sizes="(max-width: 767px) 82vw, (max-width: 1023px) 480px, 540px"
+                className={styles.galleryImage}
+                onError={() => markFailed(image.src)}
+              />
+              <span className={styles.expandControl} aria-hidden="true">
+                <FaExpand />
+              </span>
+            </>
+          )}
+        </button>
+        {image.caption ? (
+          <figcaption className={styles.caption}>{image.caption}</figcaption>
+        ) : null}
+      </figure>
+    );
+  };
+
+  const renderClone = ({
+    image,
+    originalIndex,
+  }: PortfolioGalleryEntry) => (
+    <div
+      key={`${image.src}-${originalIndex}-clone`}
+      className={styles.card}
+      style={{ aspectRatio: `${image.width} / ${image.height}` }}
+    >
+      {failedSources.has(image.src) ? (
+        <span className={styles.imageFallback}>Image temporarily unavailable</span>
+      ) : (
+        <Image
+          src={image.src}
+          alt=""
+          width={image.width}
+          height={image.height}
+          sizes="(max-width: 1023px) 480px, 540px"
+          className={styles.galleryImage}
+          draggable={false}
+        />
+      )}
+    </div>
+  );
+
   return (
     <>
-      <div className="grid auto-rows-[14rem] gap-4 sm:grid-cols-2 lg:grid-cols-12">
-        {images.map((image, index) => {
-          const isPortrait = image.height > image.width;
-          const failed = failedSources.has(image.src);
-          return (
-            <figure
-              key={`${image.src}-${index}`}
-              className={`group relative overflow-hidden rounded-3xl bg-gray-900 ${
-                isPortrait
-                  ? "sm:row-span-2 lg:col-span-4"
-                  : index % 3 === 0
-                    ? "lg:col-span-8"
-                    : "lg:col-span-4"
-              }`}
+      <div
+        className={styles.gallery}
+        role="region"
+        aria-label="Property photography gallery"
+        data-gallery-mode="responsive-marquee"
+      >
+        {rows.map((row, rowIndex) =>
+          row.length ? (
+            <div
+              key={`gallery-row-${rowIndex + 1}`}
+              className={styles.row}
+              data-gallery-row={rowIndex + 1}
+              data-direction={rowIndex === 0 ? "forward" : "reverse"}
             >
-              <button
-                ref={(node) => {
-                  triggerRefs.current[index] = node;
-                }}
-                type="button"
-                disabled={failed}
-                onClick={() => {
-                  openerRef.current = triggerRefs.current[index];
-                  setActiveIndex(index);
-                  trackEvent("portfolio_gallery_open", {
-                    project_slug: projectSlug,
-                    image_index: index + 1,
-                  });
-                }}
-                className="relative h-full w-full focus:outline-none focus-visible:ring-4 focus-visible:ring-inset focus-visible:ring-accent disabled:cursor-default"
-                aria-label={
-                  failed
-                    ? `Image unavailable: ${image.alt}`
-                    : `Open image ${index + 1} of ${images.length}: ${image.alt}`
-                }
+              <div
+                className={`${styles.track} ${
+                  rowIndex === 0 ? styles.forward : styles.reverse
+                }`}
               >
-                {failed ? (
-                  <span className="flex h-full w-full items-center justify-center bg-gray-900 px-6 text-center text-sm text-gray-400">
-                    Image temporarily unavailable
-                  </span>
-                ) : (
-                  <>
-                    <Image
-                      src={image.src}
-                      alt={image.alt}
-                      fill
-                      sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 66vw"
-                      className="object-cover transition duration-500 motion-reduce:transition-none group-hover:scale-[1.02] motion-reduce:group-hover:scale-100"
-                      onError={() => markFailed(image.src)}
-                    />
-                    <span className="absolute bottom-4 right-4 inline-flex min-h-11 min-w-11 items-center justify-center rounded-full bg-black/75 text-white opacity-90 backdrop-blur">
-                      <FaExpand aria-hidden="true" />
-                    </span>
-                  </>
-                )}
-              </button>
-              {image.caption ? (
-                <figcaption className="absolute bottom-0 left-0 max-w-[80%] bg-black/75 px-4 py-2 text-xs text-gray-200">
-                  {image.caption}
-                </figcaption>
-              ) : null}
-            </figure>
-          );
-        })}
+                <div
+                  className={styles.sequence}
+                  data-gallery-sequence="original"
+                >
+                  {row.map(renderOriginal)}
+                </div>
+                {Array.from({ length: CLONE_SEQUENCE_COUNT }, (_, cloneIndex) => (
+                  <div
+                    key={`gallery-row-${rowIndex + 1}-clone-${cloneIndex + 1}`}
+                    className={`${styles.sequence} ${styles.cloneSequence}`}
+                    aria-hidden="true"
+                    data-gallery-sequence="clone"
+                  >
+                    {row.map(renderClone)}
+                  </div>
+                ))}
+              </div>
+            </div>
+          ) : null,
+        )}
       </div>
 
       {activeImage ? (
@@ -173,6 +264,9 @@ export function PortfolioGallery({
           aria-modal="true"
           aria-label={`Property photography viewer, image ${activeIndex! + 1} of ${images.length}`}
           className="fixed inset-0 z-[100] flex items-center justify-center bg-black/95 p-4 sm:p-8"
+          onClick={(event) => {
+            if (event.target === event.currentTarget) close();
+          }}
         >
           <button
             ref={closeButtonRef}

--- a/openeire-next/components/real-estate/PortfolioGallery.tsx
+++ b/openeire-next/components/real-estate/PortfolioGallery.tsx
@@ -1,0 +1,234 @@
+"use client";
+
+import Image from "next/image";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { FaChevronLeft, FaChevronRight, FaExpand, FaTimes } from "react-icons/fa";
+import { trackEvent } from "@/lib/analytics";
+import type { PortfolioImage } from "@/lib/realEstatePortfolio";
+
+type PortfolioGalleryProps = {
+  images: readonly PortfolioImage[];
+  projectSlug: string;
+};
+
+const focusableSelector =
+  'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+export function PortfolioGallery({
+  images,
+  projectSlug,
+}: PortfolioGalleryProps) {
+  const [activeIndex, setActiveIndex] = useState<number | null>(null);
+  const [failedSources, setFailedSources] = useState<Set<string>>(
+    () => new Set(),
+  );
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const closeButtonRef = useRef<HTMLButtonElement>(null);
+  const openerRef = useRef<HTMLButtonElement | null>(null);
+  const triggerRefs = useRef<Array<HTMLButtonElement | null>>([]);
+  const activeImage = activeIndex === null ? null : images[activeIndex];
+
+  const close = useCallback(() => {
+    const trigger = openerRef.current;
+    setActiveIndex(null);
+    window.requestAnimationFrame(() => trigger?.focus());
+  }, []);
+
+  const move = useCallback((direction: -1 | 1) => {
+    setActiveIndex((current) => {
+      if (current === null || images.length < 2) return current;
+      return (current + direction + images.length) % images.length;
+    });
+  }, [images.length]);
+
+  const markFailed = useCallback((src: string) => {
+    setFailedSources((current) => {
+      const next = new Set(current);
+      next.add(src);
+      return next;
+    });
+  }, []);
+
+  useEffect(() => {
+    if (activeIndex === null) return;
+
+    const previousOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    closeButtonRef.current?.focus();
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        close();
+        return;
+      }
+      if (event.key === "ArrowLeft") {
+        event.preventDefault();
+        move(-1);
+        return;
+      }
+      if (event.key === "ArrowRight") {
+        event.preventDefault();
+        move(1);
+        return;
+      }
+      if (event.key !== "Tab") return;
+
+      const focusable = Array.from(
+        dialogRef.current?.querySelectorAll<HTMLElement>(focusableSelector) ?? [],
+      );
+      if (!focusable.length) return;
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+    return () => {
+      document.body.style.overflow = previousOverflow;
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [activeIndex, close, move]);
+
+  if (!images.length) return null;
+
+  return (
+    <>
+      <div className="grid auto-rows-[14rem] gap-4 sm:grid-cols-2 lg:grid-cols-12">
+        {images.map((image, index) => {
+          const isPortrait = image.height > image.width;
+          const failed = failedSources.has(image.src);
+          return (
+            <figure
+              key={`${image.src}-${index}`}
+              className={`group relative overflow-hidden rounded-3xl bg-gray-900 ${
+                isPortrait
+                  ? "sm:row-span-2 lg:col-span-4"
+                  : index % 3 === 0
+                    ? "lg:col-span-8"
+                    : "lg:col-span-4"
+              }`}
+            >
+              <button
+                ref={(node) => {
+                  triggerRefs.current[index] = node;
+                }}
+                type="button"
+                disabled={failed}
+                onClick={() => {
+                  openerRef.current = triggerRefs.current[index];
+                  setActiveIndex(index);
+                  trackEvent("portfolio_gallery_open", {
+                    project_slug: projectSlug,
+                    image_index: index + 1,
+                  });
+                }}
+                className="relative h-full w-full focus:outline-none focus-visible:ring-4 focus-visible:ring-inset focus-visible:ring-accent disabled:cursor-default"
+                aria-label={
+                  failed
+                    ? `Image unavailable: ${image.alt}`
+                    : `Open image ${index + 1} of ${images.length}: ${image.alt}`
+                }
+              >
+                {failed ? (
+                  <span className="flex h-full w-full items-center justify-center bg-gray-900 px-6 text-center text-sm text-gray-400">
+                    Image temporarily unavailable
+                  </span>
+                ) : (
+                  <>
+                    <Image
+                      src={image.src}
+                      alt={image.alt}
+                      fill
+                      sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 66vw"
+                      className="object-cover transition duration-500 motion-reduce:transition-none group-hover:scale-[1.02] motion-reduce:group-hover:scale-100"
+                      onError={() => markFailed(image.src)}
+                    />
+                    <span className="absolute bottom-4 right-4 inline-flex min-h-11 min-w-11 items-center justify-center rounded-full bg-black/75 text-white opacity-90 backdrop-blur">
+                      <FaExpand aria-hidden="true" />
+                    </span>
+                  </>
+                )}
+              </button>
+              {image.caption ? (
+                <figcaption className="absolute bottom-0 left-0 max-w-[80%] bg-black/75 px-4 py-2 text-xs text-gray-200">
+                  {image.caption}
+                </figcaption>
+              ) : null}
+            </figure>
+          );
+        })}
+      </div>
+
+      {activeImage ? (
+        <div
+          ref={dialogRef}
+          role="dialog"
+          aria-modal="true"
+          aria-label={`Property photography viewer, image ${activeIndex! + 1} of ${images.length}`}
+          className="fixed inset-0 z-[100] flex items-center justify-center bg-black/95 p-4 sm:p-8"
+        >
+          <button
+            ref={closeButtonRef}
+            type="button"
+            onClick={close}
+            className="absolute right-4 top-4 z-10 flex min-h-12 min-w-12 items-center justify-center rounded-full border border-white/25 bg-black/80 text-white hover:border-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+            aria-label="Close image viewer"
+          >
+            <FaTimes aria-hidden="true" />
+          </button>
+
+          {images.length > 1 ? (
+            <button
+              type="button"
+              onClick={() => move(-1)}
+              className="absolute left-3 z-10 flex min-h-12 min-w-12 items-center justify-center rounded-full border border-white/25 bg-black/80 text-white hover:border-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-accent sm:left-6"
+              aria-label="View previous image"
+            >
+              <FaChevronLeft aria-hidden="true" />
+            </button>
+          ) : null}
+
+          <figure className="flex max-h-full max-w-6xl flex-col items-center gap-3">
+            {failedSources.has(activeImage.src) ? (
+              <div className="flex min-h-80 min-w-72 items-center justify-center rounded-xl bg-gray-900 px-8 text-center text-gray-400">
+                Image temporarily unavailable
+              </div>
+            ) : (
+              <Image
+                src={activeImage.src}
+                alt={activeImage.alt}
+                width={activeImage.width}
+                height={activeImage.height}
+                sizes="95vw"
+                className="max-h-[82vh] w-auto max-w-full rounded-xl object-contain"
+                priority
+                onError={() => markFailed(activeImage.src)}
+              />
+            )}
+            <figcaption className="text-center text-sm text-gray-300">
+              {activeImage.caption ?? activeImage.alt}
+            </figcaption>
+          </figure>
+
+          {images.length > 1 ? (
+            <button
+              type="button"
+              onClick={() => move(1)}
+              className="absolute right-3 z-10 flex min-h-12 min-w-12 items-center justify-center rounded-full border border-white/25 bg-black/80 text-white hover:border-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-accent sm:right-6"
+              aria-label="View next image"
+            >
+              <FaChevronRight aria-hidden="true" />
+            </button>
+          ) : null}
+        </div>
+      ) : null}
+    </>
+  );
+}

--- a/openeire-next/components/real-estate/PortfolioImageWithFallback.tsx
+++ b/openeire-next/components/real-estate/PortfolioImageWithFallback.tsx
@@ -38,4 +38,3 @@ export function PortfolioImageWithFallback({
     />
   );
 }
-

--- a/openeire-next/components/real-estate/PortfolioImageWithFallback.tsx
+++ b/openeire-next/components/real-estate/PortfolioImageWithFallback.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import Image from "next/image";
+import { useState } from "react";
+import type { PortfolioImage } from "@/lib/realEstatePortfolio";
+
+export function PortfolioImageWithFallback({
+  image,
+  sizes,
+  className,
+}: {
+  image: PortfolioImage;
+  sizes: string;
+  className: string;
+}) {
+  const [failed, setFailed] = useState(false);
+
+  if (failed) {
+    return (
+      <div
+        role="img"
+        aria-label={`${image.alt}. Image temporarily unavailable.`}
+        className="flex h-full w-full items-center justify-center bg-gray-900 px-6 text-center text-sm text-gray-400"
+      >
+        Image temporarily unavailable
+      </div>
+    );
+  }
+
+  return (
+    <Image
+      src={image.src}
+      alt={image.alt}
+      fill
+      sizes={sizes}
+      className={className}
+      onError={() => setFailed(true)}
+    />
+  );
+}
+

--- a/openeire-next/components/real-estate/PortfolioProject.tsx
+++ b/openeire-next/components/real-estate/PortfolioProject.tsx
@@ -11,6 +11,10 @@ export function PortfolioProject({
 }: {
   project: RealEstatePortfolioProject;
 }) {
+  const hasTwoPropertyFilms = Boolean(
+    project.groundVideo && project.aerialVideo,
+  );
+
   return (
     <article
       id={project.slug}
@@ -60,6 +64,43 @@ export function PortfolioProject({
         </section>
       </div>
 
+      {project.groundVideo || project.aerialVideo ? (
+        <section className="container mx-auto mt-16 max-w-7xl px-4 lg:px-8">
+          <div
+            className={
+              hasTwoPropertyFilms
+                ? "grid items-start gap-8 lg:grid-cols-2"
+                : "mx-auto max-w-3xl"
+            }
+            data-property-video-layout={
+              hasTwoPropertyFilms ? "split" : "featured"
+            }
+          >
+            <h3
+              className={
+                hasTwoPropertyFilms
+                  ? "mb-7 text-2xl font-bold text-white lg:col-span-2"
+                  : "mb-7 text-2xl font-bold text-white"
+              }
+            >
+              Property film
+            </h3>
+            {project.groundVideo ? (
+              <PortfolioVideo
+                video={project.groundVideo}
+                projectSlug={project.slug}
+              />
+            ) : null}
+            {project.aerialVideo ? (
+              <PortfolioVideo
+                video={project.aerialVideo}
+                projectSlug={project.slug}
+              />
+            ) : null}
+          </div>
+        </section>
+      ) : null}
+
       <section className="container mx-auto mt-16 max-w-7xl px-4 lg:px-8">
         <h3 className="text-2xl font-bold text-white">Selected deliverables</h3>
         <ul className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
@@ -79,10 +120,12 @@ export function PortfolioProject({
       </section>
 
       {project.galleryImages.length ? (
-        <section className="container mx-auto mt-16 max-w-7xl px-4 lg:px-8">
-          <h3 className="mb-7 text-2xl font-bold text-white">
-            Property photography
-          </h3>
+        <section className="mt-16">
+          <div className="container mx-auto max-w-7xl px-4 lg:px-8">
+            <h3 className="mb-7 text-2xl font-bold text-white">
+              Property photography
+            </h3>
+          </div>
           <PortfolioGallery
             images={project.galleryImages}
             projectSlug={project.slug}
@@ -90,28 +133,19 @@ export function PortfolioProject({
         </section>
       ) : null}
 
-      {project.landscapeVideo || project.verticalVideo ? (
+      {project.socialVideos?.length ? (
         <section className="container mx-auto mt-16 max-w-7xl px-4 lg:px-8">
-          <h3 className="mb-7 text-2xl font-bold text-white">Property film</h3>
-          <div
-            className={`grid gap-8 ${
-              project.verticalVideo
-                ? "items-start lg:grid-cols-[1.5fr_0.5fr]"
-                : ""
-            }`}
-          >
-            {project.landscapeVideo ? (
+          <h3 className="mb-7 text-2xl font-bold text-white">
+            Social-media films
+          </h3>
+          <div className="grid items-start gap-8 md:grid-cols-2 lg:grid-cols-3">
+            {project.socialVideos.map((video) => (
               <PortfolioVideo
-                video={project.landscapeVideo}
+                key={video.youtubeVideoId}
+                video={video}
                 projectSlug={project.slug}
               />
-            ) : null}
-            {project.verticalVideo ? (
-              <PortfolioVideo
-                video={project.verticalVideo}
-                projectSlug={project.slug}
-              />
-            ) : null}
+            ))}
           </div>
         </section>
       ) : null}

--- a/openeire-next/components/real-estate/PortfolioProject.tsx
+++ b/openeire-next/components/real-estate/PortfolioProject.tsx
@@ -1,0 +1,157 @@
+import Link from "next/link";
+import { FaCheckCircle, FaMapMarkerAlt } from "react-icons/fa";
+import { PortfolioGallery } from "@/components/real-estate/PortfolioGallery";
+import { PortfolioImageWithFallback } from "@/components/real-estate/PortfolioImageWithFallback";
+import { PortfolioTrackedLink } from "@/components/real-estate/PortfolioTrackedLink";
+import { PortfolioVideo } from "@/components/real-estate/PortfolioVideo";
+import type { RealEstatePortfolioProject } from "@/lib/realEstatePortfolio";
+
+export function PortfolioProject({
+  project,
+}: {
+  project: RealEstatePortfolioProject;
+}) {
+  return (
+    <article
+      id={project.slug}
+      className="border-t border-white/10 bg-black py-20"
+    >
+      <header className="container mx-auto grid max-w-7xl gap-10 px-4 lg:grid-cols-[0.8fr_1.2fr] lg:px-8">
+        <div>
+          <p className="flex items-center gap-2 text-xs font-bold uppercase tracking-[0.22em] text-accent">
+            <FaMapMarkerAlt aria-hidden="true" />
+            {project.generalLocation} · {project.propertyType}
+          </p>
+          <h2 className="mt-4 text-3xl font-bold text-white md:text-5xl">
+            {project.title}
+          </h2>
+          <p className="mt-4 text-sm text-gray-400">
+            {project.packageName} · {project.imageCount} selected photographs
+          </p>
+        </div>
+        <p className="text-lg leading-8 text-gray-300">{project.summary}</p>
+      </header>
+
+      {project.heroImage ? (
+        <div className="container mx-auto mt-12 max-w-7xl px-4 lg:px-8">
+          <div
+            className="relative overflow-hidden rounded-[2rem] bg-gray-900"
+            style={{
+              aspectRatio: `${project.heroImage.width} / ${project.heroImage.height}`,
+            }}
+          >
+            <PortfolioImageWithFallback
+              image={project.heroImage}
+              sizes="(max-width: 1280px) 100vw, 1280px"
+              className="object-cover"
+            />
+          </div>
+        </div>
+      ) : null}
+
+      <div className="container mx-auto mt-16 grid max-w-7xl gap-8 px-4 md:grid-cols-2 lg:px-8">
+        <section className="rounded-3xl border border-white/10 bg-gray-950 p-7">
+          <h3 className="text-2xl font-bold text-white">The brief</h3>
+          <p className="mt-4 leading-7 text-gray-400">{project.challenge}</p>
+        </section>
+        <section className="rounded-3xl border border-white/10 bg-gray-950 p-7">
+          <h3 className="text-2xl font-bold text-white">Our approach</h3>
+          <p className="mt-4 leading-7 text-gray-400">{project.approach}</p>
+        </section>
+      </div>
+
+      <section className="container mx-auto mt-16 max-w-7xl px-4 lg:px-8">
+        <h3 className="text-2xl font-bold text-white">Selected deliverables</h3>
+        <ul className="mt-6 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {project.deliverables.map((deliverable) => (
+            <li
+              key={deliverable}
+              className="flex gap-3 rounded-2xl border border-white/10 bg-gray-950 p-5 text-sm text-gray-300"
+            >
+              <FaCheckCircle
+                className="mt-0.5 shrink-0 text-brand-500"
+                aria-hidden="true"
+              />
+              {deliverable}
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      {project.galleryImages.length ? (
+        <section className="container mx-auto mt-16 max-w-7xl px-4 lg:px-8">
+          <h3 className="mb-7 text-2xl font-bold text-white">
+            Property photography
+          </h3>
+          <PortfolioGallery
+            images={project.galleryImages}
+            projectSlug={project.slug}
+          />
+        </section>
+      ) : null}
+
+      {project.landscapeVideo || project.verticalVideo ? (
+        <section className="container mx-auto mt-16 max-w-7xl px-4 lg:px-8">
+          <h3 className="mb-7 text-2xl font-bold text-white">Property film</h3>
+          <div
+            className={`grid gap-8 ${
+              project.verticalVideo
+                ? "items-start lg:grid-cols-[1.5fr_0.5fr]"
+                : ""
+            }`}
+          >
+            {project.landscapeVideo ? (
+              <PortfolioVideo
+                video={project.landscapeVideo}
+                projectSlug={project.slug}
+              />
+            ) : null}
+            {project.verticalVideo ? (
+              <PortfolioVideo
+                video={project.verticalVideo}
+                projectSlug={project.slug}
+              />
+            ) : null}
+          </div>
+        </section>
+      ) : null}
+
+      {project.floorPlanImage ? (
+        <section className="container mx-auto mt-16 max-w-7xl px-4 lg:px-8">
+          <h3 className="mb-7 text-2xl font-bold text-white">
+            Measured 2D floor plan
+          </h3>
+          <div
+            className="relative max-w-4xl overflow-hidden rounded-3xl bg-white"
+            style={{
+              aspectRatio: `${project.floorPlanImage.width} / ${project.floorPlanImage.height}`,
+            }}
+          >
+            <PortfolioImageWithFallback
+              image={project.floorPlanImage}
+              sizes="(max-width: 896px) 100vw, 896px"
+              className="object-contain p-4 sm:p-8"
+            />
+          </div>
+        </section>
+      ) : null}
+
+      <div className="container mx-auto mt-14 flex max-w-7xl flex-col gap-4 px-4 sm:flex-row lg:px-8">
+        <PortfolioTrackedLink
+          href="/real-estate#enquiry"
+          eventName="portfolio_enquiry_cta"
+          eventLocation={`project:${project.slug}`}
+          className="rounded-full bg-brand-500 px-7 py-4 text-center text-sm font-bold uppercase tracking-[0.16em] text-white hover:bg-brand-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+        >
+          Discuss a similar property
+        </PortfolioTrackedLink>
+        <Link
+          href="/real-estate"
+          className="rounded-full border border-white/20 px-7 py-4 text-center text-sm font-bold uppercase tracking-[0.16em] text-white hover:border-accent hover:text-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+        >
+          View services and packages
+        </Link>
+      </div>
+    </article>
+  );
+}

--- a/openeire-next/components/real-estate/PortfolioTrackedLink.tsx
+++ b/openeire-next/components/real-estate/PortfolioTrackedLink.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import Link from "next/link";
+import type { ReactNode } from "react";
+import { trackEvent } from "@/lib/analytics";
+
+type PortfolioTrackedLinkProps = {
+  href: string;
+  eventName: "portfolio_enquiry_cta" | "portfolio_service_cta";
+  eventLocation: string;
+  className: string;
+  children: ReactNode;
+};
+
+export function PortfolioTrackedLink({
+  href,
+  eventName,
+  eventLocation,
+  className,
+  children,
+}: PortfolioTrackedLinkProps) {
+  return (
+    <Link
+      href={href}
+      className={className}
+      onClick={() =>
+        trackEvent(eventName, {
+          page: "/real-estate/portfolio",
+          location: eventLocation,
+          destination: href,
+        })
+      }
+    >
+      {children}
+    </Link>
+  );
+}
+

--- a/openeire-next/components/real-estate/PortfolioTrackedLink.tsx
+++ b/openeire-next/components/real-estate/PortfolioTrackedLink.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import type { ReactNode } from "react";
 import { trackEvent } from "@/lib/analytics";
+import { REAL_ESTATE_PORTFOLIO_PATH } from "@/lib/realEstatePresentation";
 
 type PortfolioTrackedLinkProps = {
   href: string;
@@ -25,7 +26,7 @@ export function PortfolioTrackedLink({
       className={className}
       onClick={() =>
         trackEvent(eventName, {
-          page: "/real-estate/portfolio",
+          page: REAL_ESTATE_PORTFOLIO_PATH,
           location: eventLocation,
           destination: href,
         })
@@ -35,4 +36,3 @@ export function PortfolioTrackedLink({
     </Link>
   );
 }
-

--- a/openeire-next/components/real-estate/PortfolioVideo.tsx
+++ b/openeire-next/components/real-estate/PortfolioVideo.tsx
@@ -1,8 +1,17 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
+import { FaExternalLinkAlt, FaPlay } from "react-icons/fa";
+import { PortfolioImageWithFallback } from "@/components/real-estate/PortfolioImageWithFallback";
 import { trackEvent } from "@/lib/analytics";
 import type { PortfolioVideo as PortfolioVideoData } from "@/lib/realEstatePortfolio";
+
+const YOUTUBE_VIDEO_ID_PATTERN = /^[A-Za-z0-9_-]{11}$/;
+export const VIDEO_LOAD_TIMEOUT_MS = 12_000;
+type PlayerState = "idle" | "loading" | "ready" | "error";
+
+export const isValidYouTubeVideoId = (videoId: string): boolean =>
+  YOUTUBE_VIDEO_ID_PATTERN.test(videoId);
 
 export function PortfolioVideo({
   video,
@@ -11,58 +20,153 @@ export function PortfolioVideo({
   video: PortfolioVideoData;
   projectSlug: string;
 }) {
-  const containerRef = useRef<HTMLDivElement>(null);
-  const [shouldLoad, setShouldLoad] = useState(false);
+  const [playerState, setPlayerState] = useState<PlayerState>("idle");
+  const hasValidVideoId = isValidYouTubeVideoId(video.youtubeVideoId);
+  const hasStarted = playerState !== "idle";
+  const youtubeWatchUrl = `https://www.youtube.com/watch?v=${video.youtubeVideoId}`;
 
   useEffect(() => {
-    const element = containerRef.current;
-    if (!element || typeof IntersectionObserver === "undefined") {
-      setShouldLoad(true);
-      return;
-    }
+    if (playerState !== "loading") return;
 
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        if (!entry.isIntersecting) return;
-        setShouldLoad(true);
-        observer.disconnect();
-      },
-      { rootMargin: "300px" },
-    );
-    observer.observe(element);
-    return () => observer.disconnect();
-  }, []);
+    const timeoutId = window.setTimeout(() => {
+      setPlayerState((current) =>
+        current === "loading" ? "error" : current,
+      );
+    }, VIDEO_LOAD_TIMEOUT_MS);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [playerState]);
+
+  const startVideo = () => {
+    if (!hasValidVideoId) return;
+    trackEvent("portfolio_film_play", {
+      project_slug: projectSlug,
+      video_title: video.title,
+      video_provider: "youtube",
+    });
+    setPlayerState("loading");
+  };
 
   return (
-    <div ref={containerRef}>
+    <div>
       <div
-        className="overflow-hidden rounded-3xl bg-gray-900"
+        className="relative overflow-hidden rounded-3xl bg-gray-900"
         style={{ aspectRatio: `${video.width} / ${video.height}` }}
       >
-        <video
-          controls
-          playsInline
-          preload="none"
-          poster={video.poster.src}
-          aria-label={video.title}
-          className="h-full w-full object-cover"
-          onPlay={() =>
-            trackEvent("portfolio_film_play", {
-              project_slug: projectSlug,
-              video_title: video.title,
-            })
-          }
-        >
-          {shouldLoad ? <source src={video.src} type="video/mp4" /> : null}
-          Your browser does not support HTML video. You can request an
-          accessible copy from OpenÉire Studios.
-        </video>
+        {hasValidVideoId && playerState !== "ready" ? (
+          <>
+            <PortfolioImageWithFallback
+              image={video.poster}
+              sizes="(max-width: 1024px) 100vw, 960px"
+              className="object-cover"
+            />
+            <div
+              className="absolute inset-0 bg-linear-to-t from-black/65 via-black/10 to-black/10"
+              aria-hidden="true"
+            />
+          </>
+        ) : null}
+
+        {hasValidVideoId &&
+        (playerState === "loading" || playerState === "ready") ? (
+          <iframe
+            src={`https://www.youtube-nocookie.com/embed/${video.youtubeVideoId}?autoplay=1&playsinline=1&rel=0`}
+            title={video.title}
+            data-cmp-ab="1"
+            referrerPolicy="strict-origin-when-cross-origin"
+            allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+            allowFullScreen
+            onLoad={() => setPlayerState("ready")}
+            className={`absolute inset-0 h-full w-full border-0 transition-opacity duration-300 ${
+              playerState === "ready"
+                ? "opacity-100"
+                : "pointer-events-none opacity-0"
+            }`}
+          />
+        ) : null}
+
+        {hasValidVideoId && playerState === "loading" ? (
+          <div
+            role="status"
+            aria-live="polite"
+            className="absolute inset-0 flex items-center justify-center bg-black/35 px-6 text-center text-sm font-semibold text-white"
+          >
+            Loading film…
+          </div>
+        ) : null}
+
+        {hasValidVideoId && playerState === "idle" ? (
+          <>
+            <button
+              type="button"
+              onClick={startVideo}
+              aria-label={`Play ${video.title} on YouTube`}
+              className="group absolute inset-0 flex items-center justify-center focus:outline-none focus-visible:ring-4 focus-visible:ring-inset focus-visible:ring-accent"
+            >
+              <span className="flex min-h-16 items-center gap-3 rounded-full border border-white/30 bg-black/75 px-6 py-4 text-sm font-bold uppercase tracking-[0.16em] text-white shadow-2xl backdrop-blur transition group-hover:scale-105 group-hover:border-accent group-hover:text-accent">
+                <FaPlay aria-hidden="true" />
+                Play film
+              </span>
+            </button>
+          </>
+        ) : null}
+
+        {hasValidVideoId && playerState === "error" ? (
+          <div
+            role="alert"
+            className="absolute inset-0 flex flex-col items-center justify-center gap-4 bg-black/65 px-6 text-center text-sm text-white"
+          >
+            <p>The embedded player could not be loaded.</p>
+            <div className="flex flex-wrap justify-center gap-3">
+              <button
+                type="button"
+                onClick={() => setPlayerState("loading")}
+                className="min-h-11 rounded-full border border-white/30 bg-black/70 px-5 py-3 font-bold hover:border-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+              >
+                Try again
+              </button>
+              <a
+                href={youtubeWatchUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex min-h-11 items-center gap-2 rounded-full bg-white px-5 py-3 font-bold text-black hover:bg-accent focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+              >
+                Watch on YouTube
+                <FaExternalLinkAlt aria-hidden="true" />
+              </a>
+            </div>
+          </div>
+        ) : null}
+
+        {!hasValidVideoId ? (
+          <div
+            role="status"
+            className="flex h-full w-full items-center justify-center px-6 text-center text-sm text-gray-400"
+          >
+            Video temporarily unavailable
+          </div>
+        ) : null}
       </div>
       <p className="mt-3 text-sm leading-relaxed text-gray-400">
         <span className="font-bold text-white">{video.title}.</span>{" "}
         {video.description}
       </p>
+      {!hasStarted && hasValidVideoId ? (
+        <p className="mt-2 text-xs leading-relaxed text-gray-500">
+          YouTube is loaded only after you press play.
+        </p>
+      ) : null}
+      {hasStarted && hasValidVideoId ? (
+        <a
+          href={youtubeWatchUrl}
+          target="_blank"
+          rel="noreferrer"
+          className="mt-2 inline-flex min-h-11 items-center gap-2 text-xs font-semibold text-gray-400 underline decoration-white/30 underline-offset-4 hover:text-white focus:outline-none focus-visible:ring-2 focus-visible:ring-accent"
+        >
+          Having trouble? Watch on YouTube
+          <FaExternalLinkAlt aria-hidden="true" />
+        </a>
+      ) : null}
     </div>
   );
 }
-

--- a/openeire-next/components/real-estate/PortfolioVideo.tsx
+++ b/openeire-next/components/real-estate/PortfolioVideo.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { trackEvent } from "@/lib/analytics";
+import type { PortfolioVideo as PortfolioVideoData } from "@/lib/realEstatePortfolio";
+
+export function PortfolioVideo({
+  video,
+  projectSlug,
+}: {
+  video: PortfolioVideoData;
+  projectSlug: string;
+}) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const [shouldLoad, setShouldLoad] = useState(false);
+
+  useEffect(() => {
+    const element = containerRef.current;
+    if (!element || typeof IntersectionObserver === "undefined") {
+      setShouldLoad(true);
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      ([entry]) => {
+        if (!entry.isIntersecting) return;
+        setShouldLoad(true);
+        observer.disconnect();
+      },
+      { rootMargin: "300px" },
+    );
+    observer.observe(element);
+    return () => observer.disconnect();
+  }, []);
+
+  return (
+    <div ref={containerRef}>
+      <div
+        className="overflow-hidden rounded-3xl bg-gray-900"
+        style={{ aspectRatio: `${video.width} / ${video.height}` }}
+      >
+        <video
+          controls
+          playsInline
+          preload="none"
+          poster={video.poster.src}
+          aria-label={video.title}
+          className="h-full w-full object-cover"
+          onPlay={() =>
+            trackEvent("portfolio_film_play", {
+              project_slug: projectSlug,
+              video_title: video.title,
+            })
+          }
+        >
+          {shouldLoad ? <source src={video.src} type="video/mp4" /> : null}
+          Your browser does not support HTML video. You can request an
+          accessible copy from OpenÉire Studios.
+        </video>
+      </div>
+      <p className="mt-3 text-sm leading-relaxed text-gray-400">
+        <span className="font-bold text-white">{video.title}.</span>{" "}
+        {video.description}
+      </p>
+    </div>
+  );
+}
+

--- a/openeire-next/components/real-estate/RealEstateHeroImage.tsx
+++ b/openeire-next/components/real-estate/RealEstateHeroImage.tsx
@@ -1,0 +1,24 @@
+import Image from "next/image";
+import {
+  REAL_ESTATE_HERO_IMAGE,
+  type RealEstateHeroImageConfig,
+} from "@/lib/realEstatePresentation";
+
+export function RealEstateHeroImage({
+  image = REAL_ESTATE_HERO_IMAGE,
+  objectPositionClassName,
+}: {
+  image?: RealEstateHeroImageConfig;
+  objectPositionClassName: string;
+}) {
+  return (
+    <Image
+      src={image.src}
+      alt={image.alt}
+      fill
+      priority
+      sizes="100vw"
+      className={`-z-20 object-cover ${objectPositionClassName}`}
+    />
+  );
+}

--- a/openeire-next/docs/real-estate-portfolio.md
+++ b/openeire-next/docs/real-estate-portfolio.md
@@ -36,8 +36,8 @@ or metadata. Use a general location such as `County Galway`.
 2. Add meaningful, non-identifying alt text and explicit pixel dimensions for
    every image. Omit video and floor-plan fields when those formats were not
    delivered or are not approved.
-3. Verify the package name against the signed scope. For example, describe a
-   Pro booking with a floor-plan add-on exactly that way, not as Premium.
+3. Describe the public scope shown rather than applying a historical package
+   label. Package contents and names may change over time.
 4. Complete the privacy review and record the written approval.
 5. Add the safe internal approval reference, set
    `portfolioPermissionConfirmed: true`, then set `published: true`.
@@ -51,26 +51,46 @@ the reference, so omitted or incomplete permission data cannot render.
 
 Host public portfolio media on the existing approved OpenÉire media origin
 (`https://media.openeire.ie`) or a local, intentionally web-sized asset in
-`public/`. Do not commit camera originals, delivery archives or multi-gigabyte
-video masters. The Next.js image configuration currently permits only the
-OpenÉire API and media hosts.
+`public/`. Do not commit camera originals, delivery archives or video masters.
+The Next.js image configuration currently permits only the OpenÉire API and
+media hosts.
 
 Recommended exports:
 
 - photographs: AVIF or WebP where the pipeline supports it, with JPEG fallback
   when needed; retain a long edge suitable for the displayed size and compress
   for the web;
-- landscape film: H.264 MP4, 1920 x 1080, streaming-friendly bitrate and fast
-  start;
-- vertical cut: H.264 MP4, 1080 x 1920;
+- hero photographs: 2400-2560 pixels on the long edge;
+- gallery photographs: 1800-2200 pixels on the long edge;
+- use sRGB, remove GPS and unnecessary EXIF metadata, and target roughly
+  200-500 KB per gallery image;
 - poster: compressed WebP or JPEG matching the video's aspect ratio;
-- optional WebM only when the existing media pipeline produces and serves it;
 - floor plan: cleaned WebP, PNG or accessible PDF preview with all identifying
   address blocks removed unless separately approved.
 
-Videos use native controls, do not autoplay, use `preload="none"` and attach
-their source only near the viewport. Supply a compressed poster for every
-video.
+Use descriptive filenames for distinct views and reserve the final `-v1`,
+`-v2` segment for asset revisions. For example, prefer
+`kitchen-island-v1.webp` and `kitchen-dining-v1.webp` for two different angles.
+Existing approved objects named `kitchen-v1.webp` and `kitchen-v2.webp` remain
+valid and do not need to be renamed.
+
+Portfolio films are delivered by YouTube rather than directly from the media
+bucket. Upload the best-quality 4K MP4 to the OpenÉire Studios YouTube channel,
+allow embedding, and use either Public or Unlisted visibility as appropriate.
+Wait for 4K processing to finish before publication.
+
+Add only the 11-character YouTube video ID to `youtubeVideoId`, not a full
+YouTube URL. Supply a locally controlled compressed poster for every video.
+The portfolio renders that poster as a lightweight facade and does not contact
+YouTube until the visitor presses Play. Playback then uses YouTube Privacy
+Enhanced Mode through `youtube-nocookie.com`.
+
+Recommended YouTube export:
+
+- MP4 with H.264 High Profile and AAC audio at 48 kHz;
+- 3840 x 2160 for landscape 4K, retaining the captured frame rate;
+- variable bitrate, BT.709 for SDR footage, and web/fast-start enabled;
+- 35-45 Mbps for 24/25/30 fps, or 53-68 Mbps for 48/50/60 fps.
 
 ## Local checks
 
@@ -92,7 +112,7 @@ floor-plan fields produce no empty section.
 Search the production output for exact addresses and Irish Eircodes before
 release. Historical booking data must never be imported into this catalogue.
 
-## First real project: still required
+## Before enabling a project
 
 - a signed written portfolio/self-promotional approval from an authorised
   client or property representative;
@@ -100,8 +120,16 @@ release. Historical booking data must never be imported into this catalogue.
 - confirmation of whether client credit is required;
 - final approved image selections with alt text;
 - web-sized image exports and a designated hero image;
-- H.264 landscape and vertical exports, if approved for display;
+- a processed, embeddable YouTube upload for each approved film;
+- the 11-character YouTube video ID for each approved film;
 - compressed poster images for each approved video;
 - a redacted, web-sized floor-plan preview, if approved;
 - the accurate package/scope wording and approved completion month;
 - an internal, non-public permission reference for the catalogue.
+
+The demonstrated-format cards are derived from authorised, published project
+data. Photography formats require an actual hero or gallery image. Ground,
+aerial and social video formats require their corresponding video fields, and
+the floor-plan format requires an actual approved floor-plan image. Do not add
+format fields merely to advertise services; the commercial package catalogue
+is the authority for what OpenÉire sells.

--- a/openeire-next/docs/real-estate-portfolio.md
+++ b/openeire-next/docs/real-estate-portfolio.md
@@ -1,0 +1,107 @@
+# Real estate portfolio publishing guide
+
+The public portfolio lives at `/real-estate/portfolio`. Its catalogue is
+`lib/realEstatePortfolio.ts`. Rendering fails closed: a project is public only
+when `published` and `portfolioPermissionConfirmed` are both `true` and
+`permissionReference` contains a non-public internal reference.
+
+## Permission and privacy requirements
+
+Before adding any media, obtain a separate written approval that expressly
+allows OpenÉire Studios to use the named project's photographs, films and any
+floor plan for portfolio and self-promotional use. The approval should identify:
+
+- the property or commissioned project;
+- every media type approved for display;
+- the public channels covered, including `openeire.ie`;
+- whether an agent/client credit is required;
+- any location wording or other restrictions;
+- the approver's authority, name, date and written confirmation.
+
+Copyright ownership, payment, prior listing publication and the standard client
+licence are not portfolio permission. The current Property Media Service Terms,
+Package Booking Agreement v1.3 and retainer template do not grant this use.
+
+Store the approval in the restricted business record system. Put only a safe
+internal approval reference in `permissionReference`. Never put an address,
+Eircode, owner/vendor name, booking reference, access instruction, payment
+detail or private communication in frontend code, filenames, alt text, captions
+or metadata. Use a general location such as `County Galway`.
+
+## Add and publish a project
+
+1. Prepare a `RealEstatePortfolioProject` entry in
+   `lib/realEstatePortfolio.ts` with `published: false` and
+   `portfolioPermissionConfirmed: false`.
+2. Add meaningful, non-identifying alt text and explicit pixel dimensions for
+   every image. Omit video and floor-plan fields when those formats were not
+   delivered or are not approved.
+3. Verify the package name against the signed scope. For example, describe a
+   Pro booking with a floor-plan add-on exactly that way, not as Premium.
+4. Complete the privacy review and record the written approval.
+5. Add the safe internal approval reference, set
+   `portfolioPermissionConfirmed: true`, then set `published: true`.
+6. Run the checks below and review the generated HTML for private identifiers.
+
+To unpublish immediately, set either `published` or
+`portfolioPermissionConfirmed` to `false`. The filter requires both flags plus
+the reference, so omitted or incomplete permission data cannot render.
+
+## Media delivery
+
+Host public portfolio media on the existing approved OpenÉire media origin
+(`https://media.openeire.ie`) or a local, intentionally web-sized asset in
+`public/`. Do not commit camera originals, delivery archives or multi-gigabyte
+video masters. The Next.js image configuration currently permits only the
+OpenÉire API and media hosts.
+
+Recommended exports:
+
+- photographs: AVIF or WebP where the pipeline supports it, with JPEG fallback
+  when needed; retain a long edge suitable for the displayed size and compress
+  for the web;
+- landscape film: H.264 MP4, 1920 x 1080, streaming-friendly bitrate and fast
+  start;
+- vertical cut: H.264 MP4, 1080 x 1920;
+- poster: compressed WebP or JPEG matching the video's aspect ratio;
+- optional WebM only when the existing media pipeline produces and serves it;
+- floor plan: cleaned WebP, PNG or accessible PDF preview with all identifying
+  address blocks removed unless separately approved.
+
+Videos use native controls, do not autoplay, use `preload="none"` and attach
+their source only near the viewport. Supply a compressed poster for every
+video.
+
+## Local checks
+
+From `openeire-next`:
+
+```powershell
+npm.cmd run test
+npm.cmd run lint
+npm.cmd run typecheck
+npm.cmd run build
+git diff --check
+```
+
+Review the empty state and every enabled project at mobile, tablet and desktop
+widths. Test the image viewer with keyboard-only input: opening, previous/next,
+focus trapping, Escape to close and focus restoration. Confirm missing video or
+floor-plan fields produce no empty section.
+
+Search the production output for exact addresses and Irish Eircodes before
+release. Historical booking data must never be imported into this catalogue.
+
+## First real project: still required
+
+- a signed written portfolio/self-promotional approval from an authorised
+  client or property representative;
+- an approved general location and property-category description;
+- confirmation of whether client credit is required;
+- final approved image selections with alt text;
+- web-sized image exports and a designated hero image;
+- H.264 landscape and vertical exports, if approved for display;
+- compressed poster images for each approved video;
+- a redacted, web-sized floor-plan preview, if approved;
+- the accurate package/scope wording and approved completion month;
+- an internal, non-public permission reference for the catalogue.

--- a/openeire-next/lib/realEstatePortfolio.ts
+++ b/openeire-next/lib/realEstatePortfolio.ts
@@ -1,3 +1,8 @@
+import {
+  PORTFOLIO_FORMAT_ORDER,
+  type PortfolioFormat,
+} from "@/lib/realEstatePresentation";
+
 export type PortfolioImage = {
   src: string;
   alt: string;
@@ -7,7 +12,7 @@ export type PortfolioImage = {
 };
 
 export type PortfolioVideo = {
-  src: string;
+  youtubeVideoId: string;
   poster: PortfolioImage;
   title: string;
   description: string;
@@ -28,10 +33,14 @@ export type RealEstatePortfolioProject = {
   imageCount: number;
   heroImage?: PortfolioImage;
   galleryImages: readonly PortfolioImage[];
-  landscapeVideo?: PortfolioVideo;
-  verticalVideo?: PortfolioVideo;
+  photographyFormats: readonly Extract<
+    PortfolioFormat,
+    "photography" | "aerialStills"
+  >[];
+  groundVideo?: PortfolioVideo;
+  aerialVideo?: PortfolioVideo;
+  socialVideos?: readonly PortfolioVideo[];
   floorPlanImage?: PortfolioImage;
-  services: readonly string[];
   featured: boolean;
   published: boolean;
   portfolioPermissionConfirmed: boolean;
@@ -47,8 +56,101 @@ export type RealEstatePortfolioProject = {
  * Never use a booking reference, address, Eircode, client communication, or
  * other private identifier as permissionReference.
  */
+const COUNTY_GALWAY_PROJECT_MEDIA =
+  "https://media.openeire.ie/portfolio/county-galway-20260724";
+
 export const REAL_ESTATE_PORTFOLIO_PROJECTS: readonly RealEstatePortfolioProject[] =
-  [];
+  [
+    {
+      slug: "detached-residence-county-galway",
+      title: "Detached residence in County Galway",
+      generalLocation: "County Galway",
+      propertyType: "Detached country residence",
+      summary:
+        "A considered property-media set presenting the home, its characterful interiors and its mature rural setting.",
+      challenge:
+        "Show the scale and setting of a tree-lined rural property while keeping the interior sequence natural, clear and inviting.",
+      approach:
+        "Balance framed exterior compositions and aerial context with wide interior views that preserve the rooms' colour, character and connection to the landscape.",
+      deliverables: [
+        "Interior and exterior property photography",
+        "Aerial drone photography",
+        "Ground property video",
+      ],
+      packageName: "Residential property media coverage",
+      imageCount: 8,
+      heroImage: {
+        src: `${COUNTY_GALWAY_PROJECT_MEDIA}/hero-v1.webp`,
+        alt: "Front exterior of a detached country residence framed by mature trees",
+        width: 2500,
+        height: 1406,
+      },
+      galleryImages: [
+        {
+          src: `${COUNTY_GALWAY_PROJECT_MEDIA}/exterior-v1.webp`,
+          alt: "Rear exterior of the residence viewed across its tree-lined garden",
+          width: 2000,
+          height: 1125,
+        },
+        {
+          src: `${COUNTY_GALWAY_PROJECT_MEDIA}/drone-exterior-v1.webp`,
+          alt: "Aerial view showing the residence, gardens and surrounding countryside",
+          width: 2500,
+          height: 1406,
+        },
+        {
+          src: `${COUNTY_GALWAY_PROJECT_MEDIA}/living-room-v1.webp`,
+          alt: "Living room with garden views, patterned furnishings and timber details",
+          width: 2500,
+          height: 1667,
+        },
+        {
+          src: `${COUNTY_GALWAY_PROJECT_MEDIA}/kitchen-v1.webp`,
+          alt: "Long kitchen with dark cabinetry, a central island and pale timber flooring",
+          width: 2500,
+          height: 1667,
+        },
+        {
+          src: `${COUNTY_GALWAY_PROJECT_MEDIA}/kitchen-v2.webp`,
+          alt: "Kitchen and dining space looking towards the garden",
+          width: 2500,
+          height: 1667,
+        },
+        {
+          src: `${COUNTY_GALWAY_PROJECT_MEDIA}/bedroom-v1.webp`,
+          alt: "Double bedroom with timber furniture and a wide garden-facing window",
+          width: 2500,
+          height: 1667,
+        },
+        {
+          src: `${COUNTY_GALWAY_PROJECT_MEDIA}/bathroom-v1.webp`,
+          alt: "Blue bathroom with a freestanding bath and timber floor",
+          width: 2500,
+          height: 1667,
+        },
+      ],
+      photographyFormats: ["photography", "aerialStills"],
+      groundVideo: {
+        youtubeVideoId: "MTGASk31sGo",
+        poster: {
+          src: `${COUNTY_GALWAY_PROJECT_MEDIA}/drone-exterior-v1.webp`,
+          alt: "Aerial view of a residential property used as the video poster",
+          width: 2500,
+          height: 1406,
+        },
+        title: "Detached residence property film",
+        description:
+          "A landscape property film presenting the residence, its interiors and rural setting.",
+        width: 16,
+        height: 9,
+      },
+      featured: true,
+      published: true,
+      portfolioPermissionConfirmed: true,
+      permissionReference: "portfolio-approval-2026-07",
+      completedDate: "2026-07",
+    },
+  ];
 
 export const isPublicPortfolioProject = (
   project: RealEstatePortfolioProject,
@@ -63,3 +165,30 @@ export const getPublishedPortfolioProjects = (
 ): readonly RealEstatePortfolioProject[] =>
   projects.filter(isPublicPortfolioProject);
 
+export const getDemonstratedPortfolioFormats = (
+  projects: readonly RealEstatePortfolioProject[] =
+    REAL_ESTATE_PORTFOLIO_PROJECTS,
+): readonly PortfolioFormat[] => {
+  const demonstratedFormats = new Set<PortfolioFormat>();
+
+  for (const project of getPublishedPortfolioProjects(projects)) {
+    const hasPhotography =
+      Boolean(project.heroImage) || project.galleryImages.length > 0;
+
+    if (hasPhotography) {
+      project.photographyFormats.forEach((format) =>
+        demonstratedFormats.add(format),
+      );
+    }
+    if (project.groundVideo) demonstratedFormats.add("groundVideo");
+    if (project.aerialVideo) demonstratedFormats.add("aerialVideo");
+    if (project.socialVideos?.length) {
+      demonstratedFormats.add("socialMediaCuts");
+    }
+    if (project.floorPlanImage) demonstratedFormats.add("floorPlan");
+  }
+
+  return PORTFOLIO_FORMAT_ORDER.filter((format) =>
+    demonstratedFormats.has(format),
+  );
+};

--- a/openeire-next/lib/realEstatePortfolio.ts
+++ b/openeire-next/lib/realEstatePortfolio.ts
@@ -1,0 +1,65 @@
+export type PortfolioImage = {
+  src: string;
+  alt: string;
+  width: number;
+  height: number;
+  caption?: string;
+};
+
+export type PortfolioVideo = {
+  src: string;
+  poster: PortfolioImage;
+  title: string;
+  description: string;
+  width: number;
+  height: number;
+};
+
+export type RealEstatePortfolioProject = {
+  slug: string;
+  title: string;
+  generalLocation: string;
+  propertyType: string;
+  summary: string;
+  challenge: string;
+  approach: string;
+  deliverables: readonly string[];
+  packageName: string;
+  imageCount: number;
+  heroImage?: PortfolioImage;
+  galleryImages: readonly PortfolioImage[];
+  landscapeVideo?: PortfolioVideo;
+  verticalVideo?: PortfolioVideo;
+  floorPlanImage?: PortfolioImage;
+  services: readonly string[];
+  featured: boolean;
+  published: boolean;
+  portfolioPermissionConfirmed: boolean;
+  permissionReference?: string;
+  completedDate?: string;
+  clientCredit?: string;
+};
+
+/**
+ * This catalogue is intentionally safe to ship with no public entries.
+ *
+ * Add project content only after following docs/real-estate-portfolio.md.
+ * Never use a booking reference, address, Eircode, client communication, or
+ * other private identifier as permissionReference.
+ */
+export const REAL_ESTATE_PORTFOLIO_PROJECTS: readonly RealEstatePortfolioProject[] =
+  [];
+
+export const isPublicPortfolioProject = (
+  project: RealEstatePortfolioProject,
+): boolean =>
+  project.published === true &&
+  project.portfolioPermissionConfirmed === true &&
+  Boolean(project.permissionReference?.trim());
+
+export const getPublishedPortfolioProjects = (
+  projects: readonly RealEstatePortfolioProject[] =
+    REAL_ESTATE_PORTFOLIO_PROJECTS,
+): readonly RealEstatePortfolioProject[] =>
+  projects.filter(isPublicPortfolioProject);
+

--- a/openeire-next/lib/realEstatePresentation.ts
+++ b/openeire-next/lib/realEstatePresentation.ts
@@ -1,0 +1,58 @@
+export const REAL_ESTATE_PORTFOLIO_PATH = "/real-estate/portfolio";
+
+export const REAL_ESTATE_HERO_IMAGE = {
+  src: "https://media.openeire.ie/portfolio/county-galway-20260724/drone-exterior-v1.webp",
+  alt: "Aerial view of a residential property photographed by OpenÉire Studios",
+  width: 2500,
+  height: 1406,
+} as const;
+
+export const REAL_ESTATE_PORTFOLIO_HERO_IMAGE = {
+  src: "https://media.openeire.ie/portfolio/county-galway-20260724/hero-v1.webp",
+  alt: "Exterior view of a residential property photographed by OpenÉire Studios",
+  width: 2500,
+  height: 1406,
+} as const;
+
+export type RealEstateHeroImageConfig =
+  | typeof REAL_ESTATE_HERO_IMAGE
+  | typeof REAL_ESTATE_PORTFOLIO_HERO_IMAGE;
+
+export const PORTFOLIO_FORMAT_DEFINITIONS = {
+  photography: {
+    title: "Interior and exterior photography",
+    text: "A considered sequence of rooms, details, exterior elevations and setting.",
+  },
+  aerialStills: {
+    title: "Aerial drone stills",
+    text: "Elevated context for the property, grounds and wider setting.",
+  },
+  groundVideo: {
+    title: "Ground property video",
+    text: "A natural visual walkthrough shaped around the property and listing brief.",
+  },
+  aerialVideo: {
+    title: "Aerial video",
+    text: "Controlled aerial movement that helps establish scale and setting.",
+  },
+  socialMediaCuts: {
+    title: "Social-media cuts",
+    text: "Purpose-made vertical and square edits for listing channels.",
+  },
+  floorPlan: {
+    title: "Measured 2D floor plans",
+    text: "Clear layout information supplied as an optional listing asset.",
+  },
+} as const;
+
+export type PortfolioFormat =
+  keyof typeof PORTFOLIO_FORMAT_DEFINITIONS;
+
+export const PORTFOLIO_FORMAT_ORDER: readonly PortfolioFormat[] = [
+  "photography",
+  "aerialStills",
+  "groundVideo",
+  "aerialVideo",
+  "socialMediaCuts",
+  "floorPlan",
+];

--- a/openeire-next/lib/seo/realEstatePortfolioJsonLd.ts
+++ b/openeire-next/lib/seo/realEstatePortfolioJsonLd.ts
@@ -1,0 +1,76 @@
+import type { RealEstatePortfolioProject } from "@/lib/realEstatePortfolio";
+import { buildBreadcrumbJsonLd } from "@/lib/seo/jsonLd";
+import { buildAbsoluteUrl, SITE_NAME } from "@/lib/site";
+
+export const REAL_ESTATE_PORTFOLIO_TITLE =
+  "Real Estate Photography Portfolio | OpenÉire Studios";
+export const REAL_ESTATE_PORTFOLIO_DESCRIPTION =
+  "Explore professional property photography, drone media, property films and listing assets created by OpenÉire Studios for properties across Galway and Connacht.";
+
+export const buildPortfolioJsonLd = (
+  projects: readonly RealEstatePortfolioProject[],
+) => [
+  {
+    ...buildBreadcrumbJsonLd([
+      { name: "Home", url: buildAbsoluteUrl("/") },
+      { name: "Real Estate Media", url: buildAbsoluteUrl("/real-estate") },
+      {
+        name: "Real Estate Media Portfolio",
+        url: buildAbsoluteUrl("/real-estate/portfolio"),
+      },
+    ]),
+    "@id": buildAbsoluteUrl("/real-estate/portfolio#breadcrumb"),
+  },
+  {
+    "@context": "https://schema.org",
+    "@type": "CollectionPage",
+    "@id": buildAbsoluteUrl("/real-estate/portfolio#collection"),
+    url: buildAbsoluteUrl("/real-estate/portfolio"),
+    name: REAL_ESTATE_PORTFOLIO_TITLE,
+    description: REAL_ESTATE_PORTFOLIO_DESCRIPTION,
+    isPartOf: {
+      "@type": "WebSite",
+      name: SITE_NAME,
+      url: buildAbsoluteUrl("/"),
+    },
+    breadcrumb: {
+      "@id": buildAbsoluteUrl("/real-estate/portfolio#breadcrumb"),
+    },
+    ...(projects.length
+      ? {
+          mainEntity: {
+            "@type": "ItemList",
+            numberOfItems: projects.length,
+            itemListElement: projects.map((project, index) => ({
+              "@type": "CreativeWork",
+              position: index + 1,
+              name: project.title,
+              description: project.summary,
+              url: buildAbsoluteUrl(
+                `/real-estate/portfolio#${project.slug}`,
+              ),
+              contentLocation: {
+                "@type": "Place",
+                name: project.generalLocation,
+              },
+              ...(project.completedDate
+                ? { dateCreated: project.completedDate }
+                : {}),
+              ...(project.heroImage
+                ? {
+                    image: {
+                      "@type": "ImageObject",
+                      contentUrl: buildAbsoluteUrl(project.heroImage.src),
+                      caption: project.heroImage.alt,
+                      width: project.heroImage.width,
+                      height: project.heroImage.height,
+                    },
+                  }
+                : {}),
+            })),
+          },
+        }
+      : {}),
+  },
+];
+

--- a/openeire-next/lib/seo/realEstatePortfolioJsonLd.ts
+++ b/openeire-next/lib/seo/realEstatePortfolioJsonLd.ts
@@ -1,11 +1,12 @@
 import type { RealEstatePortfolioProject } from "@/lib/realEstatePortfolio";
+import { REAL_ESTATE_PORTFOLIO_PATH } from "@/lib/realEstatePresentation";
 import { buildBreadcrumbJsonLd } from "@/lib/seo/jsonLd";
 import { buildAbsoluteUrl, SITE_NAME } from "@/lib/site";
 
 export const REAL_ESTATE_PORTFOLIO_TITLE =
   "Real Estate Photography Portfolio | OpenÉire Studios";
 export const REAL_ESTATE_PORTFOLIO_DESCRIPTION =
-  "Explore professional property photography, drone media, property films and listing assets created by OpenÉire Studios for properties across Galway and Connacht.";
+  "Explore approved property photography, aerial media and published project work created by OpenÉire Studios for properties across Galway and Connacht.";
 
 export const buildPortfolioJsonLd = (
   projects: readonly RealEstatePortfolioProject[],
@@ -16,16 +17,16 @@ export const buildPortfolioJsonLd = (
       { name: "Real Estate Media", url: buildAbsoluteUrl("/real-estate") },
       {
         name: "Real Estate Media Portfolio",
-        url: buildAbsoluteUrl("/real-estate/portfolio"),
+        url: buildAbsoluteUrl(REAL_ESTATE_PORTFOLIO_PATH),
       },
     ]),
-    "@id": buildAbsoluteUrl("/real-estate/portfolio#breadcrumb"),
+    "@id": buildAbsoluteUrl(`${REAL_ESTATE_PORTFOLIO_PATH}#breadcrumb`),
   },
   {
     "@context": "https://schema.org",
     "@type": "CollectionPage",
-    "@id": buildAbsoluteUrl("/real-estate/portfolio#collection"),
-    url: buildAbsoluteUrl("/real-estate/portfolio"),
+    "@id": buildAbsoluteUrl(`${REAL_ESTATE_PORTFOLIO_PATH}#collection`),
+    url: buildAbsoluteUrl(REAL_ESTATE_PORTFOLIO_PATH),
     name: REAL_ESTATE_PORTFOLIO_TITLE,
     description: REAL_ESTATE_PORTFOLIO_DESCRIPTION,
     isPartOf: {
@@ -34,7 +35,7 @@ export const buildPortfolioJsonLd = (
       url: buildAbsoluteUrl("/"),
     },
     breadcrumb: {
-      "@id": buildAbsoluteUrl("/real-estate/portfolio#breadcrumb"),
+      "@id": buildAbsoluteUrl(`${REAL_ESTATE_PORTFOLIO_PATH}#breadcrumb`),
     },
     ...(projects.length
       ? {
@@ -47,7 +48,7 @@ export const buildPortfolioJsonLd = (
               name: project.title,
               description: project.summary,
               url: buildAbsoluteUrl(
-                `/real-estate/portfolio#${project.slug}`,
+                `${REAL_ESTATE_PORTFOLIO_PATH}#${project.slug}`,
               ),
               contentLocation: {
                 "@type": "Place",
@@ -73,4 +74,3 @@ export const buildPortfolioJsonLd = (
       : {}),
   },
 ];
-

--- a/openeire-next/next.config.ts
+++ b/openeire-next/next.config.ts
@@ -87,6 +87,7 @@ const buildContentSecurityPolicy = (): string => {
       "https://m.stripe.network",
       "https://*.stripe.com",
       "https://accounts.google.com",
+      "https://www.youtube-nocookie.com",
       "https://cdn.iubenda.com",
       "https://embeds.iubenda.com",
       "https://*.iubenda.com",

--- a/openeire-next/tests/analyticsBootstrap.test.tsx
+++ b/openeire-next/tests/analyticsBootstrap.test.tsx
@@ -1,3 +1,5 @@
+import fs from "node:fs";
+import path from "node:path";
 import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -67,6 +69,23 @@ describe("root GA4 bootstrap", () => {
     expect(bootstrap).toContain('ad_user_data: "denied"');
     expect(bootstrap).toContain('ad_personalization: "denied"');
     expect(bootstrap).toContain("send_page_view: false");
+  });
+
+  it("loads DOM-mutating remote scripts only after React hydration", () => {
+    const layoutSource = fs.readFileSync(
+      path.join(process.cwd(), "app", "layout.tsx"),
+      "utf8",
+    );
+
+    expect(layoutSource).toMatch(
+      /id="openeire-iubenda-widget"[\s\S]*?strategy="afterInteractive"/,
+    );
+    expect(layoutSource).toMatch(
+      /id=\{GA_SCRIPT_ID\}[\s\S]*?strategy="afterInteractive"/,
+    );
+    expect(layoutSource).toMatch(
+      /id="openeire-ga4-bootstrap"[\s\S]*?strategy="beforeInteractive"/,
+    );
   });
 
   it("falls back to the checked production ID when the public env is missing", async () => {

--- a/openeire-next/tests/portfolioGallery.test.tsx
+++ b/openeire-next/tests/portfolioGallery.test.tsx
@@ -1,18 +1,25 @@
+import fs from "node:fs";
+import path from "node:path";
 import {
   cleanup,
   fireEvent,
   render,
   screen,
   waitFor,
+  within,
 } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { PortfolioGallery } from "@/components/real-estate/PortfolioGallery";
+import {
+  PortfolioGallery,
+  splitPortfolioGalleryRows,
+} from "@/components/real-estate/PortfolioGallery";
+import type { PortfolioImage } from "@/lib/realEstatePortfolio";
 
 vi.mock("@/lib/analytics", () => ({
   trackEvent: vi.fn(),
 }));
 
-const images = [
+const images: readonly PortfolioImage[] = [
   {
     src: "/hero-poster.jpg",
     alt: "Exterior view across a rural property setting",
@@ -25,46 +32,185 @@ const images = [
     width: 1080,
     height: 1350,
   },
-] as const;
+  {
+    src: "/gallery/photo/property-room.jpg",
+    alt: "Interior room with natural light",
+    width: 1600,
+    height: 1067,
+  },
+  {
+    src: "/gallery/photo/property-detail.jpg",
+    alt: "Architectural detail inside the residence",
+    width: 1200,
+    height: 1600,
+  },
+  {
+    src: "/gallery/photo/property-aerial.jpg",
+    alt: "Aerial view of the residence and grounds",
+    width: 2000,
+    height: 1125,
+  },
+];
 
 describe("portfolio gallery", () => {
-  afterEach(cleanup);
+  afterEach(() => {
+    cleanup();
+    document.body.style.overflow = "";
+  });
 
-  it("supports opening, keyboard navigation, Escape and focus restoration", async () => {
+  it("balances odd and even image sets across two rows", () => {
+    const [oddFirst, oddSecond] = splitPortfolioGalleryRows(images);
+    expect(oddFirst.map(({ originalIndex }) => originalIndex)).toEqual([
+      0, 2, 4,
+    ]);
+    expect(oddSecond.map(({ originalIndex }) => originalIndex)).toEqual([1, 3]);
+
+    const [evenFirst, evenSecond] = splitPortfolioGalleryRows(
+      images.slice(0, 4),
+    );
+    expect(evenFirst).toHaveLength(2);
+    expect(evenSecond).toHaveLength(2);
+  });
+
+  it("renders two oppositely directed rows with inaccessible clones", () => {
+    const { container } = render(
+      <PortfolioGallery images={images} projectSlug="test-project" />,
+    );
+
+    const rows = container.querySelectorAll("[data-gallery-row]");
+    expect(rows).toHaveLength(2);
+    expect(rows[0].getAttribute("data-direction")).toBe("forward");
+    expect(rows[1].getAttribute("data-direction")).toBe("reverse");
+
+    const originals = container.querySelectorAll(
+      '[data-gallery-sequence="original"] [data-gallery-original="true"]',
+    );
+    const clones = container.querySelectorAll(
+      '[data-gallery-sequence="clone"]',
+    );
+    expect(originals).toHaveLength(images.length);
+    expect(clones).toHaveLength(4);
+
+    for (const clone of clones) {
+      expect(clone.getAttribute("aria-hidden")).toBe("true");
+      expect(clone.querySelectorAll("button, a, [tabindex]")).toHaveLength(0);
+      for (const image of clone.querySelectorAll("img")) {
+        expect(image.getAttribute("alt")).toBe("");
+      }
+    }
+
+    expect(screen.getAllByRole("button", { name: /Open image/i })).toHaveLength(
+      images.length,
+    );
+  });
+
+  it("keeps original cards keyboard operable and preserves natural dimensions", () => {
     render(<PortfolioGallery images={images} projectSlug="test-project" />);
+
     const firstTrigger = screen.getByRole("button", {
-      name: /Open image 1 of 2/i,
+      name: /Open image 1 of 5/i,
     });
+    firstTrigger.focus();
+    expect(document.activeElement).toBe(firstTrigger);
+    expect(firstTrigger.getAttribute("tabindex")).not.toBe("-1");
+
+    const firstImage = screen.getByAltText(images[0].alt);
+    expect(firstImage.getAttribute("width")).toBe(String(images[0].width));
+    expect(firstImage.getAttribute("height")).toBe(String(images[0].height));
 
     fireEvent.click(firstTrigger);
     expect(screen.getByRole("dialog")).toBeTruthy();
+  });
+
+  it("uses only the unique image sequence for lightbox navigation", async () => {
+    render(<PortfolioGallery images={images} projectSlug="test-project" />);
+    const firstTrigger = screen.getByRole("button", {
+      name: /Open image 1 of 5/i,
+    });
+
+    fireEvent.click(firstTrigger);
+    expect(document.body.style.overflow).toBe("hidden");
     expect(document.activeElement).toBe(
       screen.getByRole("button", { name: "Close image viewer" }),
     );
 
+    fireEvent.keyDown(document, { key: "ArrowLeft" });
+    expect(
+      screen.getByRole("dialog", {
+        name: /image 5 of 5/i,
+      }),
+    ).toBeTruthy();
+
     fireEvent.keyDown(document, { key: "ArrowRight" });
     expect(
       screen.getByRole("dialog", {
-        name: /image 2 of 2/i,
+        name: /image 1 of 5/i,
       }),
     ).toBeTruthy();
 
     fireEvent.keyDown(document, { key: "Escape" });
     expect(screen.queryByRole("dialog")).toBeNull();
     await waitFor(() => expect(document.activeElement).toBe(firstTrigger));
+    expect(document.body.style.overflow).toBe("");
   });
 
-  it("renders an accessible fallback when an image fails", () => {
+  it("closes from the backdrop without treating image content as a backdrop click", async () => {
     render(<PortfolioGallery images={images} projectSlug="test-project" />);
-    fireEvent.error(
-      screen.getByAltText("Exterior view across a rural property setting"),
+    const firstTrigger = screen.getByRole("button", {
+      name: /Open image 1 of 5/i,
+    });
+    fireEvent.click(firstTrigger);
+
+    const dialog = screen.getByRole("dialog");
+    fireEvent.click(within(dialog).getByAltText(images[0].alt));
+    expect(screen.getByRole("dialog")).toBeTruthy();
+
+    fireEvent.click(dialog);
+    expect(screen.queryByRole("dialog")).toBeNull();
+    await waitFor(() => expect(document.activeElement).toBe(firstTrigger));
+  });
+
+  it("renders an accessible original fallback when an image fails", () => {
+    const { container } = render(
+      <PortfolioGallery images={images} projectSlug="test-project" />,
+    );
+    fireEvent.error(screen.getByAltText(images[0].alt));
+
+    const unavailableButton = screen.getByRole("button", {
+      name: /Image unavailable: Exterior view/i,
+    });
+    expect(unavailableButton.hasAttribute("disabled")).toBe(true);
+    expect(unavailableButton.textContent).toContain(
+      "Image temporarily unavailable",
+    );
+    expect(
+      container.querySelector(
+        '[data-gallery-sequence="clone"] [aria-label]',
+      ),
+    ).toBeNull();
+  });
+
+  it("defines static mobile and reduced-motion fallbacks with desktop pause controls", () => {
+    const stylesheet = fs.readFileSync(
+      path.join(
+        process.cwd(),
+        "components",
+        "real-estate",
+        "PortfolioGallery.module.css",
+      ),
+      "utf8",
     );
 
-    expect(screen.getByText("Image temporarily unavailable")).toBeTruthy();
-    expect(
-      screen.getByRole("button", {
-        name: /Image unavailable: Exterior view/i,
-      }),
-    ).toBeTruthy();
+    expect(stylesheet).toMatch(/\.cloneSequence\s*{[\s\S]*display:\s*none/);
+    expect(stylesheet).toMatch(
+      /min-width:\s*768px[\s\S]*prefers-reduced-motion:\s*no-preference/,
+    );
+    expect(stylesheet).toMatch(/\.forward[\s\S]*portfolio-marquee-forward/);
+    expect(stylesheet).toMatch(/\.reverse[\s\S]*portfolio-marquee-reverse/);
+    expect(stylesheet).toMatch(/\.row:hover \.track/);
+    expect(stylesheet).toMatch(/\.row:focus-within \.track/);
+    expect(stylesheet).toMatch(/prefers-reduced-motion:\s*reduce/);
+    expect(stylesheet).toMatch(/min-width:\s*2\.75rem/);
+    expect(stylesheet).toMatch(/min-height:\s*2\.75rem/);
   });
 });

--- a/openeire-next/tests/portfolioGallery.test.tsx
+++ b/openeire-next/tests/portfolioGallery.test.tsx
@@ -1,0 +1,70 @@
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { PortfolioGallery } from "@/components/real-estate/PortfolioGallery";
+
+vi.mock("@/lib/analytics", () => ({
+  trackEvent: vi.fn(),
+}));
+
+const images = [
+  {
+    src: "/hero-poster.jpg",
+    alt: "Exterior view across a rural property setting",
+    width: 1920,
+    height: 1080,
+  },
+  {
+    src: "/hero-poster-mobile.jpg",
+    alt: "Portrait detail of the property setting",
+    width: 1080,
+    height: 1350,
+  },
+] as const;
+
+describe("portfolio gallery", () => {
+  afterEach(cleanup);
+
+  it("supports opening, keyboard navigation, Escape and focus restoration", async () => {
+    render(<PortfolioGallery images={images} projectSlug="test-project" />);
+    const firstTrigger = screen.getByRole("button", {
+      name: /Open image 1 of 2/i,
+    });
+
+    fireEvent.click(firstTrigger);
+    expect(screen.getByRole("dialog")).toBeTruthy();
+    expect(document.activeElement).toBe(
+      screen.getByRole("button", { name: "Close image viewer" }),
+    );
+
+    fireEvent.keyDown(document, { key: "ArrowRight" });
+    expect(
+      screen.getByRole("dialog", {
+        name: /image 2 of 2/i,
+      }),
+    ).toBeTruthy();
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(screen.queryByRole("dialog")).toBeNull();
+    await waitFor(() => expect(document.activeElement).toBe(firstTrigger));
+  });
+
+  it("renders an accessible fallback when an image fails", () => {
+    render(<PortfolioGallery images={images} projectSlug="test-project" />);
+    fireEvent.error(
+      screen.getByAltText("Exterior view across a rural property setting"),
+    );
+
+    expect(screen.getByText("Image temporarily unavailable")).toBeTruthy();
+    expect(
+      screen.getByRole("button", {
+        name: /Image unavailable: Exterior view/i,
+      }),
+    ).toBeTruthy();
+  });
+});

--- a/openeire-next/tests/portfolioVideo.test.tsx
+++ b/openeire-next/tests/portfolioVideo.test.tsx
@@ -1,0 +1,153 @@
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+} from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  isValidYouTubeVideoId,
+  PortfolioVideo,
+  VIDEO_LOAD_TIMEOUT_MS,
+} from "@/components/real-estate/PortfolioVideo";
+import type { PortfolioVideo as PortfolioVideoData } from "@/lib/realEstatePortfolio";
+
+const trackEventMock = vi.hoisted(() => vi.fn());
+
+vi.mock("@/lib/analytics", () => ({
+  trackEvent: trackEventMock,
+}));
+
+const video: PortfolioVideoData = {
+  youtubeVideoId: "AbCdEfGhI12",
+  poster: {
+    src: "/hero-poster.jpg",
+    alt: "Exterior view of a rural property",
+    width: 1920,
+    height: 1080,
+  },
+  title: "County Galway property film",
+  description: "A landscape film showing the property and its setting.",
+  width: 16,
+  height: 9,
+};
+
+describe("portfolio YouTube video", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    cleanup();
+  });
+
+  it("loads no YouTube iframe until play and keeps the poster while loading", () => {
+    render(<PortfolioVideo video={video} projectSlug="galway-property" />);
+
+    expect(screen.queryByTitle(video.title)).toBeNull();
+    expect(
+      screen.getByText("YouTube is loaded only after you press play."),
+    ).toBeTruthy();
+
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: `Play ${video.title} on YouTube`,
+      }),
+    );
+
+    const iframe = screen.getByTitle(video.title);
+    expect(iframe.getAttribute("src")).toBe(
+      `https://www.youtube-nocookie.com/embed/${video.youtubeVideoId}?autoplay=1&playsinline=1&rel=0`,
+    );
+    expect(iframe.hasAttribute("loading")).toBe(false);
+    expect(iframe.getAttribute("referrerpolicy")).toBe(
+      "strict-origin-when-cross-origin",
+    );
+    expect(iframe.getAttribute("data-cmp-ab")).toBe("1");
+    expect(iframe.hasAttribute("allowfullscreen")).toBe(true);
+    expect(iframe.className).toMatch(/h-full/);
+    expect(iframe.className).toMatch(/w-full/);
+    expect(iframe.className).toMatch(/opacity-0/);
+    expect(screen.getByRole("status").textContent).toContain("Loading film");
+    expect(screen.getByAltText(video.poster.alt)).toBeTruthy();
+    expect(
+      screen.getByRole("link", {
+        name: /Having trouble\? Watch on YouTube/i,
+      }).getAttribute("href"),
+    ).toBe(`https://www.youtube.com/watch?v=${video.youtubeVideoId}`);
+
+    fireEvent.load(iframe);
+    expect(screen.queryByRole("status")).toBeNull();
+    expect(screen.queryByAltText(video.poster.alt)).toBeNull();
+    expect(screen.getByTitle(video.title).className).toMatch(/opacity-100/);
+    expect(trackEventMock).toHaveBeenCalledWith("portfolio_film_play", {
+      project_slug: "galway-property",
+      video_title: video.title,
+      video_provider: "youtube",
+    });
+  });
+
+  it("fails closed for malformed YouTube video IDs", () => {
+    render(
+      <PortfolioVideo
+        video={{ ...video, youtubeVideoId: "https://example.com/video" }}
+        projectSlug="galway-property"
+      />,
+    );
+
+    expect(screen.getByRole("status").textContent).toContain(
+      "Video temporarily unavailable",
+    );
+    expect(screen.queryByRole("button")).toBeNull();
+    expect(screen.queryByTitle(video.title)).toBeNull();
+  });
+
+  it("keeps the accessible play control when the poster fails to load", () => {
+    render(<PortfolioVideo video={video} projectSlug="galway-property" />);
+
+    fireEvent.error(screen.getByAltText(video.poster.alt));
+
+    expect(
+      screen.getByRole("img", {
+        name: `${video.poster.alt}. Image temporarily unavailable.`,
+      }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("button", {
+        name: `Play ${video.title} on YouTube`,
+      }),
+    ).toBeTruthy();
+    expect(screen.queryByTitle(video.title)).toBeNull();
+  });
+
+  it("shows retry and direct-watch controls when the iframe fails", () => {
+    vi.useFakeTimers();
+    render(<PortfolioVideo video={video} projectSlug="galway-property" />);
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: `Play ${video.title} on YouTube`,
+      }),
+    );
+
+    act(() => {
+      vi.advanceTimersByTime(VIDEO_LOAD_TIMEOUT_MS);
+    });
+
+    expect(screen.getByRole("alert").textContent).toContain(
+      "The embedded player could not be loaded.",
+    );
+    expect(screen.getByRole("button", { name: "Try again" })).toBeTruthy();
+    expect(
+      screen.getByRole("link", { name: "Watch on YouTube" }).getAttribute(
+        "href",
+      ),
+    ).toBe(`https://www.youtube.com/watch?v=${video.youtubeVideoId}`);
+    expect(screen.getByAltText(video.poster.alt)).toBeTruthy();
+  });
+
+  it("accepts only canonical 11-character YouTube video IDs", () => {
+    expect(isValidYouTubeVideoId("AbCdEfGhI12")).toBe(true);
+    expect(isValidYouTubeVideoId("abc_123-XYZ")).toBe(true);
+    expect(isValidYouTubeVideoId("MTGASk31sGo")).toBe(true);
+    expect(isValidYouTubeVideoId("short")).toBe(false);
+    expect(isValidYouTubeVideoId("AbCdEfGhI12?autoplay=1")).toBe(false);
+  });
+});

--- a/openeire-next/tests/realEstatePortfolio.test.tsx
+++ b/openeire-next/tests/realEstatePortfolio.test.tsx
@@ -1,0 +1,200 @@
+import fs from "node:fs";
+import path from "node:path";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import RealEstatePortfolioPage, {
+  metadata,
+} from "@/app/real-estate/portfolio/page";
+import { PortfolioProject } from "@/components/real-estate/PortfolioProject";
+import {
+  REAL_ESTATE_PORTFOLIO_PROJECTS,
+  getPublishedPortfolioProjects,
+  type RealEstatePortfolioProject,
+} from "@/lib/realEstatePortfolio";
+import { buildPortfolioJsonLd } from "@/lib/seo/realEstatePortfolioJsonLd";
+
+vi.mock("@/lib/analytics", () => ({
+  trackEvent: vi.fn(),
+}));
+
+const buildProject = (
+  overrides: Partial<RealEstatePortfolioProject> = {},
+): RealEstatePortfolioProject => ({
+  slug: "county-galway-residence",
+  title: "County Galway residential property",
+  generalLocation: "County Galway",
+  propertyType: "Detached residence",
+  summary: "A balanced set of listing assets shaped around the property.",
+  challenge: "Show the rooms, exterior and setting as one coherent listing.",
+  approach: "Use natural compositions and a measured capture sequence.",
+  deliverables: ["Interior and exterior photography", "Aerial drone stills"],
+  packageName: "Pro plus floor-plan add-on",
+  imageCount: 2,
+  galleryImages: [
+    {
+      src: "/hero-poster.jpg",
+      alt: "Wide landscape view used as a test portfolio image",
+      width: 1920,
+      height: 1080,
+    },
+  ],
+  services: ["Property photography", "Aerial drone stills"],
+  featured: true,
+  published: true,
+  portfolioPermissionConfirmed: true,
+  permissionReference: "CONSENT-REDACTED-001",
+  ...overrides,
+});
+
+describe("real-estate portfolio", () => {
+  afterEach(cleanup);
+
+  it("renders the correct page heading, CTAs and professional empty state", () => {
+    render(<RealEstatePortfolioPage />);
+
+    expect(
+      screen.getByRole("heading", {
+        level: 1,
+        name: /Present every property with clarity/i,
+      }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("link", { name: "Discuss a Property" }).getAttribute("href"),
+    ).toBe("/real-estate#enquiry");
+    expect(
+      screen
+        .getByRole("link", { name: "View Services & Packages" })
+        .getAttribute("href"),
+    ).toBe("/real-estate");
+    expect(
+      screen.getByRole("heading", {
+        name: /portfolio is being prepared for publication/i,
+      }),
+    ).toBeTruthy();
+  });
+
+  it("only returns projects with explicit publication and permission state", () => {
+    const authorised = buildProject();
+    const unpublished = buildProject({
+      slug: "unpublished",
+      title: "Unpublished project",
+      published: false,
+    });
+    const unpermitted = buildProject({
+      slug: "private",
+      title: "Private Listing A65 F4E2",
+      generalLocation: "Exact private location",
+      galleryImages: [
+        {
+          src: "https://media.openeire.ie/private-property.webp",
+          alt: "Private property asset",
+          width: 1600,
+          height: 1200,
+        },
+      ],
+      portfolioPermissionConfirmed: false,
+      permissionReference: undefined,
+    });
+    const missingReference = buildProject({
+      slug: "missing-reference",
+      title: "Missing permission reference",
+      permissionReference: " ",
+    });
+
+    expect(
+      getPublishedPortfolioProjects([
+        authorised,
+        unpublished,
+        unpermitted,
+        missingReference,
+      ]),
+    ).toEqual([authorised]);
+  });
+
+  it("does not leak unauthorised project data into JSON-LD", () => {
+    const authorised = buildProject();
+    const unpermitted = buildProject({
+      slug: "private",
+      title: "Private Listing A65 F4E2",
+      generalLocation: "Exact private location",
+      portfolioPermissionConfirmed: false,
+      permissionReference: undefined,
+    });
+    const publicProjects = getPublishedPortfolioProjects([
+      authorised,
+      unpermitted,
+    ]);
+    const serialized = JSON.stringify(buildPortfolioJsonLd(publicProjects));
+
+    expect(serialized).toContain(authorised.title);
+    expect(serialized).not.toContain(unpermitted.title);
+    expect(serialized).not.toContain(unpermitted.generalLocation);
+    expect(serialized).not.toContain("undefined");
+    expect(serialized).not.toMatch(/\b[A-Z]\d{2}\s?[A-Z0-9]{4}\b/);
+  });
+
+  it("omits optional film and floor-plan sections when assets are absent", () => {
+    render(<PortfolioProject project={buildProject()} />);
+
+    expect(
+      screen.queryByRole("heading", { name: "Property film" }),
+    ).toBeNull();
+    expect(
+      screen.queryByRole("heading", { name: "Measured 2D floor plan" }),
+    ).toBeNull();
+    expect(
+      screen.getByRole("heading", { name: "Property photography" }),
+    ).toBeTruthy();
+  });
+
+  it("uses production metadata and the canonical portfolio URL", () => {
+    expect(metadata.title).toBe(
+      "Real Estate Photography Portfolio | OpenÉire Studios",
+    );
+    expect(metadata.description).toMatch(/drone media, property films/i);
+    expect(metadata.alternates?.canonical).toBe(
+      "https://openeire.ie/real-estate/portfolio",
+    );
+    expect(metadata.openGraph?.url).toBe(
+      "https://openeire.ie/real-estate/portfolio",
+    );
+  });
+
+  it("integrates the portfolio into service navigation, footer and service page", () => {
+    const targets = [
+      path.join(process.cwd(), "components", "layout", "Navbar.tsx"),
+      path.join(process.cwd(), "components", "layout", "Footer.tsx"),
+      path.join(process.cwd(), "app", "real-estate", "page.tsx"),
+      path.join(process.cwd(), "app", "sitemap.ts"),
+    ];
+
+    for (const target of targets) {
+      expect(fs.readFileSync(target, "utf8")).toContain(
+        "/real-estate/portfolio",
+      );
+    }
+  });
+
+  it("does not import historical booking data into public portfolio code", () => {
+    const publicPortfolioSources = [
+      path.join(process.cwd(), "app", "real-estate", "portfolio", "page.tsx"),
+      path.join(process.cwd(), "lib", "realEstatePortfolio.ts"),
+      path.join(
+        process.cwd(),
+        "components",
+        "real-estate",
+        "PortfolioProject.tsx",
+      ),
+    ]
+      .map((target) => fs.readFileSync(target, "utf8"))
+      .join("\n");
+
+    expect(publicPortfolioSources).not.toMatch(
+      /(?:import|from|require\()[^\n]*(?:booking|agreement|client-record)/i,
+    );
+    expect(REAL_ESTATE_PORTFOLIO_PROJECTS).toEqual([]);
+    expect(publicPortfolioSources).not.toMatch(
+      /\b[A-Z]\d{2}\s?[A-Z0-9]{4}\b/,
+    );
+  });
+});

--- a/openeire-next/tests/realEstatePortfolio.test.tsx
+++ b/openeire-next/tests/realEstatePortfolio.test.tsx
@@ -2,19 +2,30 @@ import fs from "node:fs";
 import path from "node:path";
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
+import RealEstatePage from "@/app/real-estate/page";
 import RealEstatePortfolioPage, {
   metadata,
 } from "@/app/real-estate/portfolio/page";
 import { PortfolioProject } from "@/components/real-estate/PortfolioProject";
 import {
   REAL_ESTATE_PORTFOLIO_PROJECTS,
+  getDemonstratedPortfolioFormats,
   getPublishedPortfolioProjects,
   type RealEstatePortfolioProject,
 } from "@/lib/realEstatePortfolio";
+import { REAL_ESTATE_PACKAGES } from "@/lib/realEstate";
+import {
+  REAL_ESTATE_HERO_IMAGE,
+  REAL_ESTATE_PORTFOLIO_HERO_IMAGE,
+  REAL_ESTATE_PORTFOLIO_PATH,
+} from "@/lib/realEstatePresentation";
 import { buildPortfolioJsonLd } from "@/lib/seo/realEstatePortfolioJsonLd";
 
 vi.mock("@/lib/analytics", () => ({
   trackEvent: vi.fn(),
+}));
+vi.mock("@/components/real-estate/RealEstateEnquiryForm", () => ({
+  RealEstateEnquiryForm: () => <section id="enquiry">Enquiry form</section>,
 }));
 
 const buildProject = (
@@ -38,7 +49,7 @@ const buildProject = (
       height: 1080,
     },
   ],
-  services: ["Property photography", "Aerial drone stills"],
+  photographyFormats: ["photography", "aerialStills"],
   featured: true,
   published: true,
   portfolioPermissionConfirmed: true,
@@ -49,7 +60,7 @@ const buildProject = (
 describe("real-estate portfolio", () => {
   afterEach(cleanup);
 
-  it("renders the correct page heading, CTAs and professional empty state", () => {
+  it("renders the approved project, gallery, heading and CTAs", () => {
     render(<RealEstatePortfolioPage />);
 
     expect(
@@ -68,9 +79,78 @@ describe("real-estate portfolio", () => {
     ).toBe("/real-estate");
     expect(
       screen.getByRole("heading", {
-        name: /portfolio is being prepared for publication/i,
+        name: "Detached residence in County Galway",
       }),
     ).toBeTruthy();
+    expect(
+      screen.queryByRole("heading", {
+        name: /approved property work is being prepared for publication/i,
+      }),
+    ).toBeNull();
+    expect(document.body.textContent).not.toMatch(
+      /permission is still|seeking permission|written permissions/i,
+    );
+    expect(
+      screen.getByRole("heading", {
+        name: "Media demonstrated in published work.",
+      }),
+    ).toBeTruthy();
+    expect(
+      document.querySelector('[data-gallery-mode="responsive-marquee"]'),
+    ).toBeTruthy();
+  });
+
+  it("places a secondary portfolio link in the main real-estate hero", () => {
+    render(<RealEstatePage />);
+
+    const portfolioLink = screen.getByRole("link", {
+      name: "View property portfolio",
+    });
+    expect(portfolioLink.getAttribute("href")).toBe(
+      REAL_ESTATE_PORTFOLIO_PATH,
+    );
+    expect(
+      portfolioLink.closest("section")?.querySelector("h1")?.textContent,
+    ).toMatch(/Property media built for Connacht agents/i);
+  });
+
+  it("uses centrally configured approved property heroes", () => {
+    expect(REAL_ESTATE_HERO_IMAGE).toMatchObject({
+      src: "https://media.openeire.ie/portfolio/county-galway-20260724/drone-exterior-v1.webp",
+      alt: "Aerial view of a residential property photographed by OpenÉire Studios",
+      width: 2500,
+      height: 1406,
+    });
+    expect(REAL_ESTATE_PORTFOLIO_HERO_IMAGE).toMatchObject({
+      src: "https://media.openeire.ie/portfolio/county-galway-20260724/hero-v1.webp",
+      alt: "Exterior view of a residential property photographed by OpenÉire Studios",
+      width: 2500,
+      height: 1406,
+    });
+
+    const pageSources = [
+      path.join(process.cwd(), "app", "real-estate", "page.tsx"),
+      path.join(process.cwd(), "app", "real-estate", "portfolio", "page.tsx"),
+    ].map((target) => fs.readFileSync(target, "utf8"));
+
+    for (const source of pageSources) {
+      expect(source).toContain("<RealEstateHeroImage");
+      expect(source).not.toContain('src="/hero-poster.jpg"');
+      expect(source).not.toContain("url('/hero-poster.jpg')");
+    }
+
+    render(<RealEstatePage />);
+    expect(
+      screen.getByAltText(REAL_ESTATE_HERO_IMAGE.alt).getAttribute("src"),
+    ).toContain(encodeURIComponent(REAL_ESTATE_HERO_IMAGE.src));
+
+    cleanup();
+    render(<RealEstatePortfolioPage />);
+    expect(
+      screen
+        .getByAltText(REAL_ESTATE_PORTFOLIO_HERO_IMAGE.alt)
+        .getAttribute("src"),
+    ).toContain(encodeURIComponent(REAL_ESTATE_PORTFOLIO_HERO_IMAGE.src));
   });
 
   it("only returns projects with explicit publication and permission state", () => {
@@ -111,6 +191,156 @@ describe("real-estate portfolio", () => {
     ).toEqual([authorised]);
   });
 
+  it("renders no gallery for unpublished or unauthorised project collections", () => {
+    const gatedProjects = getPublishedPortfolioProjects([
+      buildProject({ published: false }),
+      buildProject({
+        slug: "unpermitted-gallery",
+        portfolioPermissionConfirmed: false,
+      }),
+    ]);
+
+    render(
+      <>
+        {gatedProjects.map((project) => (
+          <PortfolioProject key={project.slug} project={project} />
+        ))}
+      </>,
+    );
+
+    expect(
+      document.querySelector('[data-gallery-mode="responsive-marquee"]'),
+    ).toBeNull();
+  });
+
+  it("publishes only the approved R2-backed project", () => {
+    const project = REAL_ESTATE_PORTFOLIO_PROJECTS.find(
+      ({ slug }) => slug === "detached-residence-county-galway",
+    );
+
+    expect(project).toBeTruthy();
+    expect(project?.title).toBe("Detached residence in County Galway");
+    expect(project?.title).not.toMatch(/Woodland residence/i);
+    expect(project?.packageName).toBe(
+      "Residential property media coverage",
+    );
+    expect(project?.published).toBe(true);
+    expect(project?.portfolioPermissionConfirmed).toBe(true);
+    expect(project?.permissionReference).toBe(
+      "portfolio-approval-2026-07",
+    );
+    expect(project?.imageCount).toBe(8);
+    expect(project?.galleryImages).toHaveLength(7);
+    expect(project?.groundVideo).toMatchObject({
+      youtubeVideoId: "MTGASk31sGo",
+      poster: {
+        src: "https://media.openeire.ie/portfolio/county-galway-20260724/drone-exterior-v1.webp",
+        alt: "Aerial view of a residential property used as the video poster",
+        width: 2500,
+        height: 1406,
+      },
+      title: "Detached residence property film",
+      width: 16,
+      height: 9,
+    });
+    expect(project?.deliverables).toContain("Ground property video");
+    expect(project?.aerialVideo).toBeUndefined();
+    expect(project?.socialVideos).toBeUndefined();
+    expect(project?.floorPlanImage).toBeUndefined();
+    expect(getDemonstratedPortfolioFormats()).toEqual([
+      "photography",
+      "aerialStills",
+      "groundVideo",
+    ]);
+    expect(
+      getDemonstratedPortfolioFormats([
+        { ...project!, published: true },
+      ]),
+    ).toEqual(["photography", "aerialStills", "groundVideo"]);
+
+    const images = [project?.heroImage, ...(project?.galleryImages ?? [])];
+    expect(images).toHaveLength(8);
+    for (const image of images) {
+      expect(image?.src).toMatch(
+        /^https:\/\/media\.openeire\.ie\/portfolio\/county-galway-20260724\/[a-z0-9-]+\.webp$/,
+      );
+      expect(image?.width).toBeGreaterThan(0);
+      expect(image?.height).toBeGreaterThan(0);
+      expect(image?.alt.trim()).toBeTruthy();
+    }
+  });
+
+  it("derives demonstrated formats only from authorised published media", () => {
+    const photographyOnly = buildProject();
+    expect(getDemonstratedPortfolioFormats([photographyOnly])).toEqual([
+      "photography",
+      "aerialStills",
+    ]);
+
+    const video = {
+      youtubeVideoId: "AbCdEfGhI12",
+      poster: {
+        src: "/hero-poster.jpg",
+        alt: "Video poster",
+        width: 1920,
+        height: 1080,
+      },
+      title: "Property film",
+      description: "Approved test film.",
+      width: 16,
+      height: 9,
+    };
+    const allFormats = buildProject({
+      groundVideo: video,
+      aerialVideo: { ...video, youtubeVideoId: "JkLmNoPqR34" },
+      socialVideos: [{ ...video, youtubeVideoId: "StUvWxYzA56" }],
+      floorPlanImage: {
+        src: "/hero-poster.jpg",
+        alt: "Approved floor plan",
+        width: 1600,
+        height: 1200,
+      },
+    });
+    expect(getDemonstratedPortfolioFormats([allFormats])).toEqual([
+      "photography",
+      "aerialStills",
+      "groundVideo",
+      "aerialVideo",
+      "socialMediaCuts",
+      "floorPlan",
+    ]);
+
+    expect(
+      getDemonstratedPortfolioFormats([
+        { ...allFormats, published: false },
+        { ...allFormats, portfolioPermissionConfirmed: false },
+        { ...allFormats, permissionReference: " " },
+      ]),
+    ).toEqual([]);
+  });
+
+  it("renders only evidence supported by the published project", () => {
+    render(<RealEstatePortfolioPage />);
+
+    expect(
+      screen.queryByRole("heading", { name: "Social-media cuts" }),
+    ).toBeNull();
+    expect(
+      screen.queryByRole("heading", { name: "Measured 2D floor plans" }),
+    ).toBeNull();
+    expect(
+      screen.getByRole("heading", {
+        name: "Interior and exterior photography",
+      }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("heading", { name: "Aerial drone stills" }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("heading", { name: "Ground property video" }),
+    ).toBeTruthy();
+  });
+
   it("does not leak unauthorised project data into JSON-LD", () => {
     const authorised = buildProject();
     const unpermitted = buildProject({
@@ -133,7 +363,7 @@ describe("real-estate portfolio", () => {
     expect(serialized).not.toMatch(/\b[A-Z]\d{2}\s?[A-Z0-9]{4}\b/);
   });
 
-  it("omits optional film and floor-plan sections when assets are absent", () => {
+  it("renders photography independently and omits all absent optional media", () => {
     render(<PortfolioProject project={buildProject()} />);
 
     expect(
@@ -143,7 +373,37 @@ describe("real-estate portfolio", () => {
       screen.queryByRole("heading", { name: "Measured 2D floor plan" }),
     ).toBeNull();
     expect(
+      screen.queryByRole("heading", { name: "Social-media films" }),
+    ).toBeNull();
+    expect(
       screen.getByRole("heading", { name: "Property photography" }),
+    ).toBeTruthy();
+  });
+
+  it("features a single property film before deliverables and photography", () => {
+    render(<PortfolioProject project={REAL_ESTATE_PORTFOLIO_PROJECTS[0]} />);
+
+    const filmHeading = screen.getByRole("heading", {
+      name: "Property film",
+    });
+    const deliverablesHeading = screen.getByRole("heading", {
+      name: "Selected deliverables",
+    });
+    const photographyHeading = screen.getByRole("heading", {
+      name: "Property photography",
+    });
+    const filmLayout = document.querySelector(
+      '[data-property-video-layout="featured"]',
+    );
+
+    expect(filmLayout?.className).toContain("max-w-3xl");
+    expect(
+      filmHeading.compareDocumentPosition(deliverablesHeading) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+    expect(
+      filmHeading.compareDocumentPosition(photographyHeading) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
     ).toBeTruthy();
   });
 
@@ -151,7 +411,9 @@ describe("real-estate portfolio", () => {
     expect(metadata.title).toBe(
       "Real Estate Photography Portfolio | OpenÉire Studios",
     );
-    expect(metadata.description).toMatch(/drone media, property films/i);
+    expect(metadata.description).toMatch(
+      /approved property photography, aerial media/i,
+    );
     expect(metadata.alternates?.canonical).toBe(
       "https://openeire.ie/real-estate/portfolio",
     );
@@ -170,9 +432,16 @@ describe("real-estate portfolio", () => {
 
     for (const target of targets) {
       expect(fs.readFileSync(target, "utf8")).toContain(
-        "/real-estate/portfolio",
+        "REAL_ESTATE_PORTFOLIO_PATH",
       );
     }
+  });
+
+  it("keeps social cuts and floor plans in the commercial catalogue", () => {
+    const commercialCatalogue = JSON.stringify(REAL_ESTATE_PACKAGES);
+
+    expect(commercialCatalogue).toMatch(/Social media cuts included/i);
+    expect(commercialCatalogue).toMatch(/Floor plan, 2D measured/i);
   });
 
   it("does not import historical booking data into public portfolio code", () => {
@@ -192,9 +461,14 @@ describe("real-estate portfolio", () => {
     expect(publicPortfolioSources).not.toMatch(
       /(?:import|from|require\()[^\n]*(?:booking|agreement|client-record)/i,
     );
-    expect(REAL_ESTATE_PORTFOLIO_PROJECTS).toEqual([]);
+    expect(getPublishedPortfolioProjects()).toEqual([
+      REAL_ESTATE_PORTFOLIO_PROJECTS[0],
+    ]);
     expect(publicPortfolioSources).not.toMatch(
       /\b[A-Z]\d{2}\s?[A-Z0-9]{4}\b/,
+    );
+    expect(publicPortfolioSources).not.toMatch(
+      /\b(?:Laura|Kathleen|KW Ireland)\b/i,
     );
   });
 });


### PR DESCRIPTION
## What changed

- adds the public real-estate portfolio page and early portfolio navigation
- uses approved R2 property photography for the shared real-estate hero treatment
- adds the authorised County Galway project gallery and consent-aware YouTube film
- derives demonstrated formats only from authorised, published media
- preserves social edits and floor plans in the commercial service catalogue without presenting them as portfolio evidence
- adds privacy, accessibility, gallery, video, consent, SEO and publication-gate regression coverage

## Why

OpenÉire needs a production-ready property-media portfolio that presents approved work without exposing client or property identifiers and without loading YouTube before visitor interaction.

## Validation

- focused portfolio/video tests: 20 passed
- complete frontend suite: 63 passed
- ESLint passed
- TypeScript passed
- Next.js production build passed
- `git diff --check` passed
- generated portfolio HTML privacy scan passed