### PR TITLE
Fix delivery downloads and portal styling

### DIFF
--- a/openeire-next/app/api/delivery/download/route.ts
+++ b/openeire-next/app/api/delivery/download/route.ts
@@ -11,13 +11,49 @@ import {
 export const dynamic = "force-dynamic";
 const PUBLIC_ID = /^[0-9a-f-]{36}$/i;
 
+const wantsJsonResponse = (request: NextRequest): boolean =>
+  request.headers
+    .get("accept")
+    ?.split(",")
+    .some((value) => value.trim().split(";", 1)[0] === "application/json") ??
+  false;
+
+const failedDownloadResponse = (
+  request: NextRequest,
+  returnPath: string,
+  asJson: boolean,
+  status = 400,
+) =>
+  asJson
+    ? NextResponse.json(
+        { state: "unavailable" },
+        { status, headers: noStoreHeaders },
+      )
+    : NextResponse.redirect(
+        new URL(`${returnPath}?download=failed`, request.url),
+        { status: 303, headers: noStoreHeaders },
+      );
+
 export async function POST(request: NextRequest) {
   let returnPath = "/delivery/unavailable";
+  const asJson = wantsJsonResponse(request);
   try {
     const origin = assertTrustedDeliveryPost(request);
-    const form = await request.formData();
-    const deliverableId = String(form.get("deliverable_id") ?? "");
-    const recipientPublicId = String(form.get("recipient_public_id") ?? "");
+    let deliverableId = "";
+    let recipientPublicId = "";
+    if (request.headers.get("content-type")?.includes("application/json")) {
+      const body: unknown = await request.json();
+      if (!body || typeof body !== "object" || Array.isArray(body)) {
+        throw new Error("Unavailable");
+      }
+      const input = body as Record<string, unknown>;
+      deliverableId =
+        typeof input.deliverable_id === "string" ? input.deliverable_id : "";
+    } else {
+      const form = await request.formData();
+      deliverableId = String(form.get("deliverable_id") ?? "");
+      recipientPublicId = String(form.get("recipient_public_id") ?? "");
+    }
     if (PUBLIC_ID.test(recipientPublicId)) {
       returnPath = `/delivery/${recipientPublicId}`;
     }
@@ -27,18 +63,35 @@ export async function POST(request: NextRequest) {
       "download",
       { session, deliverable_id: deliverableId },
       origin,
+      { redirect: "manual" },
     );
-    const redirectUrl = backend.payload.redirect_url;
-    if (!backend.ok || typeof redirectUrl !== "string") {
+    const redirectUrl = backend.redirectUrl ?? backend.payload.redirect_url;
+    const backendAllowsRedirect = backend.ok || backend.status === 303;
+    if (!backendAllowsRedirect || typeof redirectUrl !== "string") {
       logDeliveryFailure("backend_response");
-      return NextResponse.redirect(
-        new URL(`${returnPath}?download=failed`, request.url),
-        { status: 303, headers: noStoreHeaders },
+      return failedDownloadResponse(
+        request,
+        returnPath,
+        asJson,
+        backend.status >= 400 ? backend.status : 502,
       );
     }
-    const parsed = new URL(redirectUrl);
+    let parsed: URL;
+    try {
+      parsed = new URL(redirectUrl);
+    } catch {
+      logDeliveryFailure("backend_response");
+      return failedDownloadResponse(request, returnPath, asJson, 502);
+    }
     if (parsed.protocol !== "https:" && process.env.NODE_ENV === "production") {
-      throw new Error("Unavailable");
+      logDeliveryFailure("backend_response");
+      return failedDownloadResponse(request, returnPath, asJson, 502);
+    }
+    if (asJson) {
+      return NextResponse.json(
+        { download_url: parsed.toString() },
+        { headers: noStoreHeaders },
+      );
     }
     return NextResponse.redirect(parsed, {
       status: 303,
@@ -46,9 +99,6 @@ export async function POST(request: NextRequest) {
     });
   } catch (error) {
     logDeliveryFailure(error);
-    return NextResponse.redirect(
-      new URL(`${returnPath}?download=failed`, request.url),
-      { status: 303, headers: noStoreHeaders },
-    );
+    return failedDownloadResponse(request, returnPath, asJson);
   }
 }

--- a/openeire-next/components/delivery/PrivateDeliveryClient.tsx
+++ b/openeire-next/components/delivery/PrivateDeliveryClient.tsx
@@ -98,6 +98,9 @@ export function PrivateDeliveryClient({
   const [delivery, setDelivery] = useState<DeliveryDto | null>(null);
   const [isPreview, setIsPreview] = useState(false);
   const [retryKey, setRetryKey] = useState(0);
+  const pendingDownloadRef = useRef<string | null>(null);
+  const [pendingDownloadId, setPendingDownloadId] = useState<string | null>(null);
+  const [downloadError, setDownloadError] = useState<string | null>(null);
 
   useEffect(() => {
     if (startedRef.current) return;
@@ -174,13 +177,58 @@ export function PrivateDeliveryClient({
     setRetryKey((value) => value + 1);
   };
 
+  const downloadFile = async (deliverableId: string) => {
+    if (isPreview || pendingDownloadRef.current) return;
+    pendingDownloadRef.current = deliverableId;
+    setPendingDownloadId(deliverableId);
+    setDownloadError(null);
+
+    try {
+      const response = await fetch("/api/delivery/download", {
+        method: "POST",
+        credentials: "same-origin",
+        cache: "no-store",
+        headers: {
+          Accept: "application/json",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ deliverable_id: deliverableId }),
+      });
+      const payload: unknown = await response.json();
+      const downloadUrl =
+        payload && typeof payload === "object" && !Array.isArray(payload)
+          ? (payload as { download_url?: unknown }).download_url
+          : null;
+      if (!response.ok || typeof downloadUrl !== "string") {
+        throw new Error("Download unavailable");
+      }
+      const parsed = new URL(downloadUrl);
+      if (parsed.protocol !== "https:") {
+        throw new Error("Download unavailable");
+      }
+
+      const link = document.createElement("a");
+      link.href = parsed.toString();
+      link.rel = "noreferrer";
+      link.referrerPolicy = "no-referrer";
+      document.body.append(link);
+      link.click();
+      link.remove();
+    } catch {
+      setDownloadError("We could not start that download. Please try again.");
+    } finally {
+      pendingDownloadRef.current = null;
+      setPendingDownloadId(null);
+    }
+  };
+
   return (
     <div className="min-h-screen bg-zinc-950 px-4 py-8 text-zinc-100 sm:px-6 sm:py-12">
       <div className="mx-auto max-w-5xl">
         <header className="mb-10 flex items-center justify-between border-b border-white/10 pb-6">
           <a
             href="https://openeire.ie"
-            className="rounded-sm text-xl font-extrabold tracking-tight text-white outline-none focus-visible:ring-2 focus-visible:ring-amber-400"
+            className="rounded-sm text-xl font-extrabold tracking-tight text-white outline-none focus-visible:ring-2 focus-visible:ring-[#16a34a] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950"
             aria-label="OpenÉire Studios home"
           >
             OpenÉire <span className="text-amber-400">Studios</span>
@@ -192,7 +240,7 @@ export function PrivateDeliveryClient({
 
         {state === "bootstrapping" && (
           <section aria-live="polite" aria-busy="true" className="py-20 text-center">
-            <div className="mx-auto mb-5 h-9 w-9 animate-spin rounded-full border-2 border-zinc-700 border-t-amber-400" />
+            <div className="mx-auto mb-5 h-9 w-9 animate-spin rounded-full border-2 border-zinc-700 border-t-[#16a34a]" />
             <h1 className="text-2xl font-bold">Opening your private delivery</h1>
             <p className="mt-3 text-zinc-400">Securely checking access…</p>
           </section>
@@ -209,7 +257,7 @@ export function PrivateDeliveryClient({
               </div>
             )}
             <section className="mb-10">
-              <p className="mb-3 text-sm font-semibold uppercase tracking-[0.18em] text-amber-400">
+              <p className="mb-3 text-sm font-semibold uppercase tracking-[0.18em] text-[#16a34a]">
                 Media delivery
               </p>
               <h1 className="max-w-3xl text-3xl font-bold leading-tight sm:text-5xl">
@@ -252,6 +300,15 @@ export function PrivateDeliveryClient({
               </div>
             )}
 
+            {downloadError && (
+              <div
+                role="alert"
+                className="mb-6 rounded-xl border border-red-400/30 bg-red-950/40 p-4 text-sm text-red-100"
+              >
+                {downloadError}
+              </div>
+            )}
+
             <div className="space-y-8">
               {delivery.groups.map((group) => (
                 <section key={group.category} aria-labelledby={`group-${group.category}`}>
@@ -275,22 +332,30 @@ export function PrivateDeliveryClient({
                             {file.filename} · {formatBytes(file.size)}
                           </p>
                         </div>
-                        <form method="post" action="/api/delivery/download">
-                          <input type="hidden" name="deliverable_id" value={file.id} />
-                          <input
-                            type="hidden"
-                            name="recipient_public_id"
-                            value={recipientPublicId}
-                          />
+                        <div className="w-full shrink-0 sm:w-auto">
                           <button
-                            type="submit"
-                            disabled={isPreview}
+                            type="button"
+                            onClick={() => void downloadFile(file.id)}
+                            disabled={isPreview || pendingDownloadId !== null}
+                            aria-busy={pendingDownloadId === file.id}
                             aria-label={`Download ${file.display_name}`}
-                            className="w-full rounded-lg bg-amber-400 px-5 py-3 text-sm font-bold text-zinc-950 outline-none transition hover:bg-amber-300 focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950 disabled:cursor-not-allowed disabled:bg-zinc-600 disabled:text-zinc-300 sm:w-auto"
+                            className="w-full rounded-lg bg-[#16a34a] px-5 py-3 text-sm font-bold text-white outline-none transition hover:bg-[#15803d] active:bg-[#064e3b] focus-visible:ring-2 focus-visible:ring-[#16a34a] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950 disabled:cursor-not-allowed disabled:bg-zinc-700 disabled:text-zinc-400 sm:w-auto"
                           >
-                            {isPreview ? "Preview only" : "Download"}
+                            {isPreview ? (
+                              "Preview only"
+                            ) : pendingDownloadId === file.id ? (
+                              <span className="inline-flex items-center gap-2">
+                                <span
+                                  aria-hidden="true"
+                                  className="h-4 w-4 animate-spin rounded-full border-2 border-white/40 border-t-white"
+                                />
+                                Preparing…
+                              </span>
+                            ) : (
+                              "Download"
+                            )}
                           </button>
-                        </form>
+                        </div>
                       </li>
                     ))}
                   </ul>
@@ -330,14 +395,14 @@ export function PrivateDeliveryClient({
                 <button
                   type="button"
                   onClick={retry}
-                  className="rounded-lg bg-amber-400 px-5 py-3 font-bold text-zinc-950 outline-none focus-visible:ring-2 focus-visible:ring-white"
+                  className="rounded-lg bg-[#16a34a] px-5 py-3 font-bold text-white outline-none transition hover:bg-[#15803d] active:bg-[#064e3b] focus-visible:ring-2 focus-visible:ring-[#16a34a] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950"
                 >
                   Try again
                 </button>
               )}
               <a
                 href="mailto:hello@openeire.ie"
-                className="rounded-lg border border-white/20 px-5 py-3 font-semibold text-white outline-none hover:bg-white/10 focus-visible:ring-2 focus-visible:ring-amber-400"
+                className="rounded-lg border border-white/20 px-5 py-3 font-semibold text-white outline-none transition hover:border-[#16a34a]/70 hover:bg-[#064e3b]/30 focus-visible:ring-2 focus-visible:ring-[#16a34a]"
               >
                 Contact support
               </a>

--- a/openeire-next/lib/delivery/server.ts
+++ b/openeire-next/lib/delivery/server.ts
@@ -169,12 +169,18 @@ export interface DeliveryBackendResponse {
   ok: boolean;
   status: number;
   payload: Record<string, unknown>;
+  redirectUrl: string | null;
+}
+
+interface DeliveryBackendPostOptions {
+  redirect?: RequestRedirect;
 }
 
 export const deliveryBackendPost = async (
   endpoint: string,
   body: Record<string, unknown>,
   browserOrigin: string,
+  options: DeliveryBackendPostOptions = {},
 ): Promise<DeliveryBackendResponse> => {
   const url = `${backendBaseUrl()}real-estate/delivery/${endpoint}/`;
   const secret = internalSecret();
@@ -183,6 +189,7 @@ export const deliveryBackendPost = async (
     response = await fetch(url, {
       method: "POST",
       cache: "no-store",
+      redirect: options.redirect ?? "follow",
       headers: {
         "Content-Type": "application/json",
         Origin: browserOrigin,
@@ -202,7 +209,11 @@ export const deliveryBackendPost = async (
   } catch {
     // Deliberately discard backend response text; it may contain operational data.
   }
-  return { ok: response.ok, status: response.status, payload };
+  const redirectUrl =
+    response.status >= 300 && response.status < 400
+      ? response.headers.get("location")
+      : null;
+  return { ok: response.ok, status: response.status, payload, redirectUrl };
 };
 
 export const noStoreHeaders = {

--- a/openeire-next/tests/deliveryServer.test.ts
+++ b/openeire-next/tests/deliveryServer.test.ts
@@ -4,14 +4,20 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("server-only", () => ({}));
 
 import { POST as exchangeDelivery } from "@/app/api/delivery/exchange/route";
+import { POST as downloadDelivery } from "@/app/api/delivery/download/route";
 import {
   assertTrustedDeliveryPost,
+  DELIVERY_COOKIE,
   deliveryBackendPost,
   logDeliveryFailure,
 } from "@/lib/delivery/server";
 
 const INTERNAL_SECRET = "internal-secret-with-high-entropy-1234567890";
 const PUBLIC_ID = "11111111-1111-4111-8111-111111111111";
+const FILE_ID = "22222222-2222-4222-8222-222222222222";
+const SESSION = "signed-fictional-session-private-value";
+const SIGNED_DOWNLOAD_URL =
+  "https://downloads.example.test/private/object.zip?X-Amz-Signature=fictional-private-value";
 
 const deliveryRequest = (
   body: Record<string, unknown>,
@@ -382,5 +388,287 @@ describe("delivery server boundary", () => {
     expect(logged).not.toContain(INTERNAL_SECRET);
     expect(logged).not.toContain("private connection detail");
     expect(logged).not.toContain("real-estate/delivery/exchange");
+  });
+});
+
+const downloadRequest = ({
+  origin = "https://openeire.test",
+  requestUrl = "https://openeire.test/api/delivery/download",
+  headers = {},
+  json = true,
+}: {
+  origin?: string | null;
+  requestUrl?: string;
+  headers?: Record<string, string>;
+  json?: boolean;
+} = {}) => {
+  const requestHeaders: Record<string, string> = {
+    Accept: json ? "application/json" : "text/html",
+    "Content-Type": json
+      ? "application/json"
+      : "application/x-www-form-urlencoded",
+    Cookie: `${DELIVERY_COOKIE}=${SESSION}`,
+    Host: "openeire.test",
+    ...headers,
+  };
+  if (origin !== null) requestHeaders.Origin = origin;
+  const body = json
+    ? JSON.stringify({ deliverable_id: FILE_ID })
+    : new URLSearchParams({
+        deliverable_id: FILE_ID,
+        recipient_public_id: PUBLIC_ID,
+      }).toString();
+  return new NextRequest(requestUrl, {
+    method: "POST",
+    headers: requestHeaders,
+    body,
+  });
+};
+
+describe("delivery download boundary", () => {
+  beforeEach(() => {
+    vi.stubEnv("NEXT_PUBLIC_SITE_URL", "https://openeire.test");
+    vi.stubEnv("OPENEIRE_API_BASE_URL", "https://api.example.test/api");
+    vi.stubEnv("REAL_ESTATE_DELIVERY_INTERNAL_SECRET", INTERNAL_SECRET);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("documents the native form Origin null failure at the invalid_origin branch", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("NEXT_PUBLIC_SITE_URL", "https://openeire.ie");
+    vi.stubEnv("RENDER_EXTERNAL_HOSTNAME", "openeire-next.onrender.com");
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const response = await downloadDelivery(
+      downloadRequest({
+        origin: "null",
+        requestUrl: "http://0.0.0.0:10000/api/delivery/download",
+        json: false,
+        headers: {
+          Host: "openeire-next.onrender.com",
+          "X-Forwarded-Host": "openeire.ie",
+          "X-Forwarded-Proto": "https",
+        },
+      }),
+    );
+
+    expect(response.status).toBe(303);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(consoleError).toHaveBeenCalledWith("delivery_failure", {
+      category: "invalid_origin",
+    });
+  });
+
+  it("accepts the production same-origin fetch behind Render and Cloudflare", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("NEXT_PUBLIC_SITE_URL", "https://openeire.ie");
+    vi.stubEnv("RENDER_EXTERNAL_HOSTNAME", "openeire-next.onrender.com");
+    const fetchMock = vi.fn(() =>
+      Promise.resolve(
+        new Response(JSON.stringify({ redirect_url: SIGNED_DOWNLOAD_URL }), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        }),
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await downloadDelivery(
+      downloadRequest({
+        origin: "https://openeire.ie",
+        requestUrl: "http://0.0.0.0:10000/api/delivery/download",
+        headers: {
+          Host: "openeire-next.onrender.com",
+          "X-Forwarded-Host": "openeire.ie",
+          "X-Forwarded-Proto": "https",
+        },
+      }),
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      download_url: SIGNED_DOWNLOAD_URL,
+    });
+    expect(fetchMock).toHaveBeenCalledOnce();
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.example.test/api/real-estate/delivery/download/",
+      expect.objectContaining({
+        method: "POST",
+        cache: "no-store",
+        redirect: "manual",
+        headers: expect.objectContaining({
+          Origin: "https://openeire.ie",
+          "X-OpenEire-Delivery-Internal": INTERNAL_SECRET,
+        }),
+        body: JSON.stringify({
+          session: SESSION,
+          deliverable_id: FILE_ID,
+        }),
+      }),
+    );
+  });
+
+  it("handles a Django 303 without following the signed URL server-side", async () => {
+    const fetchMock = vi.fn(() =>
+      Promise.resolve(
+        new Response(null, {
+          status: 303,
+          headers: { Location: SIGNED_DOWNLOAD_URL },
+        }),
+      ),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const response = await downloadDelivery(downloadRequest());
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      download_url: SIGNED_DOWNLOAD_URL,
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      expect.stringContaining("/real-estate/delivery/download/"),
+      expect.objectContaining({ redirect: "manual" }),
+    );
+  });
+
+  it("preserves the controlled 303 for a valid legacy POST", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() =>
+        Promise.resolve(
+          new Response(JSON.stringify({ redirect_url: SIGNED_DOWNLOAD_URL }), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          }),
+        ),
+      ),
+    );
+
+    const response = await downloadDelivery(downloadRequest({ json: false }));
+
+    expect(response.status).toBe(303);
+    expect(response.headers.get("location")).toBe(SIGNED_DOWNLOAD_URL);
+  });
+
+  it.each([
+    ["foreign", "https://attacker.example", "invalid_origin"],
+    ["missing", null, "missing_origin"],
+  ])("rejects a %s Origin before contacting Django", async (_, origin, category) => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const response = await downloadDelivery(downloadRequest({ origin }));
+
+    expect(response.status).toBe(400);
+    await expect(response.json()).resolves.toEqual({ state: "unavailable" });
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(consoleError).toHaveBeenCalledWith("delivery_failure", { category });
+  });
+
+  it("rejects spoofed forwarded headers before contacting Django", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("NEXT_PUBLIC_SITE_URL", "https://openeire.ie");
+    vi.stubEnv("RENDER_EXTERNAL_HOSTNAME", "openeire-next.onrender.com");
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const response = await downloadDelivery(
+      downloadRequest({
+        origin: "https://openeire.ie",
+        requestUrl: "http://0.0.0.0:10000/api/delivery/download",
+        headers: {
+          Host: "openeire-next.onrender.com",
+          "X-Forwarded-Host": "attacker.example",
+          "X-Forwarded-Proto": "https",
+        },
+      }),
+    );
+
+    expect(response.status).toBe(400);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(consoleError).toHaveBeenCalledWith("delivery_failure", {
+      category: "proxy_origin_mismatch",
+    });
+  });
+
+  it.each([
+    ["expired", 410],
+    ["revoked", 404],
+    ["payment_locked", 423],
+    ["preview", 403],
+  ])("passes through the %s policy status with a generic body", async (state, status) => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() =>
+        Promise.resolve(
+          new Response(
+            JSON.stringify({
+              state,
+              detail: `private-${state}-detail`,
+              deliverable_id: FILE_ID,
+            }),
+            { status, headers: { "Content-Type": "application/json" } },
+          ),
+        ),
+      ),
+    );
+
+    const response = await downloadDelivery(downloadRequest());
+
+    expect(response.status).toBe(status);
+    await expect(response.json()).resolves.toEqual({ state: "unavailable" });
+    expect(consoleError).toHaveBeenCalledWith("delivery_failure", {
+      category: "backend_response",
+    });
+    expect(JSON.stringify(consoleError.mock.calls)).not.toContain(FILE_ID);
+    expect(JSON.stringify(consoleError.mock.calls)).not.toContain(
+      `private-${state}-detail`,
+    );
+  });
+
+  it("keeps configuration and backend connection failures generic and private", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.stubEnv("OPENEIRE_API_BASE_URL", "");
+
+    const configurationResponse = await downloadDelivery(downloadRequest());
+    expect(configurationResponse.status).toBe(400);
+    await expect(configurationResponse.json()).resolves.toEqual({
+      state: "unavailable",
+    });
+    expect(consoleError).toHaveBeenLastCalledWith("delivery_failure", {
+      category: "configuration_error",
+    });
+
+    vi.stubEnv("OPENEIRE_API_BASE_URL", "https://api.example.test/api");
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.reject(new Error("private connection detail"))),
+    );
+    const connectionResponse = await downloadDelivery(downloadRequest());
+    expect(connectionResponse.status).toBe(400);
+    await expect(connectionResponse.json()).resolves.toEqual({
+      state: "unavailable",
+    });
+    expect(consoleError).toHaveBeenLastCalledWith("delivery_failure", {
+      category: "backend_connection_error",
+    });
+
+    const logged = JSON.stringify(consoleError.mock.calls);
+    expect(logged).not.toContain(FILE_ID);
+    expect(logged).not.toContain(SESSION);
+    expect(logged).not.toContain(SIGNED_DOWNLOAD_URL);
+    expect(logged).not.toContain(INTERNAL_SECRET);
+    expect(logged).not.toContain("private connection detail");
+    expect(logged).not.toContain("Cookie");
   });
 });

--- a/openeire-next/tests/privateDelivery.test.tsx
+++ b/openeire-next/tests/privateDelivery.test.tsx
@@ -1,10 +1,12 @@
-import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { PrivateDeliveryClient } from "@/components/delivery/PrivateDeliveryClient";
 
 const PUBLIC_ID = "11111111-1111-4111-8111-111111111111";
 const FILE_ID = "22222222-2222-4222-8222-222222222222";
+const SIGNED_DOWNLOAD_URL =
+  "https://downloads.example.test/private/object.zip?X-Amz-Signature=fictional";
 
 const response = (payload: unknown, ok = true, status = ok ? 200 : 423) =>
   Promise.resolve({
@@ -116,34 +118,115 @@ describe("private delivery bootstrap", () => {
     expect(document.body.textContent).not.toContain(PUBLIC_ID);
   });
 
-  it("uses an accessible POST form for downloads and handles long filenames", async () => {
+  it("uses one same-origin POST fetch and navigates the browser directly to the signed URL", async () => {
     window.history.replaceState({}, "", `/delivery/${PUBLIC_ID}`);
-    vi.stubGlobal("fetch", vi.fn(() => response(validDelivery)));
+    let resolveDownload!: (value: Response) => void;
+    const pendingDownload = new Promise<Response>((resolve) => {
+      resolveDownload = resolve;
+    });
+    const fetchMock = vi
+      .fn()
+      .mockImplementationOnce(() => response(validDelivery))
+      .mockImplementationOnce(() => pendingDownload);
+    vi.stubGlobal("fetch", fetchMock);
+    let navigatedTo = "";
+    const clickSpy = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(function (this: HTMLAnchorElement) {
+        navigatedTo = this.href;
+      });
 
     render(<PrivateDeliveryClient recipientPublicId={PUBLIC_ID} />);
 
     const button = await screen.findByRole("button", {
       name: "Download Web photographs",
     });
-    const form = button.closest("form");
-    expect(form?.method).toBe("post");
-    expect(form?.getAttribute("action")).toBe("/api/delivery/download");
-    expect(screen.getByText(/very-long-filename-/)).toBeTruthy();
+    expect(button.className).toContain("bg-[#16a34a]");
+    expect(button.className).toContain("w-full");
+    expect(button.className).toContain("sm:w-auto");
+    expect(button.closest("li")?.className).toContain("sm:flex-row");
+    expect(screen.getByText("Media delivery").className).toContain(
+      "text-[#16a34a]",
+    );
+    expect(screen.getByText(/very-long-filename-/).className).toContain(
+      "break-all",
+    );
+
+    fireEvent.click(button);
+    fireEvent.click(button);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      "/api/delivery/download",
+      expect.objectContaining({
+        method: "POST",
+        credentials: "same-origin",
+        headers: expect.objectContaining({
+          Accept: "application/json",
+          "Content-Type": "application/json",
+        }),
+      }),
+    );
+    expect(JSON.parse(fetchMock.mock.calls[1][1].body as string)).toEqual({
+      deliverable_id: FILE_ID,
+    });
+    expect(button).toHaveProperty("disabled", true);
+    expect(button.textContent).toContain("Preparing");
+
+    resolveDownload({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ download_url: SIGNED_DOWNLOAD_URL }),
+    } as Response);
+
+    await waitFor(() => expect(clickSpy).toHaveBeenCalledTimes(1));
+    expect(navigatedTo).toBe(SIGNED_DOWNLOAD_URL);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    await waitFor(() => expect(button).toHaveProperty("disabled", false));
+  });
+
+  it("shows an accessible generic error when download initiation fails", async () => {
+    window.history.replaceState({}, "", `/delivery/${PUBLIC_ID}`);
+    const fetchMock = vi
+      .fn()
+      .mockImplementationOnce(() => response(validDelivery))
+      .mockImplementationOnce(() =>
+        response({ state: "unavailable", private_detail: FILE_ID }, false),
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    render(<PrivateDeliveryClient recipientPublicId={PUBLIC_ID} />);
+
+    fireEvent.click(
+      await screen.findByRole("button", {
+        name: "Download Web photographs",
+      }),
+    );
+
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toContain(
+      "We could not start that download. Please try again.",
+    );
+    expect(document.body.textContent).not.toContain(FILE_ID);
   });
 
   it("labels staff preview and disables downloads", async () => {
     window.history.replaceState({}, "", `/delivery/${PUBLIC_ID}`);
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(() => response({ ...validDelivery, preview: true })),
+    const fetchMock = vi.fn(() =>
+      response({ ...validDelivery, preview: true }),
     );
+    vi.stubGlobal("fetch", fetchMock);
 
     render(<PrivateDeliveryClient recipientPublicId={PUBLIC_ID} />);
 
     expect(await screen.findByText(/Staff preview/)).toBeTruthy();
-    expect(
-      screen.getByRole("button", { name: "Download Web photographs" }),
-    ).toHaveProperty("disabled", true);
+    const button = screen.getByRole("button", {
+      name: "Download Web photographs",
+    });
+    expect(button).toHaveProperty("disabled", true);
+    fireEvent.click(button);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 });
 


### PR DESCRIPTION
## What changed

- replace the private delivery native download form with a guarded same-origin POST fetch
- prevent repeated download clicks while a request is pending and show an accessible generic inline error
- handle Django download responses without following signed R2 redirects server-side
- navigate the browser directly to the five-minute signed R2 URL so large files do not pass through Next.js or Django
- make OpenÉire green the private portal's primary interactive colour while retaining gold as a restrained accent
- add client and server regression coverage for proxy headers, origin rejection, policy failures, preview sessions, redirects, duplicate clicks, and privacy-safe logging

## Root cause

The private portal applied `Referrer-Policy: no-referrer` while its Download button used a native POST form. In production that form submission sent the literal `Origin: null`. `assertTrustedDeliveryPost()` therefore reached its Origin URL-parsing branch, rejected the value as `invalid_origin`, and stopped before contacting Django.

Exchange and session requests were unaffected because they already used same-origin fetch requests. The origin guard remains strict and unchanged; `NEXT_PUBLIC_SITE_URL` remains the canonical public frontend authority. No Render, R2, Django, production-data, or environment-variable changes are required.

## Security and delivery behavior

- download initiation remains POST-only
- Django policy is revalidated for every download
- preview sessions cannot download
- arbitrary Origin, Host, and forwarded headers remain rejected
- production HTTPS enforcement remains in place
- only privacy-safe failure categories are logged
- no credentials, recipient data, file IDs, object keys, signed URLs, headers, cookies, or request bodies are logged
- the browser downloads directly from R2 after receiving the controlled signed URL

## Validation

- focused delivery tests: 36 passed
- complete frontend suite: 111 passed
- ESLint passed
- TypeScript passed
- production build passed
- `git diff --check` passed