### PR TITLE
Add controlled image optimisation memory experiment

### DIFF
--- a/openeire-next/.env.example
+++ b/openeire-next/.env.example
@@ -18,3 +18,5 @@ NEXT_PUBLIC_IUBENDA_POLICY_URL=https://www.iubenda.com/privacy-policy/30754861
 SERVER_MEMORY_LOGGING=0
 SERVER_FETCH_MEMORY_LOGGING=0
 SERVER_PUBLIC_FETCH_DEBUG=0
+# Controlled native RSS experiment. Leave disabled outside the experiment window.
+NEXT_IMAGE_OPTIMIZATION_DISABLED=0

--- a/openeire-next/docs/native-rss-phase-2a-image-experiment.md
+++ b/openeire-next/docs/native-rss-phase-2a-image-experiment.md
@@ -1,0 +1,68 @@
+# Phase 2A: Next.js image optimisation experiment
+
+## Purpose
+
+This is a controlled production experiment to determine whether Next.js image
+optimisation, including its Sharp/libvips native allocations, is responsible
+for persistent RSS growth that is not represented by the V8 heap, external
+memory, or array buffer metrics.
+
+The experiment changes one variable only. It does not establish Sharp/libvips
+as the cause unless the resulting fresh-process memory profile differs
+materially from the normal optimised configuration.
+
+## Experiment flag
+
+Set the following production environment variable for the experiment:
+
+```text
+NEXT_IMAGE_OPTIMIZATION_DISABLED=1
+```
+
+An exact value of `1` sets `images.unoptimized` to `true`. An absent variable,
+`0`, or any other value preserves normal Next.js image optimisation.
+
+At startup the server emits a boolean-only diagnostic:
+
+```text
+[server-image-optimization] { nextImageOptimizationDisabled: true }
+```
+
+The diagnostic does not include the environment value or any secrets.
+
+## Production procedure
+
+1. Record the current deployment, configuration, and pre-experiment memory
+   profile as the control.
+2. Configure `NEXT_IMAGE_OPTIMIZATION_DISABLED=1` for the experimental
+   deployment.
+3. Deploy and restart from a fresh process. Do not reuse the high-RSS process
+   as the experiment baseline.
+4. Confirm the startup diagnostic reports
+   `nextImageOptimizationDisabled: true`.
+5. Record startup `rssMiB`, `heapUsedMiB`, `heapTotalMiB`, `externalMiB`, and
+   `arrayBuffersMiB` before deliberately warming routes.
+6. Exercise a consistent route set, including:
+   - the home page and other canonical public pages;
+   - the blog listing and representative blog details;
+   - the physical gallery listing;
+   - representative physical gallery detail pages with remote images.
+7. Confirm images remain visually correct. With optimisation disabled, image
+   URLs and payload sizes may differ, so also check responsive layout and page
+   loading behaviour.
+8. Observe Render RSS and the server memory diagnostics for 48–72 hours under
+   ordinary traffic. Record step changes and the associated route activity.
+9. Compare the experiment with the control using:
+   - startup and warmed RSS;
+   - maximum and steady-state RSS;
+   - `heapUsedMiB` and `heapTotalMiB`;
+   - `externalMiB`;
+   - `arrayBuffersMiB`;
+   - restart count and traffic level.
+10. Remove the flag or set it to `0` after the observation window unless the
+    result justifies a separate product decision about image delivery.
+
+Do not change allocator settings during this experiment. `MALLOC_ARENA_MAX`
+may be evaluated later as a separate Render environment experiment, after the
+image result is understood, so that allocator and image-processing effects are
+not conflated.

