### PR TITLE
Polish Safe Pass trust signal

### DIFF
--- a/openeire-next/app/real-estate/page.tsx
+++ b/openeire-next/app/real-estate/page.tsx
@@ -164,7 +164,7 @@ const faqs = [
   {
     question: "Can you work on active construction sites?",
     answer:
-      "Yes. A valid SOLAS Safe Pass is held for construction-site access. All work remains subject to the site manager’s induction, access requirements and safety procedures.",
+      "Yes. A valid Safe Pass is held for construction-site access. All work remains subject to the site manager’s induction, access requirements and safety procedures.",
   },
   {
     question: "Is OpenÉire commercially insured?",
@@ -333,7 +333,7 @@ export default function RealEstatePage() {
             "Commercial marketing licence included",
             "Package-aware business-day turnaround",
             "Drone capture subject to safe conditions",
-            "Valid SOLAS Safe Pass held for construction-site access",
+            "Valid Safe Pass held for construction-site access",
           ].map((item) => (
             <div
               key={item}

--- a/openeire-next/components/home/HomeSections.tsx
+++ b/openeire-next/components/home/HomeSections.tsx
@@ -293,6 +293,13 @@ export function HomeServicesSection() {
   );
 }
 
+const trustItems = [
+  { value: "IAA", label: "Irish Aviation Authority" },
+  { value: "EASA", label: "EU Aviation Safety" },
+  { value: "€6.5M", label: "Public Liability Insurance" },
+  { value: "Valid Safe Pass", label: "Construction-Site Access" },
+] as const;
+
 export function HomeCertsSection() {
   return (
     <section className="relative overflow-hidden border-t border-brand-700 bg-brand-900 py-12 text-white">
@@ -316,9 +323,9 @@ export function HomeCertsSection() {
       </div>
 
       <div className="container relative z-10 mx-auto px-4 lg:px-8">
-        <div className="flex flex-col items-center justify-between gap-8 text-center md:flex-row md:text-left">
+        <div className="grid items-center gap-8 text-center lg:grid-cols-[minmax(16rem,0.9fr)_minmax(0,2.1fr)] lg:text-left">
           <div>
-            <h2 className="mb-2 flex items-center justify-center gap-3 font-serif text-2xl font-bold md:justify-start">
+            <h2 className="mb-2 flex items-center justify-center gap-3 font-serif text-2xl font-bold lg:justify-start">
               <FaShieldAlt className="text-accent" />
               Fully Certified & Insured
             </h2>
@@ -328,42 +335,22 @@ export function HomeCertsSection() {
             </p>
           </div>
 
-          <div className="grid w-full grid-cols-2 items-center gap-6 lg:w-auto lg:grid-flow-col lg:grid-cols-none lg:gap-8 xl:gap-12">
-            <div className="flex flex-col items-center">
-              <span className="mb-1 block text-3xl font-bold text-white">
-                IAA
-              </span>
-              <span className="text-[10px] uppercase tracking-widest text-accent">
-                Irish Aviation Authority
-              </span>
-            </div>
-            <div className="hidden h-10 w-px bg-brand-700 lg:block" />
-            <div className="flex flex-col items-center">
-              <span className="mb-1 block text-3xl font-bold text-white">
-                EASA
-              </span>
-              <span className="text-[10px] uppercase tracking-widest text-accent">
-                EU Aviation Safety
-              </span>
-            </div>
-            <div className="hidden h-10 w-px bg-brand-700 lg:block" />
-            <div className="flex flex-col items-center">
-              <span className="mb-1 block text-3xl font-bold text-white">
-                €6.5M
-              </span>
-              <span className="text-[10px] uppercase tracking-widest text-accent">
-                Public Liability Insurance
-              </span>
-            </div>
-            <div className="hidden h-10 w-px bg-brand-700 lg:block" />
-            <div className="flex flex-col items-center">
-              <span className="mb-1 block text-xl font-bold text-white md:text-2xl">
-                Valid SOLAS Safe Pass
-              </span>
-              <span className="text-[10px] uppercase tracking-widest text-accent">
-                Construction-Site Access
-              </span>
-            </div>
+          <div className="grid w-full grid-cols-2 items-stretch lg:grid-cols-4">
+            {trustItems.map((item, index) => (
+              <div
+                key={item.value}
+                className={`flex min-h-20 flex-col items-center justify-center px-4 text-center ${
+                  index % 2 === 1 ? "border-l border-brand-700" : ""
+                } ${index > 0 ? "lg:border-l lg:border-brand-700" : "lg:border-l-0"}`}
+              >
+                <span className="block text-2xl font-bold leading-tight text-white sm:text-3xl">
+                  {item.value}
+                </span>
+                <span className="mt-1 text-[10px] uppercase tracking-widest text-accent">
+                  {item.label}
+                </span>
+              </div>
+            ))}
           </div>
         </div>
       </div>

--- a/openeire-next/tests/safePassTrustSignals.test.tsx
+++ b/openeire-next/tests/safePassTrustSignals.test.tsx
@@ -14,7 +14,8 @@ describe("Safe Pass trust signals", () => {
   it("shows the Safe Pass trust item on the homepage", () => {
     render(<HomeCertsSection />);
 
-    expect(screen.getByText("Valid SOLAS Safe Pass")).toBeTruthy();
+    expect(screen.getByText("Valid Safe Pass")).toBeTruthy();
+    expect(document.body.textContent).not.toContain("SOLAS");
   });
 
   it("shows the site-access assurance, FAQ and Custom package wording", () => {
@@ -22,7 +23,7 @@ describe("Safe Pass trust signals", () => {
 
     expect(
       screen.getByText(
-        "Valid SOLAS Safe Pass held for construction-site access",
+        "Valid Safe Pass held for construction-site access",
       ),
     ).toBeTruthy();
     expect(
@@ -30,7 +31,7 @@ describe("Safe Pass trust signals", () => {
     ).toBeTruthy();
     expect(
       screen.getByText(
-        "Yes. A valid SOLAS Safe Pass is held for construction-site access. All work remains subject to the site manager’s induction, access requirements and safety procedures.",
+        "Yes. A valid Safe Pass is held for construction-site access. All work remains subject to the site manager’s induction, access requirements and safety procedures.",
       ),
     ).toBeTruthy();
     expect(
@@ -38,5 +39,6 @@ describe("Safe Pass trust signals", () => {
         /Suitable for developments, active construction sites and multi-property projects, subject to site access and safety requirements\./,
       ),
     ).toBeTruthy();
+    expect(document.body.textContent).not.toContain("SOLAS");
   });
 });


### PR DESCRIPTION
## What changed

- shortened the trust wording from “Valid SOLAS Safe Pass” to “Valid Safe Pass” everywhere it is displayed
- rebuilt the homepage trust strip as four equal-width items with consistent type sizing, vertical alignment and responsive dividers
- updated focused tests to cover the simplified wording and ensure “SOLAS” is not rendered

## Why

The Safe Pass item wrapped and sat out of alignment with the three existing trust items on desktop. The previous divider elements also consumed layout space, making the group feel uneven.

## Validation

- focused Safe Pass tests (2 passed)
- complete frontend suite (113 passed)
- ESLint
- TypeScript
- Next.js production build
- `git diff --check`