### PR TITLE
Fix delivery proxy origin validation

### DIFF
--- a/openeire-next/app/api/delivery/download/route.ts
+++ b/openeire-next/app/api/delivery/download/route.ts
@@ -4,6 +4,7 @@ import {
   assertTrustedDeliveryPost,
   DELIVERY_COOKIE,
   deliveryBackendPost,
+  logDeliveryFailure,
   noStoreHeaders,
 } from "@/lib/delivery/server";
 
@@ -29,6 +30,7 @@ export async function POST(request: NextRequest) {
     );
     const redirectUrl = backend.payload.redirect_url;
     if (!backend.ok || typeof redirectUrl !== "string") {
+      logDeliveryFailure("backend_response");
       return NextResponse.redirect(
         new URL(`${returnPath}?download=failed`, request.url),
         { status: 303, headers: noStoreHeaders },
@@ -42,7 +44,8 @@ export async function POST(request: NextRequest) {
       status: 303,
       headers: noStoreHeaders,
     });
-  } catch {
+  } catch (error) {
+    logDeliveryFailure(error);
     return NextResponse.redirect(
       new URL(`${returnPath}?download=failed`, request.url),
       { status: 303, headers: noStoreHeaders },

--- a/openeire-next/app/api/delivery/exchange/route.ts
+++ b/openeire-next/app/api/delivery/exchange/route.ts
@@ -4,6 +4,7 @@ import {
   assertTrustedDeliveryPost,
   DELIVERY_COOKIE,
   deliveryBackendPost,
+  logDeliveryFailure,
   noStoreHeaders,
 } from "@/lib/delivery/server";
 
@@ -34,6 +35,7 @@ export async function POST(request: NextRequest) {
         ? backend.payload.state
         : "unavailable";
     if (!backend.ok || typeof backend.payload.session !== "string") {
+      logDeliveryFailure("backend_response");
       return NextResponse.json(
         { state },
         { status: backend.status, headers: noStoreHeaders },
@@ -55,7 +57,8 @@ export async function POST(request: NextRequest) {
       maxAge,
     });
     return response;
-  } catch {
+  } catch (error) {
+    logDeliveryFailure(error);
     return NextResponse.json(
       { state: "unavailable" },
       { status: 400, headers: noStoreHeaders },

--- a/openeire-next/app/api/delivery/session/route.ts
+++ b/openeire-next/app/api/delivery/session/route.ts
@@ -4,6 +4,7 @@ import {
   assertTrustedDeliveryPost,
   DELIVERY_COOKIE,
   deliveryBackendPost,
+  logDeliveryFailure,
   noStoreHeaders,
 } from "@/lib/delivery/server";
 
@@ -20,11 +21,13 @@ export async function POST(request: NextRequest) {
       );
     }
     const backend = await deliveryBackendPost("session", { session }, origin);
+    if (!backend.ok) logDeliveryFailure("backend_response");
     return NextResponse.json(
       backend.ok ? backend.payload : { state: backend.payload.state ?? "unavailable" },
       { status: backend.status, headers: noStoreHeaders },
     );
-  } catch {
+  } catch (error) {
+    logDeliveryFailure(error);
     return NextResponse.json(
       { state: "unavailable" },
       { status: 400, headers: noStoreHeaders },

--- a/openeire-next/lib/delivery/server.ts
+++ b/openeire-next/lib/delivery/server.ts
@@ -4,16 +4,87 @@ import type { NextRequest } from "next/server";
 
 export const DELIVERY_COOKIE = "openeire_delivery_access";
 
+export type DeliveryFailureCategory =
+  | "missing_origin"
+  | "invalid_origin"
+  | "proxy_origin_mismatch"
+  | "configuration_error"
+  | "backend_connection_error"
+  | "backend_response";
+
+const DELIVERY_FAILURE_CATEGORIES = new Set<DeliveryFailureCategory>([
+  "missing_origin",
+  "invalid_origin",
+  "proxy_origin_mismatch",
+  "configuration_error",
+  "backend_connection_error",
+  "backend_response",
+]);
+
+class DeliveryFailure extends Error {
+  constructor(readonly category: DeliveryFailureCategory) {
+    super("Secure delivery request is unavailable.");
+    this.name = "DeliveryFailure";
+  }
+}
+
+const configurationFailure = (): never => {
+  throw new DeliveryFailure("configuration_error");
+};
+
+const canonicalFrontendOrigin = (): URL => {
+  const configured = process.env.NEXT_PUBLIC_SITE_URL?.trim();
+  if (!configured) return configurationFailure();
+
+  let parsed: URL;
+  try {
+    parsed = new URL(configured);
+  } catch {
+    return configurationFailure();
+  }
+
+  const protocolAllowed =
+    parsed.protocol === "https:" ||
+    (process.env.NODE_ENV !== "production" && parsed.protocol === "http:");
+  if (
+    !protocolAllowed ||
+    parsed.username ||
+    parsed.password ||
+    parsed.pathname !== "/" ||
+    parsed.search ||
+    parsed.hash
+  ) {
+    return configurationFailure();
+  }
+  return parsed;
+};
+
+const renderExternalHostname = (): string | null => {
+  const configured = process.env.RENDER_EXTERNAL_HOSTNAME?.trim().toLowerCase();
+  if (!configured) return null;
+
+  try {
+    const parsed = new URL(`https://${configured}`);
+    if (parsed.host !== configured || parsed.pathname !== "/") {
+      return configurationFailure();
+    }
+    return configured;
+  } catch (error) {
+    if (error instanceof DeliveryFailure) throw error;
+    return configurationFailure();
+  }
+};
+
 const backendBaseUrl = (): string => {
   const configured = process.env.OPENEIRE_API_BASE_URL?.trim();
   if (!configured) {
-    throw new Error("Secure delivery server configuration is unavailable.");
+    return configurationFailure();
   }
   let parsed: URL;
   try {
     parsed = new URL(configured);
   } catch {
-    throw new Error("Secure delivery server configuration is unavailable.");
+    return configurationFailure();
   }
   const protocolAllowed =
     parsed.protocol === "https:" ||
@@ -25,7 +96,7 @@ const backendBaseUrl = (): string => {
     parsed.search ||
     parsed.hash
   ) {
-    throw new Error("Secure delivery server configuration is unavailable.");
+    return configurationFailure();
   }
   return parsed.toString().endsWith("/") ? parsed.toString() : `${parsed.toString()}/`;
 };
@@ -33,20 +104,65 @@ const backendBaseUrl = (): string => {
 const internalSecret = (): string => {
   const value = process.env.REAL_ESTATE_DELIVERY_INTERNAL_SECRET ?? "";
   if (value.length < 32) {
-    throw new Error("Secure delivery server configuration is unavailable.");
+    configurationFailure();
   }
   return value;
 };
 
 export const assertTrustedDeliveryPost = (request: NextRequest): string => {
   const origin = request.headers.get("origin");
-  const host = request.headers.get("host");
-  if (!origin || !host) throw new Error("Untrusted delivery request.");
-  const parsed = new URL(origin);
-  if (parsed.host !== host || parsed.origin !== request.nextUrl.origin) {
-    throw new Error("Untrusted delivery request.");
+  if (!origin) throw new DeliveryFailure("missing_origin");
+
+  let parsed: URL;
+  try {
+    parsed = new URL(origin);
+  } catch {
+    throw new DeliveryFailure("invalid_origin");
   }
-  return parsed.origin;
+
+  const canonical = canonicalFrontendOrigin();
+  if (origin !== parsed.origin || parsed.origin !== canonical.origin) {
+    throw new DeliveryFailure("invalid_origin");
+  }
+
+  const host = request.headers.get("host")?.toLowerCase() ?? "";
+  const renderHost = renderExternalHostname();
+  const allowedTransportHosts = new Set(
+    [canonical.host.toLowerCase(), renderHost].filter(
+      (value): value is string => Boolean(value),
+    ),
+  );
+  const forwardedHost = request.headers.get("x-forwarded-host")?.toLowerCase();
+  const forwardedProto = request.headers.get("x-forwarded-proto")?.toLowerCase();
+  const hasForwardingHeaders = Boolean(forwardedHost || forwardedProto);
+  const forwardedOriginMatches =
+    forwardedHost === canonical.host.toLowerCase() &&
+    forwardedProto === canonical.protocol.slice(0, -1);
+  const usesInternalRenderHost = Boolean(renderHost) && host === renderHost;
+
+  // nextUrl is built from Next.js's internal bind hostname and port on Render,
+  // so it is routing metadata rather than an authority for the public origin.
+  if (
+    !allowedTransportHosts.has(host) ||
+    (hasForwardingHeaders && !forwardedOriginMatches) ||
+    (usesInternalRenderHost && !forwardedOriginMatches)
+  ) {
+    throw new DeliveryFailure("proxy_origin_mismatch");
+  }
+  return canonical.origin;
+};
+
+export const logDeliveryFailure = (
+  failure: unknown,
+): void => {
+  const category =
+    typeof failure === "string" &&
+    DELIVERY_FAILURE_CATEGORIES.has(failure as DeliveryFailureCategory)
+      ? (failure as DeliveryFailureCategory)
+      : failure instanceof DeliveryFailure
+        ? failure.category
+        : null;
+  if (category) console.error("delivery_failure", { category });
 };
 
 export interface DeliveryBackendResponse {
@@ -60,19 +176,23 @@ export const deliveryBackendPost = async (
   body: Record<string, unknown>,
   browserOrigin: string,
 ): Promise<DeliveryBackendResponse> => {
-  const response = await fetch(
-    `${backendBaseUrl()}real-estate/delivery/${endpoint}/`,
-    {
+  const url = `${backendBaseUrl()}real-estate/delivery/${endpoint}/`;
+  const secret = internalSecret();
+  let response: Response;
+  try {
+    response = await fetch(url, {
       method: "POST",
       cache: "no-store",
       headers: {
         "Content-Type": "application/json",
         Origin: browserOrigin,
-        "X-OpenEire-Delivery-Internal": internalSecret(),
+        "X-OpenEire-Delivery-Internal": secret,
       },
       body: JSON.stringify(body),
-    },
-  );
+    });
+  } catch {
+    throw new DeliveryFailure("backend_connection_error");
+  }
   let payload: Record<string, unknown> = {};
   try {
     const parsed: unknown = await response.json();

--- a/openeire-next/tests/deliveryServer.test.ts
+++ b/openeire-next/tests/deliveryServer.test.ts
@@ -1,5 +1,5 @@
 import { NextRequest } from "next/server";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("server-only", () => ({}));
 
@@ -7,6 +7,7 @@ import { POST as exchangeDelivery } from "@/app/api/delivery/exchange/route";
 import {
   assertTrustedDeliveryPost,
   deliveryBackendPost,
+  logDeliveryFailure,
 } from "@/lib/delivery/server";
 
 const INTERNAL_SECRET = "internal-secret-with-high-entropy-1234567890";
@@ -15,18 +16,25 @@ const PUBLIC_ID = "11111111-1111-4111-8111-111111111111";
 const deliveryRequest = (
   body: Record<string, unknown>,
   origin = "https://openeire.test",
+  requestUrl = "https://openeire.test/api/delivery/exchange",
+  headers: Record<string, string> = {},
 ) =>
-  new NextRequest("https://openeire.test/api/delivery/exchange", {
+  new NextRequest(requestUrl, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",
       Host: "openeire.test",
       Origin: origin,
+      ...headers,
     },
     body: JSON.stringify(body),
   });
 
 describe("delivery server boundary", () => {
+  beforeEach(() => {
+    vi.stubEnv("NEXT_PUBLIC_SITE_URL", "https://openeire.test");
+  });
+
   afterEach(() => {
     vi.unstubAllEnvs();
     vi.unstubAllGlobals();
@@ -41,7 +49,7 @@ describe("delivery server boundary", () => {
 
     await expect(
       deliveryBackendPost("session", { session: "fictional" }, "https://openeire.test"),
-    ).rejects.toThrow("Secure delivery server configuration is unavailable.");
+    ).rejects.toThrow("Secure delivery request is unavailable.");
     expect(fetchMock).not.toHaveBeenCalled();
   });
 
@@ -53,7 +61,7 @@ describe("delivery server boundary", () => {
 
     await expect(
       deliveryBackendPost("session", { session: "fictional" }, "https://openeire.test"),
-    ).rejects.toThrow("Secure delivery server configuration is unavailable.");
+    ).rejects.toThrow("Secure delivery request is unavailable.");
   });
 
   it("sends control-plane requests only to the configured backend", async () => {
@@ -94,8 +102,178 @@ describe("delivery server boundary", () => {
       "https://attacker.example",
     );
     expect(() => assertTrustedDeliveryPost(request)).toThrow(
-      "Untrusted delivery request.",
+      "Secure delivery request is unavailable.",
     );
+  });
+
+  it("accepts the canonical HTTPS origin behind Render and Cloudflare", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("NEXT_PUBLIC_SITE_URL", "https://openeire.ie");
+    vi.stubEnv("RENDER_EXTERNAL_HOSTNAME", "openeire-next.onrender.com");
+    vi.stubEnv("OPENEIRE_API_BASE_URL", "https://api.example.test/api");
+    vi.stubEnv("REAL_ESTATE_DELIVERY_INTERNAL_SECRET", INTERNAL_SECRET);
+    const fetchMock = vi.fn(() =>
+      Promise.resolve(
+        new Response(
+          JSON.stringify({
+            state: "valid",
+            session: "signed-fictional-session",
+            expires_in: 120,
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        ),
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const request = deliveryRequest(
+      { public_id: PUBLIC_ID, secret: "fragment-secret" },
+      "https://openeire.ie",
+      "http://0.0.0.0:10000/api/delivery/exchange",
+      {
+        Host: "openeire-next.onrender.com",
+        "X-Forwarded-Host": "openeire.ie",
+        "X-Forwarded-Proto": "https",
+      },
+    );
+
+    const response = await exchangeDelivery(request);
+
+    expect(response.status).toBe(200);
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.example.test/api/real-estate/delivery/exchange/",
+      expect.objectContaining({
+        headers: expect.objectContaining({ Origin: "https://openeire.ie" }),
+      }),
+    );
+  });
+
+  it("applies the configured canonical policy to the www hostname", () => {
+    vi.stubEnv("NEXT_PUBLIC_SITE_URL", "https://openeire.ie");
+    expect(() =>
+      assertTrustedDeliveryPost(
+        deliveryRequest(
+          { public_id: PUBLIC_ID, secret: "fragment-secret" },
+          "https://www.openeire.ie",
+          "https://www.openeire.ie/api/delivery/exchange",
+          { Host: "www.openeire.ie" },
+        ),
+      ),
+    ).toThrow("Secure delivery request is unavailable.");
+
+    vi.stubEnv("NEXT_PUBLIC_SITE_URL", "https://www.openeire.ie");
+    expect(
+      assertTrustedDeliveryPost(
+        deliveryRequest(
+          { public_id: PUBLIC_ID, secret: "fragment-secret" },
+          "https://www.openeire.ie",
+          "https://www.openeire.ie/api/delivery/exchange",
+          { Host: "www.openeire.ie" },
+        ),
+      ),
+    ).toBe("https://www.openeire.ie");
+  });
+
+  it("rejects a missing browser Origin", () => {
+    const request = new NextRequest(
+      "https://openeire.test/api/delivery/exchange",
+      {
+        method: "POST",
+        headers: { Host: "openeire.test" },
+        body: JSON.stringify({ public_id: PUBLIC_ID, secret: "fragment-secret" }),
+      },
+    );
+    expect(() => assertTrustedDeliveryPost(request)).toThrow(
+      "Secure delivery request is unavailable.",
+    );
+  });
+
+  it("rejects spoofed forwarding headers and arbitrary proxy targets", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("NEXT_PUBLIC_SITE_URL", "https://openeire.ie");
+    vi.stubEnv("RENDER_EXTERNAL_HOSTNAME", "openeire-next.onrender.com");
+
+    const spoofedForwardedHost = deliveryRequest(
+      { public_id: PUBLIC_ID, secret: "fragment-secret" },
+      "https://openeire.ie",
+      "http://0.0.0.0:10000/api/delivery/exchange",
+      {
+        Host: "openeire-next.onrender.com",
+        "X-Forwarded-Host": "attacker.example",
+        "X-Forwarded-Proto": "https",
+      },
+    );
+    const arbitraryTarget = deliveryRequest(
+      { public_id: PUBLIC_ID, secret: "fragment-secret" },
+      "https://openeire.ie",
+      "http://untrusted-proxy.example/api/delivery/exchange",
+      {
+        Host: "untrusted-proxy.example",
+        "X-Forwarded-Host": "openeire.ie",
+        "X-Forwarded-Proto": "https",
+      },
+    );
+
+    expect(() => assertTrustedDeliveryPost(spoofedForwardedHost)).toThrow();
+    expect(() => assertTrustedDeliveryPost(arbitraryTarget)).toThrow();
+  });
+
+  it("rejects HTTP browser origins in production", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("NEXT_PUBLIC_SITE_URL", "https://openeire.ie");
+    expect(() =>
+      assertTrustedDeliveryPost(
+        deliveryRequest(
+          { public_id: PUBLIC_ID, secret: "fragment-secret" },
+          "http://openeire.ie",
+          "http://openeire.ie/api/delivery/exchange",
+          { Host: "openeire.ie" },
+        ),
+      ),
+    ).toThrow("Secure delivery request is unavailable.");
+  });
+
+  it("logs only fixed origin failure categories", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    const missingOrigin = new NextRequest(
+      "https://openeire.test/api/delivery/exchange",
+      {
+        method: "POST",
+        headers: { Host: "openeire.test" },
+        body: JSON.stringify({ public_id: PUBLIC_ID, secret: "fragment-secret" }),
+      },
+    );
+    await exchangeDelivery(missingOrigin);
+    await exchangeDelivery(
+      deliveryRequest(
+        { public_id: PUBLIC_ID, secret: "fragment-secret" },
+        "https://attacker.example",
+      ),
+    );
+    logDeliveryFailure("fragment-secret");
+    logDeliveryFailure(new Error("private exception detail"));
+    await exchangeDelivery(
+      deliveryRequest(
+        { public_id: PUBLIC_ID, secret: "fragment-secret" },
+        "https://openeire.test",
+        "https://openeire.test/api/delivery/exchange",
+        {
+          "X-Forwarded-Host": "attacker.example",
+          "X-Forwarded-Proto": "https",
+        },
+      ),
+    );
+
+    expect(consoleError.mock.calls).toEqual([
+      ["delivery_failure", { category: "missing_origin" }],
+      ["delivery_failure", { category: "invalid_origin" }],
+      ["delivery_failure", { category: "proxy_origin_mismatch" }],
+    ]);
+    const logged = JSON.stringify(consoleError.mock.calls);
+    expect(logged).not.toContain(PUBLIC_ID);
+    expect(logged).not.toContain("fragment-secret");
+    expect(logged).not.toContain("attacker.example");
+    expect(logged).not.toContain("private exception detail");
   });
 
   it("sets a hardened production cookie after a valid fragment exchange", async () => {
@@ -136,6 +314,7 @@ describe("delivery server boundary", () => {
   it("keeps invalid exchange responses generic", async () => {
     vi.stubEnv("OPENEIRE_API_BASE_URL", "https://api.example.test/api/");
     vi.stubEnv("REAL_ESTATE_DELIVERY_INTERNAL_SECRET", INTERNAL_SECRET);
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
     vi.stubGlobal(
       "fetch",
       vi.fn(() =>
@@ -160,5 +339,48 @@ describe("delivery server boundary", () => {
 
     expect(response.status).toBe(404);
     await expect(response.json()).resolves.toEqual({ state: "unavailable" });
+    expect(consoleError).toHaveBeenCalledWith("delivery_failure", {
+      category: "backend_response",
+    });
+  });
+
+  it("keeps configuration and backend connection failures generic", async () => {
+    vi.stubEnv("OPENEIRE_API_BASE_URL", "");
+    vi.stubEnv("REAL_ESTATE_DELIVERY_INTERNAL_SECRET", INTERNAL_SECRET);
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const configurationResponse = await exchangeDelivery(
+      deliveryRequest({ public_id: PUBLIC_ID, secret: "fragment-secret" }),
+    );
+    expect(configurationResponse.status).toBe(400);
+    await expect(configurationResponse.json()).resolves.toEqual({
+      state: "unavailable",
+    });
+    expect(consoleError).toHaveBeenLastCalledWith("delivery_failure", {
+      category: "configuration_error",
+    });
+
+    vi.stubEnv("OPENEIRE_API_BASE_URL", "https://api.example.test/api/");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.reject(new Error("private connection detail"))),
+    );
+    const connectionResponse = await exchangeDelivery(
+      deliveryRequest({ public_id: PUBLIC_ID, secret: "fragment-secret" }),
+    );
+    expect(connectionResponse.status).toBe(400);
+    await expect(connectionResponse.json()).resolves.toEqual({
+      state: "unavailable",
+    });
+    expect(consoleError).toHaveBeenLastCalledWith("delivery_failure", {
+      category: "backend_connection_error",
+    });
+
+    const logged = JSON.stringify(consoleError.mock.calls);
+    expect(logged).not.toContain(PUBLIC_ID);
+    expect(logged).not.toContain("fragment-secret");
+    expect(logged).not.toContain(INTERNAL_SECRET);
+    expect(logged).not.toContain("private connection detail");
+    expect(logged).not.toContain("real-estate/delivery/exchange");
   });
 });


### PR DESCRIPTION
## Summary

- validate delivery POSTs against the explicit canonical frontend origin from `NEXT_PUBLIC_SITE_URL`
- allow the known Render transport host while requiring exact canonical forwarded host/protocol values
- treat `request.nextUrl.origin` as proxy-internal routing metadata instead of public-origin authority
- add privacy-safe fixed-category failure logging across delivery exchange, session, and download routes
- add regression coverage for Cloudflare/Render proxy headers, canonical apex/www policy, hostile inputs, backend failures, and log privacy

## Root cause

The delivery exchange handler required the browser `Origin`, `Host`, and `request.nextUrl.origin` to match exactly. In production, Cloudflare preserves the public browser origin (`https://openeire.ie`) while Render/Next.js can expose an internal service host and an internal bind URL such as `http://0.0.0.0:10000`. The public and proxy-internal values therefore differed, causing `assertTrustedDeliveryPost()` to throw before Django was contacted. The route's generic catch converted that failure into HTTP 400 with `{"state":"unavailable"}`.

## Security and configuration

- `NEXT_PUBLIC_SITE_URL` remains the sole canonical public frontend-origin authority.
- Production requires canonical HTTPS.
- Arbitrary Origin, Host, forwarded-host, and forwarded-protocol values are rejected.
- `RENDER_EXTERNAL_HOSTNAME` is supplied automatically by Render, so no Render configuration change is required.
- Public failure responses remain generic.
- Logs contain only fixed categories: `missing_origin`, `invalid_origin`, `proxy_origin_mismatch`, `configuration_error`, `backend_connection_error`, and `backend_response`.
- Credentials, recipient identifiers, delivery fragments, complete delivery URLs, private headers, cookies, internal secrets, and request bodies are never logged.

## Validation

- focused delivery tests: 13 passed
- complete frontend suite: 98 passed
- ESLint: passed
- TypeScript: passed
- production Next.js build: passed
- `git diff --check`: passed

## Production retest procedure

After the normal frontend deployment for this PR:

1. Confirm the deployed frontend still has `NEXT_PUBLIC_SITE_URL=https://openeire.ie`; make no Render configuration changes.
2. Rotate or create a test delivery recipient and send a fresh recipient email after deployment.
3. Open the fresh delivery link in an Incognito/private browser window.
4. Confirm `POST https://openeire.ie/api/delivery/exchange` succeeds and returns the valid public state.
5. Confirm the frontend Render logs show only safe delivery failure categories, if any, and the Django service receives `/api/real-estate/delivery/exchange/`.
6. Confirm the delivery session loads and a permitted download completes.
7. Repeat with a missing or altered fragment and confirm the public response remains generic and no private delivery data appears in logs.

This PR must not be merged or deployed as part of this publication step.