### PR TITLE
Add returning-client booking experience

### DIFF
--- a/openeire-next/app/api/book/enquiries/route.ts
+++ b/openeire-next/app/api/book/enquiries/route.ts
@@ -1,0 +1,24 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import { assertTrustedBookingPost, bookingBackendPost, bookingCookieName, bookingNoStoreHeaders, logBookingFailure } from "@/lib/booking/server";
+
+export const dynamic = "force-dynamic";
+
+export async function POST(request: NextRequest) {
+  try {
+    const origin = assertTrustedBookingPost(request);
+    const session = request.cookies.get(bookingCookieName())?.value;
+    if (!session) return NextResponse.json({ state: "unavailable" }, { status: 404, headers: bookingNoStoreHeaders });
+    const body: unknown = await request.json();
+    if (!body || typeof body !== "object" || Array.isArray(body)) throw new Error("Invalid request");
+    const backend = await bookingBackendPost("enquiries", { ...(body as Record<string, unknown>), session }, origin);
+    if (!backend.ok && backend.status === 404) {
+      logBookingFailure("backend_response");
+      return NextResponse.json({ state: "unavailable" }, { status: 404, headers: bookingNoStoreHeaders });
+    }
+    return NextResponse.json(backend.payload, { status: backend.status, headers: bookingNoStoreHeaders });
+  } catch (error) {
+    logBookingFailure(error);
+    return NextResponse.json({ state: "unavailable" }, { status: 400, headers: bookingNoStoreHeaders });
+  }
+}

--- a/openeire-next/app/api/book/exchange/route.ts
+++ b/openeire-next/app/api/book/exchange/route.ts
@@ -1,0 +1,29 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import { assertTrustedBookingPost, bookingBackendPost, bookingCookieName, bookingNoStoreHeaders, logBookingFailure } from "@/lib/booking/server";
+
+export const dynamic = "force-dynamic";
+
+export async function POST(request: NextRequest) {
+  try {
+    const origin = assertTrustedBookingPost(request);
+    const body: unknown = await request.json();
+    if (!body || typeof body !== "object" || Array.isArray(body)) throw new Error("Invalid request");
+    const input = body as Record<string, unknown>;
+    if (typeof input.public_id !== "string" || typeof input.secret !== "string" || input.secret.length > 2048) throw new Error("Invalid request");
+    const backend = await bookingBackendPost("exchange", { public_id: input.public_id, secret: input.secret }, origin);
+    if (!backend.ok || typeof backend.payload.session !== "string") {
+      logBookingFailure("backend_response");
+      return NextResponse.json({ state: "unavailable" }, { status: backend.status, headers: bookingNoStoreHeaders });
+    }
+    const maxAge = typeof backend.payload.expires_in === "number" ? Math.max(1, Math.min(43_200, backend.payload.expires_in)) : 43_200;
+    const response = NextResponse.json({ state: "valid" }, { headers: bookingNoStoreHeaders });
+    response.cookies.set(bookingCookieName(), backend.payload.session, {
+      httpOnly: true, secure: process.env.NODE_ENV === "production", sameSite: "strict", path: "/", maxAge,
+    });
+    return response;
+  } catch (error) {
+    logBookingFailure(error);
+    return NextResponse.json({ state: "unavailable" }, { status: 400, headers: bookingNoStoreHeaders });
+  }
+}

--- a/openeire-next/app/api/book/session/route.ts
+++ b/openeire-next/app/api/book/session/route.ts
@@ -1,0 +1,19 @@
+import type { NextRequest } from "next/server";
+import { NextResponse } from "next/server";
+import { assertTrustedBookingPost, bookingBackendPost, bookingCookieName, bookingNoStoreHeaders, logBookingFailure } from "@/lib/booking/server";
+
+export const dynamic = "force-dynamic";
+
+export async function POST(request: NextRequest) {
+  try {
+    const origin = assertTrustedBookingPost(request);
+    const session = request.cookies.get(bookingCookieName())?.value;
+    if (!session) return NextResponse.json({ state: "unavailable" }, { status: 404, headers: bookingNoStoreHeaders });
+    const backend = await bookingBackendPost("session", { session }, origin);
+    if (!backend.ok) logBookingFailure("backend_response");
+    return NextResponse.json(backend.ok ? backend.payload : { state: "unavailable" }, { status: backend.status, headers: bookingNoStoreHeaders });
+  } catch (error) {
+    logBookingFailure(error);
+    return NextResponse.json({ state: "unavailable" }, { status: 400, headers: bookingNoStoreHeaders });
+  }
+}

--- a/openeire-next/app/book/[credentialPublicId]/page.tsx
+++ b/openeire-next/app/book/[credentialPublicId]/page.tsx
@@ -1,0 +1,19 @@
+import type { Metadata } from "next";
+import { ReturningClientBookingForm } from "@/components/real-estate/ReturningClientBookingForm";
+
+export const dynamic = "force-dynamic";
+export const revalidate = 0;
+export const metadata: Metadata = {
+  title: "Private property booking | OpenÉire Studios",
+  description: "Secure returning-client property booking.",
+  robots: { index: false, follow: false, noarchive: true, googleBot: { index: false, follow: false, noimageindex: true } },
+  referrer: "no-referrer", alternates: { canonical: null }, openGraph: null, twitter: null,
+};
+
+export default async function BookingPage({ params }: { params: Promise<{ credentialPublicId: string }> }) {
+  const { credentialPublicId } = await params;
+  if (process.env.REAL_ESTATE_BOOKING_PORTAL_ENABLED !== "true") {
+    return <div className="min-h-screen bg-zinc-950 px-4 py-8 text-zinc-100"><div className="mx-auto max-w-4xl"><header className="mb-10 border-b border-white/10 pb-6 text-xl font-extrabold">OpenÉire <span className="text-amber-400">Studios</span></header><section className="mx-auto max-w-xl py-20 text-center"><h1 className="text-3xl font-bold">Booking access unavailable</h1><p className="mt-4 leading-7 text-zinc-300">This private service is not currently available.</p></section></div></div>;
+  }
+  return <ReturningClientBookingForm credentialPublicId={credentialPublicId} />;
+}

