### PR TITLE
Label delivery ZIP archives

### DIFF
--- a/openeire-next/components/delivery/PrivateDeliveryClient.tsx
+++ b/openeire-next/components/delivery/PrivateDeliveryClient.tsx
@@ -19,6 +19,7 @@ interface Deliverable {
   filename: string;
   size: number;
   mime_type: string;
+  format_label?: string;
 }
 
 interface DeliveryDto {
@@ -327,6 +328,11 @@ export function PrivateDeliveryClient({
                         <div className="min-w-0">
                           <h3 className="break-words font-semibold text-white">
                             {file.display_name}
+                            {file.format_label && (
+                              <span className="font-normal text-zinc-300">
+                                {" "}— {file.format_label}
+                              </span>
+                            )}
                           </h3>
                           <p className="mt-1 break-all text-sm text-zinc-400">
                             {file.filename} · {formatBytes(file.size)}

--- a/openeire-next/tests/privateDelivery.test.tsx
+++ b/openeire-next/tests/privateDelivery.test.tsx
@@ -35,6 +35,7 @@ const validDelivery = {
             filename: `${"very-long-filename-".repeat(8)}.zip`,
             size: 1048576,
             mime_type: "application/zip",
+            format_label: "ZIP archive",
           },
         ],
       },
@@ -148,6 +149,12 @@ describe("private delivery bootstrap", () => {
     expect(screen.getByText("Media delivery").className).toContain(
       "text-[#16a34a]",
     );
+    expect(
+      screen.getByRole("heading", {
+        level: 3,
+        name: "Web photographs — ZIP archive",
+      }),
+    ).toBeTruthy();
     expect(screen.getByText(/very-long-filename-/).className).toContain(
       "break-all",
     );


### PR DESCRIPTION
## Related backend PR

- Backend ZIP support: https://github.com/petra66orii/openeire-api/pull/175

Deploy the backend PR first.

## What changed

- accept the backend's optional client-safe `format_label` field in delivery DTOs
- render ZIP deliverables as `<display name> — ZIP archive`
- preserve the user-supplied display name, safe filename, responsive wrapping and existing download behavior
- add private-delivery client regression coverage for the ZIP archive label

## Security and scope

- this PR does not alter upload, download, authentication, origin, R2 or logging behavior
- object keys and signed URLs are not added to the DTO or UI
- no migrations, environment changes, R2 changes, secrets, client data, generated artefacts or unrelated files
- only two private-delivery frontend files changed

## Deployment order

1. Merge and deploy backend PR https://github.com/petra66orii/openeire-api/pull/175 first.
2. Verify backend ZIP upload completion and canonical `application/zip` DTO output.
3. Deploy this frontend PR.
4. No Render variable or R2 configuration change is required.

## Production test procedure

1. Use the fictional/test delivery created for the backend smoke test.
2. Confirm the backend has completed and verified a Photographs ZIP before deploying this PR.
3. Open the recipient portal and confirm the preserved display name renders as `Complete photograph package — ZIP archive`.
4. Confirm the ZIP remains a downloadable file row and is not rendered as an individual photograph preview.
5. Confirm long `.zip` filenames wrap safely on mobile and the Download button remains accessible.
6. Initiate the existing POST download and confirm the browser navigates directly to the controlled five-minute R2 attachment URL.
7. Confirm no object key, signed URL, recipient credential, cookie or client data appears in the page source, public DTO fields, or frontend logs.
8. Re-open JPG, WebP, MP4 and PDF deliverables and confirm their presentation and downloads are unchanged.

## Validation

- focused private-delivery test: 11 passed
- complete frontend suite: 111 passed
- ESLint: passed
- TypeScript: passed
- `git diff --check`: passed