### PR TITLE
Reduce Next.js runtime memory pressure

### DIFF
--- a/openeire-next/.env.example
+++ b/openeire-next/.env.example
@@ -14,3 +14,7 @@ NEXT_PUBLIC_SITE_SOCIAL_INSTAGRAM_URL=https://www.instagram.com/openeirestudios/
 NEXT_PUBLIC_SITE_SOCIAL_YOUTUBE_URL=https://www.youtube.com/@openeirestudios
 NEXT_PUBLIC_IUBENDA_CONSENT_PUBLIC_API_KEY=
 NEXT_PUBLIC_IUBENDA_POLICY_URL=https://www.iubenda.com/privacy-policy/30754861
+# Optional server diagnostics. All recurring/per-fetch diagnostics are off by default.
+SERVER_MEMORY_LOGGING=0
+SERVER_FETCH_MEMORY_LOGGING=0
+SERVER_PUBLIC_FETCH_DEBUG=0

--- a/openeire-next/app/blog/[slug]/page.tsx
+++ b/openeire-next/app/blog/[slug]/page.tsx
@@ -5,7 +5,7 @@ import { notFound } from "next/navigation";
 import { BlogComments } from "@/components/blog/BlogComments";
 import { BlogLikeButton } from "@/components/blog/BlogLikeButton";
 import { JsonLd } from "@/components/JsonLd";
-import { getPublishedBlogPostBySlug } from "@/lib/api/blog";
+import { getCachedPublishedBlogPostBySlug } from "@/lib/api/serverDetails";
 import { formatBlogDisplayDate } from "@/lib/blog/dates";
 import { resolveMediaUrl } from "@/lib/media";
 import { buildBreadcrumbJsonLd } from "@/lib/seo/jsonLd";