--- a/openeire-next/app/robots.ts
+++ b/openeire-next/app/robots.ts
@@ -27,6 +27,8 @@ export default function robots(): MetadataRoute.Robots {
           "/gallery/photo",
           "/gallery/video",
           "/delivery/",
+          "/book/",
+          "/api/book/",
           "/403",
           "/404",
           "/500",

--- a/openeire-next/components/layout/AppShell.tsx
+++ b/openeire-next/components/layout/AppShell.tsx
@@ -16,8 +16,10 @@ export function AppShell({ children }: { children: ReactNode }) {
   const pathname = usePathname() ?? "";
   const isPrivateDelivery =
     pathname.startsWith("/delivery/") || pathname.startsWith("/api/delivery/");
+  const isPrivateBooking =
+    pathname.startsWith("/book/") || pathname.startsWith("/api/book/");
 
-  if (isPrivateDelivery) {
+  if (isPrivateDelivery || isPrivateBooking) {
     return (
       <main id="main" tabIndex={-1} className="min-h-screen bg-zinc-950 text-white">
         {children}

--- a/openeire-next/components/real-estate/ReturningClientBookingForm.tsx
+++ b/openeire-next/components/real-estate/ReturningClientBookingForm.tsx
@@ -134,7 +134,7 @@ export function ReturningClientBookingForm({ credentialPublicId }: { credentialP
       const body: unknown = await response.json();
       if (!response.ok) {
         if (response.status === 404) { setPageState("unavailable"); return; }
-        const fieldErrors = body && typeof body === "object" ? Object.fromEntries(Object.entries(body as Record<string, unknown>).map(([key, value]) => [key, Array.isArray(value) ? value.join(" ") : String(value)])) : { submit: "We could not submit the request." };
+        const fieldErrors = body && typeof body === "object" ? Object.fromEntries(Object.entries(body as Record<string, unknown>).map(([key, value]) => [key === "detail" ? "submit" : key, Array.isArray(value) ? value.join(" ") : String(value)])) : { submit: "We could not submit the request." };
         setErrors(fieldErrors); submittingRef.current = false; setSubmitting(false); focusFirstError(fieldErrors); return;
       }
       setPageState("success");

--- a/openeire-next/components/real-estate/ReturningClientBookingForm.tsx
+++ b/openeire-next/components/real-estate/ReturningClientBookingForm.tsx
@@ -1,0 +1,207 @@
+"use client";
+
+import { useEffect, useRef, useState, type FormEvent } from "react";
+import { REAL_ESTATE_ENQUIRY_PACKAGES } from "@/lib/realEstate";
+
+type ClientSummary = { display_name: string; company_name: string; masked_email: string; masked_phone: string; credential_expires_at: string };
+type PageState = "loading" | "ready" | "unavailable" | "error" | "success";
+type FormValues = Record<string, string | boolean | string[]>;
+
+const counties = ["Carlow","Cavan","Clare","Cork","Donegal","Dublin","Galway","Kerry","Kildare","Kilkenny","Laois","Leitrim","Limerick","Longford","Louth","Mayo","Meath","Monaghan","Offaly","Roscommon","Sligo","Tipperary","Waterford","Westmeath","Wexford","Wicklow"];
+const initialValues: FormValues = {
+  property_address: "", county: "", eircode: "", no_eircode: false, location_details: "",
+  property_type: "", property_type_details: "", bedroom_count: "", floor_count: "",
+  preferred_package: "", scheduling_preference: "", preferred_date: "", alternative_date: "",
+  preferred_time_window: "", access_provider: "", access_contact_name: "", access_contact_phone: "",
+  message: "", readiness_acknowledged: false, saved_details_confirmed: false, privacy_acknowledged: false,
+  contact_update_requested: false, contact_update_request: "", internal_floor_area: "", internal_floor_area_unit: "",
+  secondary_accommodation: "", secondary_accommodation_details: "", outbuildings: "", outbuildings_details: "",
+  grounds_size: "", property_features: "", occupancy_status: "", access_notes: "", add_ons: [],
+  additional_stills_quantity: "", on_camera: "", on_camera_people: "", audio_requirements: "",
+};
+const inputClass = "w-full rounded-xl border border-white/15 bg-black/60 px-4 py-3 text-white outline-none focus:border-green-500 focus:ring-1 focus:ring-green-500";
+const labelClass = "mb-2 block text-xs font-bold uppercase tracking-[0.16em] text-zinc-400";
+const eircodeRe = /^(?:[AC-FHKNPRTV-Y]\d{2}|D6W)\s?[0-9AC-FHKNPRTV-Y]{4}$/i;
+
+function Field({ name, label, error, required, children }: { name: string; label: string; error?: string; required?: boolean; children: React.ReactNode }) {
+  return <div data-field={name}><label htmlFor={`booking-${name}`} className={labelClass}>{label}{required ? " *" : ""}</label>{children}{error ? <p id={`${name}-error`} role="alert" className="mt-2 text-sm text-red-300">{error}</p> : null}</div>;
+}
+
+const option = (value: string, label: string) => <option key={value} value={value}>{label}</option>;
+
+export function ReturningClientBookingForm({ credentialPublicId }: { credentialPublicId: string }) {
+  const started = useRef(false);
+  const submissionId = useRef("");
+  const submittingRef = useRef(false);
+  const [pageState, setPageState] = useState<PageState>("loading");
+  const [client, setClient] = useState<ClientSummary | null>(null);
+  const [values, setValues] = useState<FormValues>(initialValues);
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [submitting, setSubmitting] = useState(false);
+
+  const newSubmissionId = () => {
+    submissionId.current = crypto.randomUUID();
+  };
+
+  useEffect(() => {
+    if (started.current) return;
+    started.current = true;
+    newSubmissionId();
+    let cancelled = false;
+    const bootstrap = async () => {
+      try {
+        const secret = window.location.hash.slice(1);
+        if (secret) {
+          window.history.replaceState(null, "", `${window.location.pathname}${window.location.search}`);
+          const exchange = await fetch("/api/book/exchange", { method: "POST", credentials: "same-origin", cache: "no-store", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ public_id: credentialPublicId, secret }) });
+          if (!exchange.ok) { if (!cancelled) setPageState("unavailable"); return; }
+        }
+        const response = await fetch("/api/book/session", { method: "POST", credentials: "same-origin", cache: "no-store" });
+        const payload: unknown = await response.json();
+        if (!response.ok || !payload || typeof payload !== "object" || !(payload as { client?: unknown }).client) { if (!cancelled) setPageState("unavailable"); return; }
+        if (!cancelled) { setClient((payload as { client: ClientSummary }).client); setPageState("ready"); }
+      } catch { if (!cancelled) setPageState("error"); }
+    };
+    void bootstrap();
+    return () => { cancelled = true; };
+  }, [credentialPublicId]);
+
+  const set = (name: string, value: string | boolean | string[]) => {
+    setValues(current => ({ ...current, [name]: value, ...(name === "no_eircode" && value === true ? { eircode: "" } : {}) }));
+    setErrors(current => ({ ...current, [name]: "", submit: "" }));
+  };
+  const text = (name: string) => String(values[name] ?? "");
+  const checked = (name: string) => values[name] === true;
+  const addOns = values.add_ons as string[];
+  const toggleAddOn = (key: string) => set("add_ons", addOns.includes(key) ? addOns.filter(item => item !== key) : [...addOns, key]);
+
+  const focusFirstError = (fieldErrors: Record<string, string>) => {
+    const first = Object.keys(fieldErrors)[0];
+    if (!first) return;
+    requestAnimationFrame(() => document.querySelector<HTMLElement>(`[data-field="${first}"] input, [data-field="${first}"] select, [data-field="${first}"] textarea`)?.focus());
+  };
+
+  const validate = () => {
+    const next: Record<string, string> = {};
+    for (const [name, label] of [["property_address","Property address"],["county","County"],["property_type","Property category"],["bedroom_count","Bedrooms"],["floor_count","Floors"],["preferred_package","Preferred package"],["scheduling_preference","Date choice"],["preferred_time_window","Preferred time"],["access_provider","Access provider"]]) {
+      if (!text(name).trim()) next[name] = `${label} is required.`;
+    }
+    if (checked("no_eircode")) { if (!text("location_details").trim()) next.location_details = "Provide precise directions or a Google Maps link."; }
+    else if (!eircodeRe.test(text("eircode").trim())) next.eircode = "Enter a valid Eircode or confirm there is none.";
+    if (text("property_type") === "other" && !text("property_type_details").trim()) next.property_type_details = "Describe the property category.";
+    if (text("scheduling_preference") === "request_date" && !text("preferred_date")) next.preferred_date = "Choose a preferred date.";
+    if (text("access_provider") && text("access_provider") !== "enquirer") {
+      if (!text("access_contact_name").trim()) next.access_contact_name = "Provide the access contact's name.";
+      const digits = text("access_contact_phone").replace(/\D/g, "");
+      if (digits.length < 7 || digits.length > 15) next.access_contact_phone = "Provide a plausible access contact number.";
+    }
+    if (text("internal_floor_area") && !text("internal_floor_area_unit")) next.internal_floor_area_unit = "Choose a floor-area unit.";
+    if (text("secondary_accommodation") === "yes" && !text("secondary_accommodation_details").trim()) next.secondary_accommodation_details = "Describe the secondary accommodation.";
+    if (text("outbuildings") === "yes" && !text("outbuildings_details").trim()) next.outbuildings_details = "Describe the outbuildings.";
+    if (["site_land", "agricultural"].includes(text("property_type")) && !text("grounds_size")) next.grounds_size = "Provide the approximate land or grounds size.";
+    if (text("property_type") === "agricultural" && !text("outbuildings")) next.outbuildings = "Confirm whether outbuildings are included.";
+    if (addOns.includes("additional_stills")) { const quantity = Number(text("additional_stills_quantity")); if (!Number.isInteger(quantity) || quantity < 1 || quantity > 50) next.additional_stills_quantity = "Enter a whole number from 1 to 50."; }
+    if (text("on_camera") === "yes") {
+      if (!text("on_camera_people").trim()) next.on_camera_people = "Tell us who will appear or speak.";
+      if (!text("audio_requirements").trim()) next.audio_requirements = "Describe the audio or microphone requirements.";
+    }
+    const packageConflicts: Record<string, string[]> = { pro: ["additional_social_cuts"], premium: ["floor_plan", "virtual_tour_3d", "additional_social_cuts"] };
+    if (addOns.some(key => (packageConflicts[text("preferred_package")] ?? []).includes(key))) next.add_ons = "One or more selected add-ons are already included in the package.";
+    if (checked("contact_update_requested") && !text("contact_update_request").trim()) next.contact_update_request = "Describe what staff should review.";
+    if (!checked("readiness_acknowledged")) next.readiness_acknowledged = "Confirm the property will be ready.";
+    if (!checked("saved_details_confirmed")) next.saved_details_confirmed = "Confirm that these saved details can be used.";
+    if (!checked("privacy_acknowledged")) next.privacy_acknowledged = "Acknowledge that we may contact you about this request.";
+    return next;
+  };
+
+  const submit = async (event: FormEvent) => {
+    event.preventDefault();
+    if (submittingRef.current) return;
+    const next = validate();
+    if (Object.keys(next).length) {
+      setErrors(next);
+      focusFirstError(next);
+      return;
+    }
+    submittingRef.current = true; setSubmitting(true); setErrors({});
+    const payload: Record<string, unknown> = { submission_id: submissionId.current };
+    for (const [key, value] of Object.entries(values)) {
+      if (value === "") continue;
+      payload[key] = key === "internal_floor_area" || key === "additional_stills_quantity" ? Number(value) : value;
+    }
+    try {
+      const response = await fetch("/api/book/enquiries", { method: "POST", credentials: "same-origin", cache: "no-store", headers: { "Content-Type": "application/json" }, body: JSON.stringify(payload) });
+      const body: unknown = await response.json();
+      if (!response.ok) {
+        if (response.status === 404) { setPageState("unavailable"); return; }
+        const fieldErrors = body && typeof body === "object" ? Object.fromEntries(Object.entries(body as Record<string, unknown>).map(([key, value]) => [key, Array.isArray(value) ? value.join(" ") : String(value)])) : { submit: "We could not submit the request." };
+        setErrors(fieldErrors); submittingRef.current = false; setSubmitting(false); focusFirstError(fieldErrors); return;
+      }
+      setPageState("success");
+    } catch { submittingRef.current = false; setErrors({ submit: "We could not submit the request. Please try again." }); setSubmitting(false); }
+  };
+
+  const startAnother = () => { setValues(initialValues); setErrors({}); newSubmissionId(); submittingRef.current = false; setSubmitting(false); setPageState("ready"); };
+  const landRelevant = ["site_land", "agricultural", "commercial", "new_build"].includes(text("property_type"));
+
+  if (pageState === "loading") return <PrivateMessage title="Opening your private booking form" message="Securely checking access…" loading />;
+  if (pageState === "unavailable") return <PrivateMessage title="Booking access unavailable" message="This private link is invalid or no longer available. Please contact OpenÉire Studios for assistance." />;
+  if (pageState === "error") return <PrivateMessage title="Temporarily unavailable" message="We could not open the booking form just now. Please try again later." />;
+  if (pageState === "success") return <PrivateMessage title="Property request received" message="We’ll review the property, requested scope and preferred date before confirming the quotation and booking."><button onClick={startAnother} className="mt-7 rounded-full bg-green-600 px-6 py-3 font-bold hover:bg-green-700">Book another property</button></PrivateMessage>;
+
+  return <div className="min-h-screen bg-zinc-950 px-4 py-8 text-zinc-100 sm:px-6 sm:py-12">
+    <div className="mx-auto max-w-4xl">
+      <PrivateHeader />
+      <div className="mb-8"><p className="text-xs font-bold uppercase tracking-[0.22em] text-amber-400">Returning client</p><h1 className="mt-3 font-serif text-3xl font-bold sm:text-5xl">Book another property</h1><p className="mt-4 max-w-2xl text-zinc-400">Only tell us what changes for this property. Dates remain requests until confirmed.</p></div>
+      <section className="mb-7 rounded-2xl border border-amber-400/20 bg-amber-400/[0.06] p-5" aria-labelledby="saved-details"><h2 id="saved-details" className="text-lg font-bold">Saved client details</h2><dl className="mt-4 grid gap-3 text-sm sm:grid-cols-2"><div><dt className="text-zinc-500">Client</dt><dd>{client?.display_name}</dd></div><div><dt className="text-zinc-500">Agency/company</dt><dd>{client?.company_name || "Not recorded"}</dd></div><div><dt className="text-zinc-500">Email</dt><dd>{client?.masked_email}</dd></div><div><dt className="text-zinc-500">Phone</dt><dd>{client?.masked_phone}</dd></div></dl></section>
+      <form onSubmit={submit} noValidate className="space-y-6 rounded-3xl border border-white/10 bg-black p-5 sm:p-8">
+        {errors.submit ? <div role="alert" className="rounded-xl bg-red-500/10 p-4 text-red-200">{errors.submit}</div> : null}
+        <section className="space-y-5"><h2 className="font-serif text-2xl font-bold">Property and shoot</h2>
+          <Field name="property_address" label="Property address" required error={errors.property_address}><textarea id="booking-property_address" className={inputClass} value={text("property_address")} onChange={e => set("property_address", e.target.value)} rows={2} /></Field>
+          <div className="grid gap-5 sm:grid-cols-2"><Field name="county" label="County" required error={errors.county}><select id="booking-county" className={inputClass} value={text("county")} onChange={e => set("county", e.target.value)}><option value="">Select…</option>{counties.map(item => option(item, item))}</select></Field>{!checked("no_eircode") ? <Field name="eircode" label="Eircode" required error={errors.eircode}><input id="booking-eircode" className={inputClass} value={text("eircode")} onChange={e => set("eircode", e.target.value)} /></Field> : null}</div>
+          <label className="flex gap-3 text-sm"><input type="checkbox" checked={checked("no_eircode")} onChange={e => set("no_eircode", e.target.checked)} />This property has no Eircode</label>
+          {checked("no_eircode") ? <Field name="location_details" label="Directions or Google Maps link" required error={errors.location_details}><textarea id="booking-location_details" className={inputClass} value={text("location_details")} onChange={e => set("location_details", e.target.value)} rows={2} /></Field> : null}
+          <div className="grid gap-5 sm:grid-cols-3"><Field name="property_type" label="Property category" required error={errors.property_type}><select id="booking-property_type" className={inputClass} value={text("property_type")} onChange={e => set("property_type", e.target.value)}><option value="">Select…</option>{[["house","House"],["apartment","Apartment"],["new_build","New build / development"],["site_land","Site / land"],["commercial","Commercial"],["agricultural","Agricultural"],["other","Other"]].map(([v,l]) => option(v,l))}</select></Field><Field name="bedroom_count" label="Bedrooms" required error={errors.bedroom_count}><select id="booking-bedroom_count" className={inputClass} value={text("bedroom_count")} onChange={e => set("bedroom_count", e.target.value)}><option value="">Select…</option>{["studio","1","2","3","4","5","6_plus","not_applicable"].map(v => option(v, v === "6_plus" ? "6+" : v === "not_applicable" ? "Not applicable" : v))}</select></Field><Field name="floor_count" label="Floors" required error={errors.floor_count}><select id="booking-floor_count" className={inputClass} value={text("floor_count")} onChange={e => set("floor_count", e.target.value)}><option value="">Select…</option>{[["1","1"],["2","2"],["3","3"],["4_plus","4+"],["not_applicable","Not applicable"]].map(([v,l]) => option(v,l))}</select></Field></div>
+          {text("property_type") === "other" ? <Field name="property_type_details" label="Property category details" required error={errors.property_type_details}><input id="booking-property_type_details" className={inputClass} value={text("property_type_details")} onChange={e => set("property_type_details", e.target.value)} /></Field> : null}
+          <Field name="preferred_package" label="Preferred package" required error={errors.preferred_package}><select id="booking-preferred_package" className={inputClass} value={text("preferred_package")} onChange={e => set("preferred_package", e.target.value)}><option value="">Select…</option>{REAL_ESTATE_ENQUIRY_PACKAGES.map(item => option(item.id, item.id === "not_sure" ? "Recommend one" : `${item.name} — ${item.price}`))}</select></Field>
+          <div className="grid gap-5 sm:grid-cols-3"><Field name="scheduling_preference" label="Preferred date" required error={errors.scheduling_preference}><select id="booking-scheduling_preference" className={inputClass} value={text("scheduling_preference")} onChange={e => set("scheduling_preference", e.target.value)}><option value="">Select…</option>{option("request_date","Request a date")}{option("flexible","Flexible — contact me")}</select></Field>{text("scheduling_preference") === "request_date" ? <Field name="preferred_date" label="Requested date" required error={errors.preferred_date}><input id="booking-preferred_date" type="date" className={inputClass} value={text("preferred_date")} onChange={e => set("preferred_date", e.target.value)} /></Field> : null}<Field name="preferred_time_window" label="Preferred time" required error={errors.preferred_time_window}><select id="booking-preferred_time_window" className={inputClass} value={text("preferred_time_window")} onChange={e => set("preferred_time_window", e.target.value)}><option value="">Select…</option>{option("morning","Morning")}{option("afternoon","Afternoon")}{option("flexible","Flexible")}</select></Field></div>
+          <Field name="access_provider" label="Who will provide access?" required error={errors.access_provider}><select id="booking-access_provider" className={inputClass} value={text("access_provider")} onChange={e => set("access_provider", e.target.value)}><option value="">Select…</option>{option("enquirer","I will — use my saved details")}{option("owner","Owner / vendor")}{option("tenant","Tenant")}{option("agent_colleague","Agent / colleague")}{option("other","Other")}</select></Field>
+          {text("access_provider") && text("access_provider") !== "enquirer" ? <div className="grid gap-5 sm:grid-cols-2"><Field name="access_contact_name" label="Access contact name" required error={errors.access_contact_name}><input id="booking-access_contact_name" className={inputClass} value={text("access_contact_name")} onChange={e => set("access_contact_name", e.target.value)} /></Field><Field name="access_contact_phone" label="Access contact phone" required error={errors.access_contact_phone}><input id="booking-access_contact_phone" type="tel" className={inputClass} value={text("access_contact_phone")} onChange={e => set("access_contact_phone", e.target.value)} /></Field></div> : null}
+          <Field name="message" label="Additional/property notes" error={errors.message}><textarea id="booking-message" className={inputClass} value={text("message")} onChange={e => set("message", e.target.value)} rows={3} /></Field>
+        </section>
+        <details open={landRelevant || undefined} className="rounded-2xl border border-white/10 p-5"><summary className="cursor-pointer font-bold text-amber-300">Additional property details <span className="font-normal text-zinc-500">(optional unless a shown answer requires details)</span></summary><div className="mt-5 space-y-5">
+          <div className="grid gap-5 sm:grid-cols-2"><Field name="internal_floor_area" label="Approximate floor area" error={errors.internal_floor_area}><input id="booking-internal_floor_area" type="number" min="1" className={inputClass} value={text("internal_floor_area")} onChange={e => set("internal_floor_area", e.target.value)} /></Field><Field name="internal_floor_area_unit" label="Area unit" error={errors.internal_floor_area_unit}><select id="booking-internal_floor_area_unit" className={inputClass} value={text("internal_floor_area_unit")} onChange={e => set("internal_floor_area_unit", e.target.value)}><option value="">Select…</option>{option("sqm","m²")}{option("sqft","sq ft")}</select></Field></div>
+          <div className="grid gap-5 sm:grid-cols-3"><OptionalChoice name="secondary_accommodation" label="Secondary accommodation" values={values} set={set} error={errors.secondary_accommodation} /><OptionalChoice name="outbuildings" label="Outbuildings" values={values} set={set} error={errors.outbuildings} /><Field name="grounds_size" label="Land / grounds size" error={errors.grounds_size}><select id="booking-grounds_size" className={inputClass} value={text("grounds_size")} onChange={e => set("grounds_size", e.target.value)}><option value="">Not specified</option>{[["no_grounds","No grounds"],["normal_garden","Normal garden"],["large_garden","Large garden"],["under_1_acre","Under 1 acre"],["1_to_5_acres","1–5 acres"],["over_5_acres","Over 5 acres"],["not_sure","Not sure"],["not_applicable","Not applicable"]].map(([v,l]) => option(v,l))}</select></Field></div>
+          {text("secondary_accommodation") === "yes" ? <Field name="secondary_accommodation_details" label="Secondary accommodation details" required error={errors.secondary_accommodation_details}><textarea id="booking-secondary_accommodation_details" className={inputClass} value={text("secondary_accommodation_details")} onChange={e => set("secondary_accommodation_details", e.target.value)} /></Field> : null}
+          {text("outbuildings") === "yes" ? <Field name="outbuildings_details" label="Outbuilding details" required error={errors.outbuildings_details}><textarea id="booking-outbuildings_details" className={inputClass} value={text("outbuildings_details")} onChange={e => set("outbuildings_details", e.target.value)} /></Field> : null}
+          <Field name="property_features" label="Notable features affecting coverage" error={errors.property_features}><textarea id="booking-property_features" className={inputClass} value={text("property_features")} onChange={e => set("property_features", e.target.value)} /></Field>
+          <div className="grid gap-5 sm:grid-cols-2"><Field name="occupancy_status" label="Occupancy" error={errors.occupancy_status}><select id="booking-occupancy_status" className={inputClass} value={text("occupancy_status")} onChange={e => set("occupancy_status", e.target.value)}><option value="">Not specified</option>{[["vacant","Vacant"],["owner_occupied","Owner occupied"],["tenant_occupied","Tenant occupied"],["new_build_site","New build / site"],["other","Other"]].map(([v,l]) => option(v,l))}</select></Field><Field name="alternative_date" label="Alternative date" error={errors.alternative_date}><input id="booking-alternative_date" type="date" className={inputClass} value={text("alternative_date")} onChange={e => set("alternative_date", e.target.value)} /></Field></div>
+          <Field name="access_notes" label="Detailed access notes" error={errors.access_notes}><textarea id="booking-access_notes" className={inputClass} value={text("access_notes")} onChange={e => set("access_notes", e.target.value)} /></Field>
+          <fieldset data-field="add_ons"><legend className={labelClass}>Optional add-ons</legend><div className="grid gap-3 sm:grid-cols-2">{[["additional_stills","Additional edited photographs"],["floor_plan","2D measured floor plan"],["virtual_tour_3d","Hosted 3D virtual tour"],["rush_delivery","Rush same-day still photography"],["extended_drone_video","Extended drone video"],["additional_social_cuts","Additional social cuts"]].map(([key,label]) => <label key={key} className="flex gap-3 rounded-xl border border-white/10 p-3"><input type="checkbox" checked={addOns.includes(key)} onChange={() => toggleAddOn(key)} />{label}</label>)}</div>{errors.add_ons ? <p role="alert" className="mt-2 text-sm text-red-300">{errors.add_ons}</p> : null}</fieldset>
+          {addOns.includes("additional_stills") ? <Field name="additional_stills_quantity" label="Additional photograph quantity" required error={errors.additional_stills_quantity}><input id="booking-additional_stills_quantity" type="number" min="1" max="50" className={inputClass} value={text("additional_stills_quantity")} onChange={e => set("additional_stills_quantity", e.target.value)} /></Field> : null}
+          <Field name="on_camera" label="Will anyone appear or speak on camera?" error={errors.on_camera}><select id="booking-on_camera" className={inputClass} value={text("on_camera")} onChange={e => set("on_camera", e.target.value)}><option value="">Not specified</option>{option("yes","Yes")}{option("no","No")}{option("not_sure","Not sure")}</select></Field>
+          {text("on_camera") === "yes" ? <div className="grid gap-5 sm:grid-cols-2"><Field name="on_camera_people" label="Who will appear or speak?" required error={errors.on_camera_people}><input id="booking-on_camera_people" className={inputClass} value={text("on_camera_people")} onChange={e => set("on_camera_people", e.target.value)} /></Field><Field name="audio_requirements" label="Audio / microphone requirements" required error={errors.audio_requirements}><textarea id="booking-audio_requirements" className={inputClass} value={text("audio_requirements")} onChange={e => set("audio_requirements", e.target.value)} /></Field></div> : null}
+        </div></details>
+        <section className="space-y-4 border-t border-white/10 pt-6">
+          <Check name="readiness_acknowledged" checked={checked("readiness_acknowledged")} set={set} error={errors.readiness_acknowledged}>The property will be cleaned, staged and ready at the agreed arrival time.</Check>
+          <Check name="saved_details_confirmed" checked={checked("saved_details_confirmed")} set={set} error={errors.saved_details_confirmed}>The saved contact details above can be used for this request.</Check>
+          <Check name="contact_update_requested" checked={checked("contact_update_requested")} set={set}>Request an update to my saved details.</Check>
+          {checked("contact_update_requested") ? <Field name="contact_update_request" label="What should staff review?" required error={errors.contact_update_request}><textarea id="booking-contact_update_request" className={inputClass} value={text("contact_update_request")} onChange={e => set("contact_update_request", e.target.value)} /></Field> : null}
+          <Check name="privacy_acknowledged" checked={checked("privacy_acknowledged")} set={set} error={errors.privacy_acknowledged}>I acknowledge that OpenÉire Studios may contact me about this operational booking request.</Check>
+        </section>
+        <button disabled={submitting} className="w-full rounded-full bg-green-600 px-6 py-4 font-bold text-white hover:bg-green-700 disabled:opacity-60">{submitting ? "Sending…" : "Send property request"}</button>
+      </form>
+    </div>
+  </div>;
+}
+
+function OptionalChoice({ name, label, values, set, error }: { name: string; label: string; values: FormValues; set: (name: string, value: string) => void; error?: string }) {
+  return <Field name={name} label={label} error={error}><select id={`booking-${name}`} className={inputClass} value={String(values[name] ?? "")} onChange={e => set(name, e.target.value)}><option value="">Not specified</option>{option("yes","Yes")}{option("no","No")}{option("not_sure","Not sure")}</select></Field>;
+}
+
+function Check({ name, checked, set, error, children }: { name: string; checked: boolean; set: (name: string, value: boolean) => void; error?: string; children: React.ReactNode }) {
+  return <div data-field={name}><label className="flex items-start gap-3 text-sm"><input type="checkbox" checked={checked} onChange={e => set(name, e.target.checked)} /><span>{children}</span></label>{error ? <p className="mt-2 text-sm text-red-300">{error}</p> : null}</div>;
+}
+
+function PrivateHeader() { return <header className="mb-10 flex items-center justify-between border-b border-white/10 pb-6"><span className="text-xl font-extrabold">OpenÉire <span className="text-amber-400">Studios</span></span><span className="text-xs font-semibold uppercase tracking-[0.2em] text-zinc-400">Private booking</span></header>; }
+function PrivateMessage({ title, message, loading, children }: { title: string; message: string; loading?: boolean; children?: React.ReactNode }) { return <div className="min-h-screen bg-zinc-950 px-4 py-8 text-zinc-100"><div className="mx-auto max-w-4xl"><PrivateHeader /><section aria-live="polite" aria-busy={loading} className="mx-auto max-w-xl py-20 text-center">{loading ? <div className="mx-auto mb-5 h-9 w-9 animate-spin rounded-full border-2 border-zinc-700 border-t-green-500" /> : null}<h1 className="text-3xl font-bold">{title}</h1><p className="mt-4 leading-7 text-zinc-300">{message}</p>{children}</section></div></div>; }

--- a/openeire-next/lib/booking/server.ts
+++ b/openeire-next/lib/booking/server.ts
@@ -1,0 +1,126 @@
+import "server-only";
+
+import type { NextRequest } from "next/server";
+
+export const bookingCookieName = () =>
+  process.env.NODE_ENV === "production"
+    ? "__Host-openeire_booking_access"
+    : "openeire_booking_access";
+
+type BookingFailureCategory =
+  | "missing_origin"
+  | "invalid_origin"
+  | "proxy_origin_mismatch"
+  | "configuration_error"
+  | "backend_connection_error"
+  | "backend_response";
+
+const FAILURE_CATEGORIES = new Set<BookingFailureCategory>([
+  "missing_origin", "invalid_origin", "proxy_origin_mismatch",
+  "configuration_error", "backend_connection_error", "backend_response",
+]);
+
+export class BookingFailure extends Error {
+  constructor(readonly category: BookingFailureCategory) {
+    super("Secure booking request is unavailable.");
+    this.name = "BookingFailure";
+  }
+}
+
+const configurationFailure = (): never => { throw new BookingFailure("configuration_error"); };
+
+const canonicalFrontendOrigin = (): URL => {
+  const configured = process.env.NEXT_PUBLIC_SITE_URL?.trim();
+  if (!configured) return configurationFailure();
+  let parsed: URL;
+  try { parsed = new URL(configured); } catch { return configurationFailure(); }
+  const protocolAllowed = parsed.protocol === "https:" || (process.env.NODE_ENV !== "production" && parsed.protocol === "http:");
+  if (!protocolAllowed || parsed.username || parsed.password || parsed.pathname !== "/" || parsed.search || parsed.hash) return configurationFailure();
+  return parsed;
+};
+
+const renderExternalHostname = (): string | null => {
+  const configured = process.env.RENDER_EXTERNAL_HOSTNAME?.trim().toLowerCase();
+  if (!configured) return null;
+  try {
+    const parsed = new URL(`https://${configured}`);
+    if (parsed.host !== configured || parsed.pathname !== "/") return configurationFailure();
+    return configured;
+  } catch (error) {
+    if (error instanceof BookingFailure) throw error;
+    return configurationFailure();
+  }
+};
+
+const backendBaseUrl = (): string => {
+  const configured = process.env.OPENEIRE_API_BASE_URL?.trim();
+  if (!configured) return configurationFailure();
+  let parsed: URL;
+  try { parsed = new URL(configured); } catch { return configurationFailure(); }
+  const protocolAllowed = parsed.protocol === "https:" || (process.env.NODE_ENV !== "production" && parsed.protocol === "http:");
+  if (!protocolAllowed || parsed.username || parsed.password || parsed.search || parsed.hash) return configurationFailure();
+  parsed.pathname = `${parsed.pathname.replace(/\/+$/, "")}/`;
+  if (process.env.NODE_ENV === "production" && parsed.pathname !== "/api/") return configurationFailure();
+  return parsed.toString();
+};
+
+const internalSecret = (): string => {
+  const value = process.env.REAL_ESTATE_BOOKING_INTERNAL_SECRET ?? "";
+  if (value.length < 32) return configurationFailure();
+  return value;
+};
+
+export const assertBookingFeatureEnabled = () => {
+  if (process.env.REAL_ESTATE_BOOKING_PORTAL_ENABLED !== "true") configurationFailure();
+};
+
+export const assertTrustedBookingPost = (request: NextRequest): string => {
+  assertBookingFeatureEnabled();
+  const origin = request.headers.get("origin");
+  if (!origin) throw new BookingFailure("missing_origin");
+  let parsed: URL;
+  try { parsed = new URL(origin); } catch { throw new BookingFailure("invalid_origin"); }
+  const canonical = canonicalFrontendOrigin();
+  if (origin !== parsed.origin || parsed.origin !== canonical.origin) throw new BookingFailure("invalid_origin");
+  const host = request.headers.get("host")?.toLowerCase() ?? "";
+  const renderHost = renderExternalHostname();
+  const allowedHosts = new Set([canonical.host.toLowerCase(), renderHost].filter((value): value is string => Boolean(value)));
+  const forwardedHost = request.headers.get("x-forwarded-host")?.toLowerCase();
+  const forwardedProto = request.headers.get("x-forwarded-proto")?.toLowerCase();
+  const hasForwarding = Boolean(forwardedHost || forwardedProto);
+  const forwardingMatches = forwardedHost === canonical.host.toLowerCase() && forwardedProto === canonical.protocol.slice(0, -1);
+  const usesRenderHost = Boolean(renderHost) && host === renderHost;
+  if (!allowedHosts.has(host) || (hasForwarding && !forwardingMatches) || (usesRenderHost && !forwardingMatches)) throw new BookingFailure("proxy_origin_mismatch");
+  return canonical.origin;
+};
+
+export const logBookingFailure = (failure: unknown) => {
+  const category = typeof failure === "string" && FAILURE_CATEGORIES.has(failure as BookingFailureCategory)
+    ? failure as BookingFailureCategory
+    : failure instanceof BookingFailure ? failure.category : null;
+  if (category) console.error("booking_failure", { category });
+};
+
+export const bookingBackendPost = async (endpoint: string, body: Record<string, unknown>, browserOrigin: string) => {
+  if (!new Set(["exchange", "session", "enquiries"]).has(endpoint)) configurationFailure();
+  let response: Response;
+  try {
+    const url = new URL(`real-estate/booking/${endpoint}/`, backendBaseUrl());
+    response = await fetch(url.toString(), {
+      method: "POST", cache: "no-store",
+      headers: { "Content-Type": "application/json", Origin: browserOrigin, "X-OpenEire-Booking-Internal": internalSecret() },
+      body: JSON.stringify(body),
+    });
+  } catch { throw new BookingFailure("backend_connection_error"); }
+  let payload: Record<string, unknown> = {};
+  try {
+    const parsed: unknown = await response.json();
+    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) payload = parsed as Record<string, unknown>;
+  } catch { /* Never surface backend text. */ }
+  return { ok: response.ok, status: response.status, payload };
+};
+
+export const bookingNoStoreHeaders = {
+  "Cache-Control": "private, no-store, max-age=0", Pragma: "no-cache",
+  "Referrer-Policy": "no-referrer", "X-Robots-Tag": "noindex, nofollow, noarchive",
+};

--- a/openeire-next/next.config.ts
+++ b/openeire-next/next.config.ts
@@ -165,6 +165,8 @@ const privateDeliveryHeaders = [
   },
 ];
 
+const privateBookingHeaders = privateDeliveryHeaders;
+
 const nextConfig: NextConfig = {
   poweredByHeader: false,
   reactStrictMode: true,
@@ -208,6 +210,14 @@ const nextConfig: NextConfig = {
       {
         source: "/api/delivery/:path*",
         headers: privateDeliveryHeaders,
+      },
+      {
+        source: "/book/:path*",
+        headers: privateBookingHeaders,
+      },
+      {
+        source: "/api/book/:path*",
+        headers: privateBookingHeaders,
       },
     ];
   },

--- a/openeire-next/tests/bookingServer.test.ts
+++ b/openeire-next/tests/bookingServer.test.ts
@@ -1,0 +1,132 @@
+import { NextRequest } from "next/server";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { POST as exchangeBooking } from "@/app/api/book/exchange/route";
+import { POST as sessionBooking } from "@/app/api/book/session/route";
+import { POST as submitBooking } from "@/app/api/book/enquiries/route";
+import { assertTrustedBookingPost, bookingBackendPost } from "@/lib/booking/server";
+
+const INTERNAL = "booking-internal-key-abcdefghijklmnopqrstuvwxyz-123456";
+const PUBLIC_ID = "11111111-1111-4111-8111-111111111111";
+
+const request = (origin = "https://openeire.test", headers: Record<string, string> = {}) => new NextRequest("https://openeire.test/api/book/exchange", {
+  method: "POST",
+  headers: { Origin: origin, Host: "openeire.test", "Content-Type": "application/json", ...headers },
+  body: JSON.stringify({ public_id: PUBLIC_ID, secret: "fictional-fragment" }),
+});
+
+describe("private booking server boundary", () => {
+  beforeEach(() => {
+    vi.stubEnv("REAL_ESTATE_BOOKING_PORTAL_ENABLED", "true");
+    vi.stubEnv("NEXT_PUBLIC_SITE_URL", "https://openeire.test");
+    vi.stubEnv("OPENEIRE_API_BASE_URL", "https://api.example.test/api/");
+    vi.stubEnv("REAL_ESTATE_BOOKING_INTERNAL_SECRET", INTERNAL);
+  });
+  afterEach(() => { vi.unstubAllEnvs(); vi.unstubAllGlobals(); vi.restoreAllMocks(); });
+
+  it("rejects cross-origin and missing-origin browser posts", () => {
+    expect(() => assertTrustedBookingPost(request("https://attacker.example"))).toThrow();
+    const missing = new NextRequest("https://openeire.test/api/book/exchange", { method: "POST", headers: { Host: "openeire.test" }, body: "{}" });
+    expect(() => assertTrustedBookingPost(missing)).toThrow();
+  });
+
+  it("accepts the canonical origin behind the trusted Render host", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("NEXT_PUBLIC_SITE_URL", "https://openeire.ie");
+    vi.stubEnv("RENDER_EXTERNAL_HOSTNAME", "openeire-next.onrender.com");
+    const production = new NextRequest("http://0.0.0.0:10000/api/book/exchange", {
+      method: "POST",
+      headers: { Origin: "https://openeire.ie", Host: "openeire-next.onrender.com", "X-Forwarded-Host": "openeire.ie", "X-Forwarded-Proto": "https" },
+      body: "{}",
+    });
+    expect(assertTrustedBookingPost(production)).toBe("https://openeire.ie");
+  });
+
+  it("joins production API bases with and without a trailing slash exactly once", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    const fetchMock = vi.fn(() => Promise.resolve(new Response("{}", { status: 200, headers: { "Content-Type": "application/json" } })));
+    vi.stubGlobal("fetch", fetchMock);
+    for (const base of ["https://api.openeire.ie/api", "https://api.openeire.ie/api/"]) {
+      vi.stubEnv("OPENEIRE_API_BASE_URL", base);
+      await bookingBackendPost("session", { session: "fictional" }, "https://openeire.ie");
+    }
+    expect(fetchMock.mock.calls.map(call => String((call as unknown[])[0]))).toEqual([
+      "https://api.openeire.ie/api/real-estate/booking/session/",
+      "https://api.openeire.ie/api/real-estate/booking/session/",
+    ]);
+  });
+
+  it("rejects production HTTP, missing-api and unsupported endpoints", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("OPENEIRE_API_BASE_URL", "http://api.openeire.ie/api");
+    await expect(bookingBackendPost("session", {}, "https://openeire.ie")).rejects.toThrow();
+    vi.stubEnv("OPENEIRE_API_BASE_URL", "https://api.openeire.ie");
+    await expect(bookingBackendPost("session", {}, "https://openeire.ie")).rejects.toThrow();
+    vi.stubEnv("OPENEIRE_API_BASE_URL", "https://api.openeire.ie/api");
+    await expect(bookingBackendPost("other", {}, "https://openeire.ie")).rejects.toThrow();
+  });
+
+  it("fails closed when the frontend flag or required server configuration is absent", async () => {
+    vi.stubEnv("REAL_ESTATE_BOOKING_PORTAL_ENABLED", "false");
+    expect(() => assertTrustedBookingPost(request())).toThrow();
+    vi.stubEnv("REAL_ESTATE_BOOKING_PORTAL_ENABLED", "true");
+    vi.stubEnv("REAL_ESTATE_BOOKING_INTERNAL_SECRET", "");
+    await expect(bookingBackendPost("session", {}, "https://openeire.test")).rejects.toThrow();
+  });
+
+  it("accepts session and enquiry posts only under realistic trusted Render headers", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("NEXT_PUBLIC_SITE_URL", "https://openeire.ie");
+    vi.stubEnv("RENDER_EXTERNAL_HOSTNAME", "openeire-next.onrender.com");
+    vi.stubEnv("OPENEIRE_API_BASE_URL", "https://api.openeire.ie/api");
+    const fetchMock = vi.fn()
+      .mockImplementationOnce(() => Promise.resolve(new Response(JSON.stringify({ state: "valid", client: { display_name: "Fictional" } }), { status: 200, headers: { "Content-Type": "application/json" } })))
+      .mockImplementationOnce(() => Promise.resolve(new Response(JSON.stringify({ state: "submitted", duplicate: false }), { status: 201, headers: { "Content-Type": "application/json" } })));
+    vi.stubGlobal("fetch", fetchMock);
+    const trustedHeaders = {
+      Origin: "https://openeire.ie", Host: "openeire-next.onrender.com",
+      "X-Forwarded-Host": "openeire.ie", "X-Forwarded-Proto": "https",
+      Cookie: "__Host-openeire_booking_access=fictional-session",
+    };
+    const sessionResponse = await sessionBooking(new NextRequest("http://0.0.0.0:10000/api/book/session", { method: "POST", headers: trustedHeaders }));
+    const enquiryResponse = await submitBooking(new NextRequest("http://0.0.0.0:10000/api/book/enquiries", { method: "POST", headers: { ...trustedHeaders, "Content-Type": "application/json" }, body: JSON.stringify({ submission_id: "22222222-2222-4222-8222-222222222222" }) }));
+    expect(sessionResponse.status).toBe(200);
+    expect(enquiryResponse.status).toBe(201);
+    expect(fetchMock.mock.calls.map(call => String((call as unknown[])[0]))).toEqual([
+      "https://api.openeire.ie/api/real-estate/booking/session/",
+      "https://api.openeire.ie/api/real-estate/booking/enquiries/",
+    ]);
+  });
+
+  it("rejects www and spoofed forwarded values unless explicitly canonical", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("NEXT_PUBLIC_SITE_URL", "https://openeire.ie");
+    vi.stubEnv("RENDER_EXTERNAL_HOSTNAME", "openeire-next.onrender.com");
+    expect(() => assertTrustedBookingPost(new NextRequest("https://www.openeire.ie/api/book/exchange", { method: "POST", headers: { Origin: "https://www.openeire.ie", Host: "www.openeire.ie" }, body: "{}" }))).toThrow();
+    expect(() => assertTrustedBookingPost(new NextRequest("http://0.0.0.0:10000/api/book/exchange", { method: "POST", headers: { Origin: "https://openeire.ie", Host: "openeire-next.onrender.com", "X-Forwarded-Host": "attacker.example", "X-Forwarded-Proto": "https" }, body: "{}" }))).toThrow();
+  });
+
+  it("sets a hardened production booking cookie and forwards only through the booking secret", async () => {
+    vi.stubEnv("NODE_ENV", "production");
+    vi.stubEnv("NEXT_PUBLIC_SITE_URL", "https://openeire.ie");
+    const fetchMock = vi.fn(() => Promise.resolve(new Response(JSON.stringify({ state: "valid", session: "signed-fictional-session", expires_in: 120 }), { status: 200, headers: { "Content-Type": "application/json" } })));
+    vi.stubGlobal("fetch", fetchMock);
+    const response = await exchangeBooking(new NextRequest("https://openeire.ie/api/book/exchange", {
+      method: "POST", headers: { Origin: "https://openeire.ie", Host: "openeire.ie", "Content-Type": "application/json" },
+      body: JSON.stringify({ public_id: PUBLIC_ID, secret: "fictional-fragment" }),
+    }));
+    const cookie = response.headers.get("set-cookie") ?? "";
+    expect(cookie).toContain("__Host-openeire_booking_access");
+    expect(cookie).toContain("HttpOnly");
+    expect(cookie).toContain("Secure");
+    expect(cookie.toLowerCase()).toContain("samesite=strict");
+    expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining("/real-estate/booking/exchange/"), expect.objectContaining({ headers: expect.objectContaining({ "X-OpenEire-Booking-Internal": INTERNAL }) }));
+  });
+
+  it("logs only fixed failure categories", async () => {
+    const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+    await exchangeBooking(request("https://attacker.example"));
+    expect(consoleError).toHaveBeenCalledWith("booking_failure", { category: "invalid_origin" });
+    expect(JSON.stringify(consoleError.mock.calls)).not.toContain(PUBLIC_ID);
+    expect(JSON.stringify(consoleError.mock.calls)).not.toContain("fictional-fragment");
+  });
+});