--- a/openeire-next/lib/config/nextImages.ts
+++ b/openeire-next/lib/config/nextImages.ts
@@ -1,0 +1,28 @@
+import type { NextConfig } from "next";
+
+type NextImageConfig = NonNullable<NextConfig["images"]>;
+type NextImageEnvironment = Record<string, string | undefined>;
+
+export const NEXT_IMAGE_CONFIG_DEFAULTS = {
+  remotePatterns: [
+    {
+      protocol: "https",
+      hostname: "api.openeire.ie",
+    },
+    {
+      protocol: "https",
+      hostname: "media.openeire.ie",
+    },
+  ],
+} satisfies NextImageConfig;
+
+export const isNextImageOptimizationDisabled = (
+  environment: NextImageEnvironment = process.env,
+): boolean => environment.NEXT_IMAGE_OPTIMIZATION_DISABLED === "1";
+
+export const createNextImageConfig = (
+  environment: NextImageEnvironment = process.env,
+): NextImageConfig => ({
+  ...NEXT_IMAGE_CONFIG_DEFAULTS,
+  unoptimized: isNextImageOptimizationDisabled(environment),
+});

--- a/openeire-next/lib/server/memoryLogging.ts
+++ b/openeire-next/lib/server/memoryLogging.ts
@@ -4,6 +4,7 @@ import {
   SERVER_MEMORY_LOGGER_SYMBOL,
   type ServerMemoryLoggerGlobal,
 } from "@/lib/memoryLoggingShared";