@@ -39,7 +39,7 @@ export async function generateMetadata({
   const { slug } = await params;
 
   try {
-    const post = await getPublishedBlogPostBySlug(slug);
+    const post = await getCachedPublishedBlogPostBySlug(slug);
     if (!post) {
       return {
         title: "Journal post not found | OpenÉire Studios",
@@ -100,7 +100,7 @@ export default async function BlogDetailPage({
 }) {
   const { slug } = await params;
   let failedToLoad = false;
-  const post = await getPublishedBlogPostBySlug(slug).catch(() => {
+  const post = await getCachedPublishedBlogPostBySlug(slug).catch(() => {
     failedToLoad = true;
     return null;
   });

--- a/openeire-next/app/gallery/physical/[id]/page.tsx
+++ b/openeire-next/app/gallery/physical/[id]/page.tsx
@@ -8,7 +8,7 @@ import { RelatedPrintsRail } from "@/components/gallery/RelatedPrintsRail";
 import { SpecBox } from "@/components/gallery/SpecBox";
 import { ProductReviews } from "@/components/reviews/ProductReviews";
 import { ShareControls } from "@/components/share/ShareControls";
-import { getPublicPhysicalProduct } from "@/lib/api/gallery";
+import { getCachedPublicPhysicalProduct } from "@/lib/api/serverDetails";
 import { getProductReviews } from "@/lib/api/reviews";
 import { getLowestVariant, splitTags } from "@/lib/gallery/format";
 import { resolveMediaUrl } from "@/lib/media";
@@ -27,7 +27,7 @@ export async function generateMetadata({
   const { id } = await params;
 
   try {
-    const product = await getPublicPhysicalProduct(id);
+    const product = await getCachedPublicPhysicalProduct(id);
     if (!product) {
       return {
         title: "Art print not found | OpenÉire Studios",
@@ -85,7 +85,7 @@ export default async function PhysicalProductPage({
 }) {
   const { id } = await params;
   let failedToLoad = false;
-  const product = await getPublicPhysicalProduct(id).catch(() => {
+  const product = await getCachedPublicPhysicalProduct(id).catch(() => {
     failedToLoad = true;
     return null;
   });

--- a/openeire-next/app/sitemap.ts
+++ b/openeire-next/app/sitemap.ts
@@ -34,7 +34,6 @@ const staticPublicRoutes = [
   "/privacy",
 ];
 
-export const dynamic = "force-dynamic";
 export const revalidate = 300;
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {

--- a/openeire-next/instrumentation.ts
+++ b/openeire-next/instrumentation.ts
@@ -1,0 +1,11 @@
+export async function register(): Promise<void> {
+  if (process.env.NEXT_RUNTIME !== "nodejs") {
+    return;
+  }
+
+  const { registerServerMemoryLogging } = await import(
+    "@/lib/server/memoryLogging"
+  );
+
+  registerServerMemoryLogging();
+}

--- a/openeire-next/lib/api/client.ts
+++ b/openeire-next/lib/api/client.ts
@@ -5,6 +5,10 @@ import {
   getRefreshToken,
   updateAccessToken,
 } from "@/lib/auth/tokenStorage";
+import {
+  SERVER_MEMORY_LOGGER_SYMBOL,
+  type ServerMemoryLoggerGlobal,
+} from "@/lib/memoryLoggingShared";
 import { getSiteUrl } from "@/lib/site";
 
 export interface ApiResponse<T = unknown> {
@@ -196,7 +200,11 @@ const request = async <T>(
     headers.set("Content-Type", "application/json");
   }
 
-  if (isServerRequest && config.publicFetchContext) {
+  if (
+    process.env.SERVER_PUBLIC_FETCH_DEBUG === "1" &&
+    isServerRequest &&
+    config.publicFetchContext
+  ) {
     console.info("[server-public-fetch-debug]", {
       context: config.publicFetchContext,
       finalUrl: url,
@@ -217,6 +225,22 @@ const request = async <T>(
       next: config.next,
     });
     const data = await parseResponseBody(response);
+
+    if (
+      process.env.SERVER_FETCH_MEMORY_LOGGING === "1" &&
+      isServerRequest &&
+      config.publicFetchContext
+    ) {
+      const memoryLogger = (globalThis as ServerMemoryLoggerGlobal)[
+        SERVER_MEMORY_LOGGER_SYMBOL
+      ];
+      memoryLogger?.("public-fetch", {
+        context: config.publicFetchContext,
+        method,
+        status: String(response.status),
+      });
+    }
+
     const apiResponse: ApiResponse<T> = {
       data: data as T,
       status: response.status,

--- a/openeire-next/lib/api/serverDetails.ts
+++ b/openeire-next/lib/api/serverDetails.ts
@@ -1,0 +1,12 @@
+import "server-only";
+
+import { cache } from "react";
+
+import { getPublishedBlogPostBySlug } from "@/lib/api/blog";
+import { getPublicPhysicalProduct } from "@/lib/api/gallery";
+
+export const getCachedPublishedBlogPostBySlug = cache(
+  getPublishedBlogPostBySlug,
+);
+
+export const getCachedPublicPhysicalProduct = cache(getPublicPhysicalProduct);

--- a/openeire-next/lib/memoryLoggingShared.ts
+++ b/openeire-next/lib/memoryLoggingShared.ts
@@ -1,0 +1,12 @@
+export const SERVER_MEMORY_LOGGER_SYMBOL = Symbol.for(
+  "openeire.server-memory.logger",
+);
+
+export type ServerMemoryLog = (
+  event: "startup" | "interval" | "public-fetch",
+  details?: Record<string, string>,
+) => void;
+
+export type ServerMemoryLoggerGlobal = typeof globalThis & {
+  [SERVER_MEMORY_LOGGER_SYMBOL]?: ServerMemoryLog;
+};

--- a/openeire-next/lib/server/memoryLogging.ts
+++ b/openeire-next/lib/server/memoryLogging.ts
@@ -1,0 +1,78 @@
+import "server-only";
+
+import {
+  SERVER_MEMORY_LOGGER_SYMBOL,
+  type ServerMemoryLoggerGlobal,
+} from "@/lib/memoryLoggingShared";
+
+const MEMORY_LOG_STARTUP_SYMBOL = Symbol.for(
+  "openeire.server-memory.startup-logged",
+);
+const MEMORY_LOG_INTERVAL_SYMBOL = Symbol.for(
+  "openeire.server-memory.interval",
+);
+const MEMORY_LOG_INTERVAL_MS = 5 * 60 * 1_000;
+const BYTES_PER_MEBIBYTE = 1024 * 1024;
+
+type MemoryLoggingGlobal = ServerMemoryLoggerGlobal & {
+  [MEMORY_LOG_STARTUP_SYMBOL]?: boolean;
+  [MEMORY_LOG_INTERVAL_SYMBOL]?: NodeJS.Timeout;
+};
+
+export type MemorySnapshot = {
+  rssMiB: number;
+  heapUsedMiB: number;
+  heapTotalMiB: number;
+  externalMiB: number;
+  arrayBuffersMiB: number;
+  uptimeSeconds: number;
+};
+
+const bytesToMiB = (bytes: number): number =>
+  Number((bytes / BYTES_PER_MEBIBYTE).toFixed(2));
+
+export const formatMemoryUsage = (
+  usage: NodeJS.MemoryUsage,
+  uptimeSeconds: number,
+): MemorySnapshot => ({
+  rssMiB: bytesToMiB(usage.rss),
+  heapUsedMiB: bytesToMiB(usage.heapUsed),
+  heapTotalMiB: bytesToMiB(usage.heapTotal),
+  externalMiB: bytesToMiB(usage.external),
+  arrayBuffersMiB: bytesToMiB(usage.arrayBuffers),
+  uptimeSeconds: Math.round(uptimeSeconds),
+});
+
+export const logServerMemory = (
+  event: "startup" | "interval" | "public-fetch",
+  details?: Record<string, string>,
+): void => {
+  console.info("[server-memory]", {
+    event,
+    ...formatMemoryUsage(process.memoryUsage(), process.uptime()),
+    ...(details ? { details } : {}),
+  });
+};
+
+export const registerServerMemoryLogging = (): void => {
+  const memoryGlobal = globalThis as MemoryLoggingGlobal;
+
+  memoryGlobal[SERVER_MEMORY_LOGGER_SYMBOL] = logServerMemory;
+
+  if (!memoryGlobal[MEMORY_LOG_STARTUP_SYMBOL]) {
+    memoryGlobal[MEMORY_LOG_STARTUP_SYMBOL] = true;
+    logServerMemory("startup");
+  }
+
+  if (
+    process.env.SERVER_MEMORY_LOGGING === "1" &&
+    !memoryGlobal[MEMORY_LOG_INTERVAL_SYMBOL]
+  ) {
+    const interval = setInterval(() => {
+      logServerMemory("interval");
+    }, MEMORY_LOG_INTERVAL_MS);
+
+    interval.unref();
+    memoryGlobal[MEMORY_LOG_INTERVAL_SYMBOL] = interval;
+  }
+};

--- a/openeire-next/next.config.ts
+++ b/openeire-next/next.config.ts
@@ -167,6 +167,7 @@ const privateDeliveryHeaders = [
 const nextConfig: NextConfig = {
   poweredByHeader: false,
   reactStrictMode: true,
+  cacheMaxMemorySize: 8 * 1024 * 1024,
   outputFileTracingRoot: process.cwd(),
   images: {
     remotePatterns: [

--- a/openeire-next/tests/detailAccessorDeduplication.test.tsx
+++ b/openeire-next/tests/detailAccessorDeduplication.test.tsx
@@ -1,0 +1,158 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { BlogPostDetail } from "@/types/blog";
+import type { PublicPhysicalProductDetail } from "@/types/gallery";
+
+const detailMocks = vi.hoisted(() => ({
+  cacheStores: [] as Map<string, unknown>[],
+  parseBlogBody: vi.fn(),
+  parseGalleryBody: vi.fn(),
+  getProductReviews: vi.fn(),
+}));
+
+vi.mock("react", async (importOriginal) => {
+  const react = await importOriginal<typeof import("react")>();
+
+  return {
+    ...react,
+    cache: <Result, Arguments extends unknown[]>(
+      callback: (...args: Arguments) => Result,
+    ) => {
+      const store = new Map<string, Result>();
+      detailMocks.cacheStores.push(store as Map<string, unknown>);
+
+      return (...args: Arguments): Result => {
+        const key = JSON.stringify(args);
+        if (!store.has(key)) {
+          store.set(key, callback(...args));
+        }
+        return store.get(key) as Result;
+      };
+    },
+  };
+});
+
+vi.mock("@/lib/api/blog", () => ({
+  getPublishedBlogPostBySlug: (slug: string) =>
+    detailMocks.parseBlogBody(slug),
+}));
+
+vi.mock("@/lib/api/gallery", () => ({
+  getPublicPhysicalProduct: (id: string | number) =>
+    detailMocks.parseGalleryBody(id),
+}));
+
+vi.mock("@/lib/api/reviews", () => ({
+  getProductReviews: detailMocks.getProductReviews,
+}));
+
+vi.mock("next/navigation", () => ({
+  notFound: () => {
+    throw new Error("not found");
+  },
+}));
+
+import BlogDetailPage, {
+  generateMetadata as generateBlogMetadata,
+} from "@/app/blog/[slug]/page";
+import PhysicalProductPage, {
+  generateMetadata as generateGalleryMetadata,
+} from "@/app/gallery/physical/[id]/page";
+
+const createBlogPost = (slug: string): BlogPostDetail => ({
+  id: 1,
+  title: `Post ${slug}`,
+  slug,
+  author: "OpenÉire",
+  featured_image: null,
+  excerpt: "Excerpt",
+  meta_title: "",
+  meta_description: "",
+  canonical_url: "",
+  created_at: "2026-01-01T00:00:00Z",
+  updated_at: "2026-01-01T00:00:00Z",
+  tags: [],
+  likes_count: 0,
+  has_liked: false,
+  content: "<p>Body</p>",
+  related_posts: [],
+});
+
+const createPhysicalProduct = (
+  id: string | number,
+): PublicPhysicalProductDetail => ({
+  id: Number(id),
+  title: `Print ${id}`,
+  description: "Description",
+  preview_image: null,
+  product_type: "physical",
+  variants: [],
+  tags: "",
+  average_rating: null,
+  review_count: 0,
+  related_products: [],
+});
+
+describe("detail route request memoization", () => {
+  beforeEach(() => {
+    for (const store of detailMocks.cacheStores) {
+      store.clear();
+    }
+    detailMocks.parseBlogBody.mockReset();
+    detailMocks.parseGalleryBody.mockReset();
+    detailMocks.getProductReviews.mockReset();
+    detailMocks.parseBlogBody.mockImplementation(async (slug: string) =>
+      createBlogPost(slug),
+    );
+    detailMocks.parseGalleryBody.mockImplementation(
+      async (id: string | number) => createPhysicalProduct(id),
+    );
+    detailMocks.getProductReviews.mockResolvedValue([]);
+  });
+
+  it("shares one blog detail accessor/body parse between metadata and page", async () => {
+    const params = Promise.resolve({ slug: "shared-blog-post" });
+
+    await generateBlogMetadata({ params });
+    await BlogDetailPage({ params });
+
+    expect(detailMocks.parseBlogBody).toHaveBeenCalledTimes(1);
+    expect(detailMocks.parseBlogBody).toHaveBeenCalledWith("shared-blog-post");
+  });
+
+  it("keeps different blog slugs as separate accessor calls", async () => {
+    await generateBlogMetadata({
+      params: Promise.resolve({ slug: "first-post" }),
+    });
+    await generateBlogMetadata({
+      params: Promise.resolve({ slug: "second-post" }),
+    });
+
+    expect(detailMocks.parseBlogBody).toHaveBeenCalledTimes(2);
+    expect(detailMocks.parseBlogBody).toHaveBeenNthCalledWith(1, "first-post");
+    expect(detailMocks.parseBlogBody).toHaveBeenNthCalledWith(2, "second-post");
+  });
+
+  it("shares one gallery detail accessor/body parse between metadata and page", async () => {
+    const params = Promise.resolve({ id: "42" });
+
+    await generateGalleryMetadata({ params });
+    await PhysicalProductPage({ params });
+
+    expect(detailMocks.parseGalleryBody).toHaveBeenCalledTimes(1);
+    expect(detailMocks.parseGalleryBody).toHaveBeenCalledWith("42");
+  });
+
+  it("keeps different gallery IDs as separate accessor calls", async () => {
+    await generateGalleryMetadata({
+      params: Promise.resolve({ id: "42" }),
+    });
+    await generateGalleryMetadata({
+      params: Promise.resolve({ id: "43" }),
+    });
+
+    expect(detailMocks.parseGalleryBody).toHaveBeenCalledTimes(2);
+    expect(detailMocks.parseGalleryBody).toHaveBeenNthCalledWith(1, "42");
+    expect(detailMocks.parseGalleryBody).toHaveBeenNthCalledWith(2, "43");
+  });
+});

--- a/openeire-next/tests/memoryLogging.test.ts
+++ b/openeire-next/tests/memoryLogging.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { register } from "@/instrumentation";
+import {
+  formatMemoryUsage,
+  type MemorySnapshot,
+} from "@/lib/server/memoryLogging";
+
+const STARTUP_SYMBOL = Symbol.for("openeire.server-memory.startup-logged");
+const INTERVAL_SYMBOL = Symbol.for("openeire.server-memory.interval");
+const LOGGER_SYMBOL = Symbol.for("openeire.server-memory.logger");
+
+type MemoryTestGlobal = typeof globalThis & {
+  [STARTUP_SYMBOL]?: boolean;
+  [INTERVAL_SYMBOL]?: NodeJS.Timeout;
+  [LOGGER_SYMBOL]?: unknown;
+};
+
+const memoryGlobal = globalThis as MemoryTestGlobal;
+
+describe("server memory logging", () => {
+  const originalNextRuntime = process.env.NEXT_RUNTIME;
+  const originalMemoryLogging = process.env.SERVER_MEMORY_LOGGING;
+
+  beforeEach(() => {
+    delete memoryGlobal[STARTUP_SYMBOL];
+    delete memoryGlobal[INTERVAL_SYMBOL];
+    delete memoryGlobal[LOGGER_SYMBOL];
+    process.env.NEXT_RUNTIME = "nodejs";
+    process.env.SERVER_MEMORY_LOGGING = "1";
+  });
+
+  afterEach(() => {
+    delete memoryGlobal[STARTUP_SYMBOL];
+    delete memoryGlobal[INTERVAL_SYMBOL];
+    delete memoryGlobal[LOGGER_SYMBOL];
+
+    if (originalNextRuntime === undefined) {
+      delete process.env.NEXT_RUNTIME;
+    } else {
+      process.env.NEXT_RUNTIME = originalNextRuntime;
+    }
+
+    if (originalMemoryLogging === undefined) {
+      delete process.env.SERVER_MEMORY_LOGGING;
+    } else {
+      process.env.SERVER_MEMORY_LOGGING = originalMemoryLogging;
+    }
+  });
+
+  it("formats every required field in MiB without combining external memory", () => {
+    const mebibyte = 1024 * 1024;
+    const snapshot: MemorySnapshot = formatMemoryUsage(
+      {
+        rss: 10 * mebibyte,
+        heapUsed: 2.25 * mebibyte,
+        heapTotal: 4.5 * mebibyte,
+        external: 3 * mebibyte,
+        arrayBuffers: 1.5 * mebibyte,
+      },
+      123.6,
+    );
+
+    expect(snapshot).toEqual({
+      rssMiB: 10,
+      heapUsedMiB: 2.25,
+      heapTotalMiB: 4.5,
+      externalMiB: 3,
+      arrayBuffersMiB: 1.5,
+      uptimeSeconds: 124,
+    });
+  });
+
+  it("registers startup logging and the five-minute interval only once", async () => {
+    const unref = vi.fn();
+    const interval = { unref } as unknown as NodeJS.Timeout;
+    const setIntervalSpy = vi
+      .spyOn(globalThis, "setInterval")
+      .mockReturnValue(interval);
+    const consoleInfoSpy = vi
+      .spyOn(console, "info")
+      .mockImplementation(() => undefined);
+
+    await register();
+    await register();
+
+    expect(setIntervalSpy).toHaveBeenCalledTimes(1);
+    expect(setIntervalSpy).toHaveBeenCalledWith(
+      expect.any(Function),
+      5 * 60 * 1_000,
+    );
+    expect(unref).toHaveBeenCalledTimes(1);
+    expect(
+      consoleInfoSpy.mock.calls.filter(
+        ([label, value]) =>
+          label === "[server-memory]" &&
+          typeof value === "object" &&
+          value !== null &&
+          "event" in value &&
+          value.event === "startup",
+      ),
+    ).toHaveLength(1);
+  });
+});

--- a/openeire-next/tests/serverPublicFetchDebug.test.ts
+++ b/openeire-next/tests/serverPublicFetchDebug.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { api } from "@/lib/api/client";
+
+describe("server public fetch diagnostics", () => {
+  const originalDebugFlag = process.env.SERVER_PUBLIC_FETCH_DEBUG;
+
+  beforeEach(() => {
+    vi.stubGlobal("window", undefined);
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        new Response(JSON.stringify({ id: 1 }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+
+    if (originalDebugFlag === undefined) {
+      delete process.env.SERVER_PUBLIC_FETCH_DEBUG;
+    } else {
+      process.env.SERVER_PUBLIC_FETCH_DEBUG = originalDebugFlag;
+    }
+  });
+
+  it("does not emit public fetch debug output when the flag is absent", async () => {
+    delete process.env.SERVER_PUBLIC_FETCH_DEBUG;
+    const consoleInfoSpy = vi
+      .spyOn(console, "info")
+      .mockImplementation(() => undefined);
+
+    await api.get("blog/example/", {
+      publicFetchContext: "blog:detail",
+    });
+
+    expect(consoleInfoSpy).not.toHaveBeenCalledWith(
+      "[server-public-fetch-debug]",
+      expect.anything(),
+    );
+  });
+
+  it("emits public fetch debug output when explicitly enabled", async () => {
+    process.env.SERVER_PUBLIC_FETCH_DEBUG = "1";
+    const consoleInfoSpy = vi
+      .spyOn(console, "info")
+      .mockImplementation(() => undefined);
+
+    await api.get("blog/example/", {
+      publicFetchContext: "blog:detail",
+    });
+
+    expect(consoleInfoSpy).toHaveBeenCalledWith(
+      "[server-public-fetch-debug]",
+      expect.objectContaining({
+        context: "blog:detail",
+        isServer: true,
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## What changed

- add guarded Node.js memory instrumentation for startup, periodic, and opt-in public-fetch snapshots
- gate public fetch diagnostics behind an explicit environment variable
- deduplicate blog and physical gallery detail accessors with request-scoped React `cache()`
- reduce the Next.js in-memory incremental cache to 8 MiB
- restore five-minute sitemap caching
- add focused instrumentation, logging, and request-deduplication tests

## Why

The Render Starter service was operating close to its 512 MiB memory limit. The changes add the memory breakdown needed to distinguish heap and native/external growth while reducing confirmed duplicate parsing and cache pressure.

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm test` — 87 tests passed
- `npm run build` — Next.js 15.5.20 production build passed