--- a/openeire-next/tests/privateBookingPage.test.tsx
+++ b/openeire-next/tests/privateBookingPage.test.tsx
@@ -1,0 +1,22 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import BookingPage from "@/app/book/[credentialPublicId]/page";
+
+const PUBLIC_ID = "11111111-1111-4111-8111-111111111111";
+
+describe("private booking page rollout flag", () => {
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+  });
+
+  it("renders a static unavailable state and performs no exchange when disabled", async () => {
+    vi.stubEnv("REAL_ESTATE_BOOKING_PORTAL_ENABLED", "false");
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    render(await BookingPage({ params: Promise.resolve({ credentialPublicId: PUBLIC_ID }) }));
+    expect(screen.getByText("Booking access unavailable")).toBeTruthy();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/openeire-next/tests/privateBookingShell.test.tsx
+++ b/openeire-next/tests/privateBookingShell.test.tsx
@@ -1,0 +1,39 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const shellPath = vi.hoisted(() => ({
+  value: "/book/11111111-1111-4111-8111-111111111111",
+}));
+
+vi.mock("next/navigation", () => ({ usePathname: () => shellPath.value }));
+vi.mock("next/script", () => ({ default: () => <span data-testid="tracking-script" /> }));
+vi.mock("@/components/Providers", () => ({
+  Providers: ({ children }: { children: React.ReactNode }) => <div data-testid="public-providers">{children}</div>,
+}));
+vi.mock("@/components/layout/Navbar", () => ({ Navbar: () => <div data-testid="public-navbar" /> }));
+vi.mock("@/components/layout/Footer", () => ({ Footer: () => <div data-testid="public-footer" /> }));
+
+describe("private booking route isolation", () => {
+  afterEach(() => {
+    cleanup();
+    shellPath.value = "/book/11111111-1111-4111-8111-111111111111";
+  });
+
+  it("does not mount analytics, Iubenda, public providers, navigation or footer", async () => {
+    const { AppShell } = await import("@/components/layout/AppShell");
+    render(<AppShell><p>Private booking content</p></AppShell>);
+    expect(screen.getByText("Private booking content")).toBeTruthy();
+    expect(screen.queryByTestId("tracking-script")).toBeNull();
+    expect(screen.queryByTestId("public-providers")).toBeNull();
+    expect(screen.queryByTestId("public-navbar")).toBeNull();
+    expect(screen.queryByTestId("public-footer")).toBeNull();
+  });
+
+  it("isolates booking API paths through the same private shell branch", async () => {
+    shellPath.value = "/api/book/session";
+    const { AppShell } = await import("@/components/layout/AppShell");
+    render(<AppShell><p>Private API content</p></AppShell>);
+    expect(screen.queryByTestId("tracking-script")).toBeNull();
+    expect(screen.queryByTestId("public-providers")).toBeNull();
+  });
+});

--- a/openeire-next/tests/returningBooking.test.tsx
+++ b/openeire-next/tests/returningBooking.test.tsx
@@ -1,0 +1,136 @@
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ReturningClientBookingForm } from "@/components/real-estate/ReturningClientBookingForm";
+
+const PUBLIC_ID = "11111111-1111-4111-8111-111111111111";
+const summary = { display_name: "Fiona Agent", company_name: "Fictional Homes", masked_email: "f***@example.test", masked_phone: "*** *** 4567", credential_expires_at: "2026-11-01T12:00:00Z" };
+const response = (payload: unknown, ok = true, status = ok ? 200 : 400) => Promise.resolve({ ok, status, json: () => Promise.resolve(payload) } as Response);
+
+const select = (id: string, value: string) => fireEvent.change(document.getElementById(`booking-${id}`)!, { target: { value } });
+const type = (id: string, value: string) => fireEvent.change(document.getElementById(`booking-${id}`)!, { target: { value } });
+
+async function openForm(fetchMock = vi.fn()
+  .mockImplementationOnce(() => response({ state: "valid" }))
+  .mockImplementationOnce(() => response({ state: "valid", client: summary }))) {
+  vi.stubGlobal("fetch", fetchMock);
+  window.history.replaceState({}, "", `/book/${PUBLIC_ID}#fictional-fragment-secret`);
+  render(<ReturningClientBookingForm credentialPublicId={PUBLIC_ID} />);
+  await screen.findByText("Saved client details");
+  return fetchMock;
+}
+
+function completeVisibleFields() {
+  type("property_address", "Fictional House, Galway");
+  select("county", "Galway");
+  type("eircode", "H91 X4K8");
+  select("property_type", "house");
+  select("bedroom_count", "3");
+  select("floor_count", "2");
+  select("preferred_package", "starter");
+  select("scheduling_preference", "flexible");
+  select("preferred_time_window", "morning");
+  select("access_provider", "enquirer");
+  for (const textValue of [
+    /property will be cleaned/i,
+    /saved contact details above/i,
+    /may contact me about this operational/i,
+  ]) fireEvent.click(screen.getByText(textValue).closest("label")!.querySelector("input")!);
+}
+
+describe("returning-client short booking form", () => {
+  beforeEach(() => vi.stubGlobal("crypto", { randomUUID: vi.fn(() => "22222222-2222-4222-8222-222222222222") }));
+  afterEach(() => { cleanup(); vi.unstubAllGlobals(); vi.restoreAllMocks(); });
+
+  it("removes the fragment before exchange and displays only masked saved details", async () => {
+    const fetchMock = await openForm();
+    expect(window.location.hash).toBe("");
+    expect(fetchMock.mock.calls[0][0]).toBe("/api/book/exchange");
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toEqual({ public_id: PUBLIC_ID, secret: "fictional-fragment-secret" });
+    expect(screen.getByText("f***@example.test")).toBeTruthy();
+    expect(screen.getByText("*** *** 4567")).toBeTruthy();
+    expect(document.body.textContent).not.toContain("FIONA@EXAMPLE.TEST");
+  });
+
+  it("keeps secondary, land, add-on and presenter questions optional and conditional", async () => {
+    await openForm();
+    expect(screen.getByText(/Additional property details/)).toBeTruthy();
+    expect(document.getElementById("booking-secondary_accommodation_details")).toBeNull();
+    expect(document.getElementById("booking-on_camera_people")).toBeNull();
+    select("secondary_accommodation", "yes");
+    select("on_camera", "yes");
+    expect(screen.getByLabelText(/Secondary accommodation details/)).toBeTruthy();
+    expect(screen.getByLabelText(/Who will appear or speak/)).toBeTruthy();
+  });
+
+  it("focuses the first invalid visible field", async () => {
+    await openForm();
+    fireEvent.submit(screen.getByRole("button", { name: /Send property request/ }).closest("form")!);
+    await waitFor(() => expect(document.activeElement).toBe(document.getElementById("booking-property_address")));
+  });
+
+  it("submits a stable UUID without authoritative identity fields", async () => {
+    const fetchMock = vi.fn()
+      .mockImplementationOnce(() => response({ state: "valid" }))
+      .mockImplementationOnce(() => response({ state: "valid", client: summary }))
+      .mockImplementationOnce(() => response({ state: "submitted", duplicate: false }, true, 201));
+    await openForm(fetchMock);
+    completeVisibleFields();
+    fireEvent.submit(screen.getByRole("button", { name: /Send property request/ }).closest("form")!);
+    await screen.findByText("Property request received");
+    const body = JSON.parse(fetchMock.mock.calls[2][1].body);
+    expect(body.submission_id).toBe("22222222-2222-4222-8222-222222222222");
+    expect(body).not.toHaveProperty("name");
+    expect(body).not.toHaveProperty("email");
+    expect(body).not.toHaveProperty("phone");
+    expect(body).not.toHaveProperty("client_id");
+  });
+
+  it("preserves entered values after backend validation errors", async () => {
+    const fetchMock = vi.fn()
+      .mockImplementationOnce(() => response({ state: "valid" }))
+      .mockImplementationOnce(() => response({ state: "valid", client: summary }))
+      .mockImplementationOnce(() => response({ property_address: ["Backend validation error."] }, false, 400));
+    await openForm(fetchMock);
+    completeVisibleFields();
+    fireEvent.submit(screen.getByRole("button", { name: /Send property request/ }).closest("form")!);
+    await screen.findByText("Backend validation error.");
+    expect((document.getElementById("booking-property_address") as HTMLTextAreaElement).value).toBe("Fictional House, Galway");
+    await waitFor(() => expect(document.activeElement).toBe(document.getElementById("booking-property_address")));
+  });
+
+  it("requires land scope only for relevant property categories", async () => {
+    await openForm();
+    completeVisibleFields();
+    select("property_type", "agricultural");
+    fireEvent.submit(screen.getByRole("button", { name: /Send property request/ }).closest("form")!);
+    expect(await screen.findByText("Provide the approximate land or grounds size.")).toBeTruthy();
+    select("grounds_size", "1_to_5_acres");
+    fireEvent.submit(screen.getByRole("button", { name: /Send property request/ }).closest("form")!);
+    expect(await screen.findByText("Confirm whether outbuildings are included.")).toBeTruthy();
+  });
+
+  it("shows package inclusion conflicts without losing form state", async () => {
+    await openForm();
+    completeVisibleFields();
+    select("preferred_package", "premium");
+    fireEvent.click(screen.getByText("Additional social cuts").closest("label")!.querySelector("input")!);
+    fireEvent.submit(screen.getByRole("button", { name: /Send property request/ }).closest("form")!);
+    expect(await screen.findByText(/already included in the package/i)).toBeTruthy();
+    expect((document.getElementById("booking-property_address") as HTMLTextAreaElement).value).toBe("Fictional House, Galway");
+  });
+
+  it("guards against a synchronous double submit while retaining one submission UUID", async () => {
+    const pending = new Promise<Response>(() => {});
+    const fetchMock = vi.fn()
+      .mockImplementationOnce(() => response({ state: "valid" }))
+      .mockImplementationOnce(() => response({ state: "valid", client: summary }))
+      .mockImplementationOnce(() => pending);
+    await openForm(fetchMock);
+    completeVisibleFields();
+    const form = screen.getByRole("button", { name: /Send property request/ }).closest("form")!;
+    fireEvent.submit(form);
+    fireEvent.submit(form);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(JSON.parse(fetchMock.mock.calls[2][1].body).submission_id).toBe("22222222-2222-4222-8222-222222222222");
+  });
+});

--- a/openeire-next/tests/returningBooking.test.tsx
+++ b/openeire-next/tests/returningBooking.test.tsx
@@ -98,6 +98,18 @@ describe("returning-client short booking form", () => {
     await waitFor(() => expect(document.activeElement).toBe(document.getElementById("booking-property_address")));
   });
 
+  it("shows generic backend conflicts as a visible form error", async () => {
+    const fetchMock = vi.fn()
+      .mockImplementationOnce(() => response({ state: "valid" }))
+      .mockImplementationOnce(() => response({ state: "valid", client: summary }))
+      .mockImplementationOnce(() => response({ state: "unavailable", detail: "Booking access is unavailable." }, false, 409));
+    await openForm(fetchMock);
+    completeVisibleFields();
+    fireEvent.submit(screen.getByRole("button", { name: /Send property request/ }).closest("form")!);
+    expect((await screen.findByRole("alert")).textContent).toContain("Booking access is unavailable.");
+    expect((document.getElementById("booking-property_address") as HTMLTextAreaElement).value).toBe("Fictional House, Galway");
+  });
+
   it("requires land scope only for relevant property categories", async () => {
     await openForm();
     completeVisibleFields();


### PR DESCRIPTION
## Purpose

Add the private returning-client booking experience that consumes the backend portal safely and lets a verified client submit another property with a genuinely shorter form.

## Backend

Companion backend PR: https://github.com/petra66orii/openeire-api/pull/176

## Frontend changes

- Adds the private `/book/[credentialPublicId]` route.
- Removes the credential secret from the URL fragment and performs a same-origin session exchange.
- Shows a masked saved-client summary.
- Provides a genuinely shorter progressive property-booking form.
- Generates and preserves a submission UUID for exactly-once retries.
- Handles the Render proxy/origin boundary explicitly.
- Enforces strict backend URL normalization to the `/api` base.
- Isolates the private route from public AppShell behavior and search indexing.
- Uses an independent runtime rollout flag.
- Applies the reviewed green-primary visual direction with gold as an accent.
- Displays generic backend conflicts as visible form-level errors.

## Verification completed

- Focused frontend booking/private-route suite: 21 passed.
- Complete frontend suite: 132 passed.
- ESLint, TypeScript, production build, and `git diff --check` passed.
- Production build confirms the private booking route remains dynamic.
- GitHub frontend CI and dependency review passed after the error-display fix.

Responsive browser inspection at 375px, 768px, and 1440px remains a pre-merge requirement and is not represented as complete here.

## Accurate rollout order

1. Complete local PostgreSQL and responsive pre-merge checks.
2. Merge the backend and deploy with all booking and email flags disabled.
3. Apply migration `0027_realestatebookingcredential_and_more`.
4. Merge and deploy the frontend with its booking flag disabled.
5. Configure independent booking secrets.
6. Run fictional deployed acceptance.
7. Enable booking flags only after acceptance.
8. Keep booking email disabled until click tracking is separately verified.

No feature or email flag was changed. Nothing was deployed.

## Deferred

- Production rollout.
- Production email enablement.
- Enhancements beyond the reviewed returning-client MVP.

This PR must not be merged until its remaining pre-merge gate is complete.