+import { isNextImageOptimizationDisabled } from "@/lib/config/nextImages";
 
 const MEMORY_LOG_STARTUP_SYMBOL = Symbol.for(
   "openeire.server-memory.startup-logged",
@@ -61,6 +62,9 @@ export const registerServerMemoryLogging = (): void => {
 
   if (!memoryGlobal[MEMORY_LOG_STARTUP_SYMBOL]) {
     memoryGlobal[MEMORY_LOG_STARTUP_SYMBOL] = true;
+    console.info("[server-image-optimization]", {
+      nextImageOptimizationDisabled: isNextImageOptimizationDisabled(),
+    });
     logServerMemory("startup");
   }
 

--- a/openeire-next/next.config.ts
+++ b/openeire-next/next.config.ts
@@ -1,4 +1,5 @@
 import type { NextConfig } from "next";
+import { createNextImageConfig } from "./lib/config/nextImages";
 
 const isProduction = process.env.NODE_ENV === "production";
 
@@ -169,18 +170,7 @@ const nextConfig: NextConfig = {
   reactStrictMode: true,
   cacheMaxMemorySize: 8 * 1024 * 1024,
   outputFileTracingRoot: process.cwd(),
-  images: {
-    remotePatterns: [
-      {
-        protocol: "https",
-        hostname: "api.openeire.ie",
-      },
-      {
-        protocol: "https",
-        hostname: "media.openeire.ie",
-      },
-    ],
-  },
+  images: createNextImageConfig(),
   async redirects() {
     return [
       {

--- a/openeire-next/tests/memoryLogging.test.ts
+++ b/openeire-next/tests/memoryLogging.test.ts
@@ -21,6 +21,8 @@ const memoryGlobal = globalThis as MemoryTestGlobal;
 describe("server memory logging", () => {
   const originalNextRuntime = process.env.NEXT_RUNTIME;
   const originalMemoryLogging = process.env.SERVER_MEMORY_LOGGING;
+  const originalImageOptimizationDisabled =
+    process.env.NEXT_IMAGE_OPTIMIZATION_DISABLED;
 
   beforeEach(() => {
     delete memoryGlobal[STARTUP_SYMBOL];
@@ -28,6 +30,7 @@ describe("server memory logging", () => {
     delete memoryGlobal[LOGGER_SYMBOL];
     process.env.NEXT_RUNTIME = "nodejs";
     process.env.SERVER_MEMORY_LOGGING = "1";
+    process.env.NEXT_IMAGE_OPTIMIZATION_DISABLED = "1";
   });
 
   afterEach(() => {
@@ -45,6 +48,13 @@ describe("server memory logging", () => {
       delete process.env.SERVER_MEMORY_LOGGING;
     } else {
       process.env.SERVER_MEMORY_LOGGING = originalMemoryLogging;
+    }
+
+    if (originalImageOptimizationDisabled === undefined) {
+      delete process.env.NEXT_IMAGE_OPTIMIZATION_DISABLED;
+    } else {
+      process.env.NEXT_IMAGE_OPTIMIZATION_DISABLED =
+        originalImageOptimizationDisabled;
     }
   });
 
@@ -90,6 +100,16 @@ describe("server memory logging", () => {
       5 * 60 * 1_000,
     );
     expect(unref).toHaveBeenCalledTimes(1);
+    expect(
+      consoleInfoSpy.mock.calls.filter(
+        ([label]) => label === "[server-image-optimization]",
+      ),
+    ).toEqual([
+      [
+        "[server-image-optimization]",
+        { nextImageOptimizationDisabled: true },
+      ],
+    ]);
     expect(
       consoleInfoSpy.mock.calls.filter(
         ([label, value]) =>

--- a/openeire-next/tests/nextImagesConfig.test.ts
+++ b/openeire-next/tests/nextImagesConfig.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  createNextImageConfig,
+  NEXT_IMAGE_CONFIG_DEFAULTS,
+} from "@/lib/config/nextImages";
+
+describe("Next image optimisation configuration", () => {
+  it("retains image optimisation when the variable is absent", () => {
+    expect(createNextImageConfig({})).toEqual({
+      ...NEXT_IMAGE_CONFIG_DEFAULTS,
+      unoptimized: false,
+    });
+  });
+
+  it("retains image optimisation when the variable is 0", () => {
+    expect(
+      createNextImageConfig({ NEXT_IMAGE_OPTIMIZATION_DISABLED: "0" })
+        .unoptimized,
+    ).toBe(false);
+  });
+
+  it("enables unoptimized images only when the variable is 1", () => {
+    expect(
+      createNextImageConfig({ NEXT_IMAGE_OPTIMIZATION_DISABLED: "1" })
+        .unoptimized,
+    ).toBe(true);
+  });
+
+  it("preserves every existing image configuration setting", () => {
+    const enabledConfig = createNextImageConfig({
+      NEXT_IMAGE_OPTIMIZATION_DISABLED: "1",
+    });
+    const { unoptimized, ...preservedConfig } = enabledConfig;
+
+    expect(unoptimized).toBe(true);
+    expect(preservedConfig).toEqual(NEXT_IMAGE_CONFIG_DEFAULTS);
+    expect(enabledConfig.remotePatterns).toEqual([
+      { protocol: "https", hostname: "api.openeire.ie" },
+      { protocol: "https", hostname: "media.openeire.ie" },
+    ]);
+  });
+});


### PR DESCRIPTION
## What changed

- add `NEXT_IMAGE_OPTIMIZATION_DISABLED=1` as a controlled switch for `images.unoptimized`
- preserve the existing remote image configuration and normal optimisation by default
- add a boolean-only startup diagnostic for the effective experiment state
- add focused configuration and startup-registration tests
- document the 48–72 hour production observation procedure

## Why

Production RSS stepped sharply and remained near the 512 MiB Render limit while V8 heap, external memory, array buffers, CPU, and traffic remained comparatively stable. Sharp/libvips allocations from Next.js image optimisation are the leading native-memory hypothesis, so this PR introduces a reversible single-variable experiment without hard-coding unoptimised images.

## Impact

Normal behaviour is unchanged unless `NEXT_IMAGE_OPTIMIZATION_DISABLED` is exactly `1`. When enabled for the experiment, Next.js serves unoptimised images so RSS behaviour can be compared from a fresh process over 48–72 hours.

## Validation

- `npm run lint`
- `npm run typecheck`
- `npm test` — 91 tests passed across 16 files
- default `npm run build` — resolved `images.unoptimized: false`
- flagged `npm run build` — resolved `images.unoptimized: true`
- `git diff --check`