### PR TITLE
Add Safe Pass trust signals

### DIFF
--- a/openeire-next/app/real-estate/page.tsx
+++ b/openeire-next/app/real-estate/page.tsx
@@ -162,6 +162,11 @@ const faqs = [
       "Aerial work depends on weather, site conditions, airspace restrictions and safe operating limits. We review this before confirming the shoot.",
   },
   {
+    question: "Can you work on active construction sites?",
+    answer:
+      "Yes. A valid SOLAS Safe Pass is held for construction-site access. All work remains subject to the site manager’s induction, access requirements and safety procedures.",
+  },
+  {
     question: "Is OpenÉire commercially insured?",
     answer:
       "OpenÉire is fully insured for commercial drone operations, with public liability cover of up to €6.5 million per occurrence.",
@@ -322,12 +327,13 @@ export default function RealEstatePage() {
         aria-label="Property media service assurances"
         className="border-y border-white/10 bg-gray-950"
       >
-        <div className="container mx-auto grid max-w-7xl gap-px px-4 py-5 sm:grid-cols-2 lg:grid-cols-4 lg:px-8">
+        <div className="container mx-auto grid max-w-7xl gap-px px-4 py-5 sm:grid-cols-2 lg:grid-cols-5 lg:px-8">
           {[
             "Photography packages from €175 total",
             "Commercial marketing licence included",
             "Package-aware business-day turnaround",
             "Drone capture subject to safe conditions",
+            "Valid SOLAS Safe Pass held for construction-site access",
           ].map((item) => (
             <div
               key={item}

--- a/openeire-next/components/home/HomeSections.tsx
+++ b/openeire-next/components/home/HomeSections.tsx
@@ -328,7 +328,7 @@ export function HomeCertsSection() {
             </p>
           </div>
 
-          <div className="flex items-center gap-6 md:gap-12">
+          <div className="grid w-full grid-cols-2 items-center gap-6 lg:w-auto lg:grid-flow-col lg:grid-cols-none lg:gap-8 xl:gap-12">
             <div className="flex flex-col items-center">
               <span className="mb-1 block text-3xl font-bold text-white">
                 IAA
@@ -337,7 +337,7 @@ export function HomeCertsSection() {
                 Irish Aviation Authority
               </span>
             </div>
-            <div className="hidden h-10 w-px bg-brand-700 md:block" />
+            <div className="hidden h-10 w-px bg-brand-700 lg:block" />
             <div className="flex flex-col items-center">
               <span className="mb-1 block text-3xl font-bold text-white">
                 EASA
@@ -346,13 +346,22 @@ export function HomeCertsSection() {
                 EU Aviation Safety
               </span>
             </div>
-            <div className="hidden h-10 w-px bg-brand-700 md:block" />
+            <div className="hidden h-10 w-px bg-brand-700 lg:block" />
             <div className="flex flex-col items-center">
               <span className="mb-1 block text-3xl font-bold text-white">
                 €6.5M
               </span>
               <span className="text-[10px] uppercase tracking-widest text-accent">
                 Public Liability Insurance
+              </span>
+            </div>
+            <div className="hidden h-10 w-px bg-brand-700 lg:block" />
+            <div className="flex flex-col items-center">
+              <span className="mb-1 block text-xl font-bold text-white md:text-2xl">
+                Valid SOLAS Safe Pass
+              </span>
+              <span className="text-[10px] uppercase tracking-widest text-accent">
+                Construction-Site Access
               </span>
             </div>
           </div>

--- a/openeire-next/lib/realEstate.ts
+++ b/openeire-next/lib/realEstate.ts
@@ -163,7 +163,7 @@ export const REAL_ESTATE_PACKAGES = [
     includedPhotographs: null,
     includedPhotographsLabel: "Included photographs as specifically agreed",
     description:
-      "For multi-property shoots, large developments, commercial properties, agricultural properties and bespoke bundles.",
+      "For multi-property shoots, large developments, commercial properties, agricultural properties and bespoke bundles. Suitable for developments, active construction sites and multi-property projects, subject to site access and safety requirements.",
     features: [
       "Included photographs as specifically agreed",
       "Multiple properties in a single booking",

--- a/openeire-next/tests/safePassTrustSignals.test.tsx
+++ b/openeire-next/tests/safePassTrustSignals.test.tsx
@@ -1,0 +1,42 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import RealEstatePage from "@/app/real-estate/page";
+import { HomeCertsSection } from "@/components/home/HomeSections";
+
+vi.mock("@/components/real-estate/RealEstateEnquiryForm", () => ({
+  RealEstateEnquiryForm: () => <section id="enquiry">Enquiry form</section>,
+}));
+
+describe("Safe Pass trust signals", () => {
+  afterEach(cleanup);
+
+  it("shows the Safe Pass trust item on the homepage", () => {
+    render(<HomeCertsSection />);
+
+    expect(screen.getByText("Valid SOLAS Safe Pass")).toBeTruthy();
+  });
+
+  it("shows the site-access assurance, FAQ and Custom package wording", () => {
+    render(<RealEstatePage />);
+
+    expect(
+      screen.getByText(
+        "Valid SOLAS Safe Pass held for construction-site access",
+      ),
+    ).toBeTruthy();
+    expect(
+      screen.getByText("Can you work on active construction sites?"),
+    ).toBeTruthy();
+    expect(
+      screen.getByText(
+        "Yes. A valid SOLAS Safe Pass is held for construction-site access. All work remains subject to the site manager’s induction, access requirements and safety procedures.",
+      ),
+    ).toBeTruthy();
+    expect(
+      screen.getByText(
+        /Suitable for developments, active construction sites and multi-property projects, subject to site access and safety requirements\./,
+      ),
+    ).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## What changed

- added a valid SOLAS Safe Pass trust item to the homepage certification and insurance strip
- added construction-site access assurance and FAQ wording to the real-estate page
- added site-access and safety context to the Custom real-estate package
- added focused rendering coverage for all new visible wording

## Why

This gives property and development clients an accurate trust signal for construction-site access without describing OpenÉire as Safe Pass certified or implying guaranteed site entry.

## Validation

- focused Safe Pass tests (2 passed)
- complete frontend suite (113 passed)
- ESLint
- TypeScript
- Next.js production build
- `git diff --check`